### PR TITLE
Remove pytest to wheel

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -51,15 +51,15 @@ WORKDIR /usr/src/app
 
 RUN groupadd -r itsclient && useradd --no-log-init -r -g itsclient itsclient && \
     mkdir /usr/src/app/log && \
-    printf "Version 1.1\n" > /usr/src/app/log/RELEASE
+    printf "Version 1.2\n" > /usr/src/app/log/RELEASE
 
-COPY --from=builder --chown=itsclient:itsclient /usr/src/app/dist/its_client-1.1.1-py3-none-any.whl .
+COPY --from=builder --chown=itsclient:itsclient /usr/src/app/dist/its_client-1.2.0-py3-none-any.whl .
 
 COPY docker-entrypoint.sh .
 
 RUN chown -R itsclient:itsclient /usr/src/app && \
     chmod -R ug+rwx /usr/src/app && \
-    pip install its_client-1.1.1-py3-none-any.whl
+    pip install its_client-1.2.0-py3-none-any.whl
 
 # no parameters today, just to check de lint
 CMD [""]

--- a/python/its_client/__init__.py
+++ b/python/its_client/__init__.py
@@ -12,5 +12,3 @@
 import its_client.cam
 import its_client.mobility
 import its_client.quadtree
-
-__version__ = "1.1.1"

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="its_client",
-    version="1.1.1",
+    version="1.2.0",
     author="Frederic GARDES",
     author_email="frederic(dot)gardes(at)orange(dot)com",
     maintainer="Frederic GARDES",

--- a/python/setup.py
+++ b/python/setup.py
@@ -45,7 +45,6 @@ setup(
         "gpsd-py3==0.3.0",
         "paho-mqtt==1.6.1",
         "pyGeoTile==1.0.6",
-        "pytest==7.1.0",
     ],
     entry_points={"console_scripts": ["its-client = its_client.main:main"]},
 )


### PR DESCRIPTION
**How to test:**

Let's generate the wheel:

```
/home/kvmk8371/workspace/its-client/python/venv/bin/python /home/kvmk8371/workspace/its-client/python/setup.py bdist_wheel
running bdist_wheel
running build
running build_py
running egg_info
writing its_client.egg-info/PKG-INFO
writing dependency_links to its_client.egg-info/dependency_links.txt
writing entry points to its_client.egg-info/entry_points.txt
writing requirements to its_client.egg-info/requires.txt
writing top-level names to its_client.egg-info/top_level.txt
reading manifest file 'its_client.egg-info/SOURCES.txt'
writing manifest file 'its_client.egg-info/SOURCES.txt'
/home/kvmk8371/workspace/its-client/python/venv/lib/python3.8/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/its_client
copying build/lib/its_client/roi.py -> build/bdist.linux-x86_64/wheel/its_client
creating build/bdist.linux-x86_64/wheel/its_client/logger
copying build/lib/its_client/logger/monitoring.py -> build/bdist.linux-x86_64/wheel/its_client/logger
copying build/lib/its_client/logger/its.py -> build/bdist.linux-x86_64/wheel/its_client/logger
copying build/lib/its_client/logger/__init__.py -> build/bdist.linux-x86_64/wheel/its_client/logger
copying build/lib/its_client/logger/logger.py -> build/bdist.linux-x86_64/wheel/its_client/logger
creating build/bdist.linux-x86_64/wheel/its_client/mqtt
copying build/lib/its_client/mqtt/mqtt_client.py -> build/bdist.linux-x86_64/wheel/its_client/mqtt
copying build/lib/its_client/mqtt/__init__.py -> build/bdist.linux-x86_64/wheel/its_client/mqtt
copying build/lib/its_client/mqtt/mqtt_worker.py -> build/bdist.linux-x86_64/wheel/its_client/mqtt
copying build/lib/its_client/mobility.py -> build/bdist.linux-x86_64/wheel/its_client
copying build/lib/its_client/configuration.py -> build/bdist.linux-x86_64/wheel/its_client
creating build/bdist.linux-x86_64/wheel/its_client/position
copying build/lib/its_client/position/gpsd_py3.py -> build/bdist.linux-x86_64/wheel/its_client/position
copying build/lib/its_client/position/static.py -> build/bdist.linux-x86_64/wheel/its_client/position
copying build/lib/its_client/position/__init__.py -> build/bdist.linux-x86_64/wheel/its_client/position
copying build/lib/its_client/__init__.py -> build/bdist.linux-x86_64/wheel/its_client
creating build/bdist.linux-x86_64/wheel/its_client/test
copying build/lib/its_client/test/test_quadtree.py -> build/bdist.linux-x86_64/wheel/its_client/test
copying build/lib/its_client/test/test_configuration.py -> build/bdist.linux-x86_64/wheel/its_client/test
copying build/lib/its_client/test/__init__.py -> build/bdist.linux-x86_64/wheel/its_client/test
copying build/lib/its_client/main.py -> build/bdist.linux-x86_64/wheel/its_client
copying build/lib/its_client/quadtree.py -> build/bdist.linux-x86_64/wheel/its_client
copying build/lib/its_client/cam.py -> build/bdist.linux-x86_64/wheel/its_client
copying build/lib/its_client/its_client.cfg -> build/bdist.linux-x86_64/wheel/its_client
running install_egg_info
Copying its_client.egg-info to build/bdist.linux-x86_64/wheel/its_client-1.2.0-py3.8.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/its_client-1.2.0.dist-info/WHEEL
creating 'dist/its_client-1.2.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'its_client/__init__.py'
adding 'its_client/cam.py'
adding 'its_client/configuration.py'
adding 'its_client/its_client.cfg'
adding 'its_client/main.py'
adding 'its_client/mobility.py'
adding 'its_client/quadtree.py'
adding 'its_client/roi.py'
adding 'its_client/logger/__init__.py'
adding 'its_client/logger/its.py'
adding 'its_client/logger/logger.py'
adding 'its_client/logger/monitoring.py'
adding 'its_client/mqtt/__init__.py'
adding 'its_client/mqtt/mqtt_client.py'
adding 'its_client/mqtt/mqtt_worker.py'
adding 'its_client/position/__init__.py'
adding 'its_client/position/gpsd_py3.py'
adding 'its_client/position/static.py'
adding 'its_client/test/__init__.py'
adding 'its_client/test/test_configuration.py'
adding 'its_client/test/test_quadtree.py'
adding 'its_client-1.2.0.dist-info/METADATA'
adding 'its_client-1.2.0.dist-info/WHEEL'
adding 'its_client-1.2.0.dist-info/entry_points.txt'
adding 'its_client-1.2.0.dist-info/top_level.txt'
adding 'its_client-1.2.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel

Process finished with exit code 0
```

