### PR TITLE
rust: propagate the forget version update to 1.1.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -424,7 +424,7 @@ checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libits-client"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-channel",
  "cheap-ruler",


### PR DESCRIPTION
Nothing to test : the lock was just not updated