### PR TITLE
schema/cam: fix schema validity

### DIFF
--- a/schema/cam_schema_1-1-1.json
+++ b/schema/cam_schema_1-1-1.json
@@ -142,8 +142,8 @@
                   "$comment": "mandatory on ETSI specification, FIXME?",
                   "type": "object",
                   "properties": {
-                    "$comment": "if not provided, 'semi_major_confidence' = 4095 (unavailable)",
                     "semi_major_confidence": {
+                      "$comment": "if not provided, 'semi_major_confidence' = 4095 (unavailable)",
                       "type": "integer",
                       "description": "oneCentimeter(1), outOfRange(4094), unavailable(4095)",
                       "default": 4095,

--- a/schema/cam_schema_1-1-2.json
+++ b/schema/cam_schema_1-1-2.json
@@ -31,7 +31,7 @@
     "version": {
       "type": "string",
       "description": "json message format version",
-      "const": "1.1.1"
+      "const": "1.1.2"
     },
     "source_uuid": {
       "type": "string",

--- a/schema/validate
+++ b/schema/validate
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import jsonschema
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('SCHEMA', help='JSON schema to validate')
+    args = parser.parse_args()
+
+    if 'Draft202012Validator' not in dir(jsonschema):
+        raise Exception('jsonschema version too old; at least 4.0.0'
+                        ' (or better, 4.9.1) needed for Draft 2020-12')
+
+    with open(args.SCHEMA, 'rb') as f:
+        schema = json.load(f)
+
+    r = requests.get(schema['$schema'])
+    meta_schema = json.loads(r.content)
+
+    jsonschema.validate(schema=meta_schema, instance=schema)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The CAM schema was not validating against the 2020-12 Draft schema, because of a misplaced `$comment` key.

Fix that, and introduce a small helper script to validate schemas.

Since the schema changed, also bump its version.