### PR TITLE
gh-workflow/crates: only publish crates on tags

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -2,7 +2,8 @@ name: Crates
 
 on:
   push:
-    branches: [ master ]
+    tags:
+      - v*
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Only publish crates on a tag being pushed.

Fixes #9.