### PR TITLE
Add editable settings to Configuration

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "its-client"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -424,7 +424,7 @@ checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libits-client"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-channel",
  "cheap-ruler",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "libits-copycat"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "libits-client",

--- a/rust/its-client/Cargo.toml
+++ b/rust/its-client/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "its-client"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Frédéric Gardes <frederic.gardes@orange.com>", "Nicolas Buffon <nicolas.buffon@orange.com>"]
 license = "MIT"
 description = "binary to connect on an ITS MQTT server"
@@ -43,10 +43,10 @@ version = "1.8.1"
 features = ["full", "macros"]
 
 [dependencies.libits-client]
-version = "1.0"
+version = "1.1"
 path="../libits-client"
 
 [dependencies.libits-copycat]
-version = "1.0"
+version = "1.1"
 path="../libits-copycat"
 optional = true

--- a/rust/its-client/src/main.rs
+++ b/rust/its-client/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 // Software Name: its-client
 // SPDX-FileCopyrightText: Copyright (c) 2016-2022 Orange
 // SPDX-License-Identifier: MIT License
@@ -165,6 +166,7 @@ async fn main() {
         mqtt_password,
         mqtt_root_topic,
         region_of_responsibility,
+        HashMap::new(),
     )
     .await;
 

--- a/rust/libits-client/Cargo.toml
+++ b/rust/libits-client/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "libits-client"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Frédéric Gardes <frederic.gardes@orange.com>", "Nicolas Buffon <nicolas.buffon@orange.com>"]
 license = "MIT"
 description = "library to connect on an ITS MQTT server"

--- a/rust/libits-client/src/analyse/configuration.rs
+++ b/rust/libits-client/src/analyse/configuration.rs
@@ -10,6 +10,7 @@ use std::sync::RwLock;
 
 use crate::mqtt::topic::geo_extension::GeoExtension;
 use crate::reception::information::Information;
+use std::collections::HashMap;
 
 pub struct Configuration {
     client_id: String,
@@ -17,14 +18,20 @@ pub struct Configuration {
     region_of_responsibility: bool,
     // TODO add the information's of the neighbourhood
     // TODO if you're a central node, remove from your Region Of Responsibility the Regions Of Responsibility of the neighbourhood
+    custom_settings: HashMap<String, String>,
 }
 
 impl Configuration {
-    pub fn new(client_id: String, region_of_responsibility: bool) -> Self {
+    pub fn new(
+        client_id: String,
+        region_of_responsibility: bool,
+        custom_settings: HashMap<String, String>,
+    ) -> Self {
         Configuration {
             client_id,
             information: RwLock::new(Information::new()),
             region_of_responsibility,
+            custom_settings,
         }
     }
 
@@ -61,5 +68,13 @@ impl Configuration {
     pub fn update(&self, new_information: Information) {
         let mut information_guard = self.information.write().unwrap();
         *information_guard = new_information;
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.custom_settings.get(key)
+    }
+
+    pub fn set(&mut self, key: &str, value: String) {
+        self.custom_settings.insert(key.to_string(), value);
     }
 }

--- a/rust/libits-client/src/pipeline.rs
+++ b/rust/libits-client/src/pipeline.rs
@@ -7,6 +7,7 @@
 // Author: Frédéric GARDES <frederic.gardes@orange.com> et al.
 // Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) client based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::mpsc::{channel, Receiver};
 use std::sync::Arc;
 use std::thread;
@@ -40,6 +41,7 @@ pub async fn run<T: Analyser>(
     mqtt_password: Option<&str>,
     mqtt_root_topic: &str,
     region_of_responsibility: bool,
+    custom_settings: HashMap<String, String>,
 ) {
     loop {
         // build the shared topic list
@@ -62,6 +64,7 @@ pub async fn run<T: Analyser>(
         let configuration = Arc::new(Configuration::new(
             mqtt_client_id.to_string(),
             region_of_responsibility,
+            custom_settings.clone(),
         ));
 
         // subscribe

--- a/rust/libits-copycat/Cargo.toml
+++ b/rust/libits-copycat/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "libits-copycat"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Frédéric Gardes <frederic.gardes@orange.com>", "Nicolas Buffon <nicolas.buffon@orange.com>"]
 license = "MIT"
 description = "library to provide an example of analyser which copycat 10 seconds later the message received appropriating it"
@@ -28,5 +28,5 @@ timer = "0.2"
 chrono = "0.4"
 
 [dependencies.libits-client]
-version = "1.0"
+version = "1.1"
 path="../libits-client"


### PR DESCRIPTION
New features
-----------------

* Add a raw key/value HashMap to store custom settings that are application related
  Configuration struct is already provided to the analyser, adding custom settings directly through that struct ease the use of external user/application related configuration through the pipeline