### PR TITLE
python/its-client: add more static position items

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run black
         run: |
           cd python
-          black --check .
+          black --diff --check .
       - name: Run Unit Tests and generate coverage report
         run: |
           cd python

--- a/python/its_client/main.py
+++ b/python/its_client/main.py
@@ -50,10 +50,12 @@ def main():
         latitude = config.getfloat("position", "latitude")
         longitude = config.getfloat("position", "longitude")
         heading = config.getfloat("position", "heading")
-        logging.info(f"we use a static position:{latitude}, {longitude}, {heading}")
+        speed = config.getfloat("position", "speed")
+        logging.info(f"we use a static position:{latitude}, {longitude}, {speed}, {heading}")
         position_client = static.GeoPosition(
             latitude=latitude,
             longitude=longitude,
+            speed=speed,
             heading=heading,
         )
     else:

--- a/python/its_client/main.py
+++ b/python/its_client/main.py
@@ -49,12 +49,16 @@ def main():
     if config.getboolean("position", "static"):
         latitude = config.getfloat("position", "latitude")
         longitude = config.getfloat("position", "longitude")
+        altitude = config.getfloat("position", "altitude")
         heading = config.getfloat("position", "heading")
         speed = config.getfloat("position", "speed")
-        logging.info(f"we use a static position:{latitude}, {longitude}, {speed}, {heading}")
+        logging.info(
+            f"we use a static position:{latitude}, {longitude}, {altitude}, {speed}, {heading}"
+        )
         position_client = static.GeoPosition(
             latitude=latitude,
             longitude=longitude,
+            altitude=altitude,
             speed=speed,
             heading=heading,
         )

--- a/python/its_client/main.py
+++ b/python/its_client/main.py
@@ -49,10 +49,12 @@ def main():
     if config.getboolean("position", "static"):
         latitude = config.getfloat("position", "latitude")
         longitude = config.getfloat("position", "longitude")
-        logging.info(f"we use a static position:{latitude}, {longitude}")
+        heading = config.getfloat("position", "heading")
+        logging.info(f"we use a static position:{latitude}, {longitude}, {heading}")
         position_client = static.GeoPosition(
             latitude=latitude,
             longitude=longitude,
+            heading=heading,
         )
     else:
         logging.info(f"we use the gps position")

--- a/python/its_client/main.py
+++ b/python/its_client/main.py
@@ -51,8 +51,8 @@ def main():
         longitude = config.getfloat("position", "longitude")
         logging.info(f"we use a static position:{latitude}, {longitude}")
         position_client = static.GeoPosition(
-            latitude,
-            longitude,
+            latitude=latitude,
+            longitude=longitude,
         )
     else:
         logging.info(f"we use the gps position")

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -33,6 +33,7 @@ class GeoPosition:
         lon_drift = 0
         lat_drift = 0
         if self.count % 5 == 0:
+            # 0.000002° of delta is ~0.2226m at the equator, ~0.2219m at the poles
             lon_drift = round(random.uniform(-0.000002, 0.000002), 6)
             lat_drift = round(random.uniform(-0.000002, 0.000002), 6)
             self.count = 0

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -20,11 +20,13 @@ class GeoPosition:
         latitude: float,
         longitude: float,
         heading: float,
+        speed: float,
     ):
         self.count = 0
         self.lat = latitude
         self.lon = longitude
         self.heading = heading
+        self.speed = speed
 
     def get_current_position(self):
         return self.lon, self.lat
@@ -45,7 +47,7 @@ class GeoPosition:
         lon, lat = self.get_current_position()
         lon = lon + lon_drift
         lat = lat + lat_drift
-        speed = 0.103
+        speed = self.speed
         alt = 131.693
         heading = self.heading + heading_drift
         position_time = datetime.utcnow()

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -30,13 +30,12 @@ class GeoPosition:
     def get_current_value(self):
         # stub
         self.count += 1
+        lon_drift = 0
+        lat_drift = 0
         if self.count % 5 == 0:
             lon_drift = round(random.uniform(-0.000002, 0.000002), 6)
             lat_drift = round(random.uniform(-0.000002, 0.000002), 6)
             self.count = 0
-        else:
-            lon_drift = 0
-            lat_drift = 0
         lon, lat = self.get_current_position()
         lon = lon + lon_drift
         lat = lat + lat_drift

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -21,10 +21,12 @@ class GeoPosition:
         longitude: float,
         heading: float,
         speed: float,
+        altitude: float,
     ):
         self.count = 0
         self.lat = latitude
         self.lon = longitude
+        self.alt = altitude
         self.heading = heading
         self.speed = speed
 
@@ -36,6 +38,7 @@ class GeoPosition:
         self.count += 1
         lon_drift = 0
         lat_drift = 0
+        alt_drift = 0
         heading_drift = 0
         if self.count % 5 == 0:
             # 0.000002° of delta is ~0.2226m at the equator, ~0.2219m at the poles
@@ -43,12 +46,14 @@ class GeoPosition:
             lat_drift = round(random.uniform(-0.000002, 0.000002), 6)
             # 0.5° of heading drift.
             heading_drift = round(random.uniform(-0.5, 0.5), 3)
+            # 0.25m of altitude drift
+            alt_drift = round(random.uniform(-0.25, 0.25), 3)
             self.count = 0
         lon, lat = self.get_current_position()
         lon = lon + lon_drift
         lat = lat + lat_drift
         speed = self.speed
-        alt = 131.693
+        alt = self.alt + alt_drift
         heading = self.heading + heading_drift
         position_time = datetime.utcnow()
         return lon, lat, speed, alt, heading, position_time

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -19,10 +19,12 @@ class GeoPosition:
         *,
         latitude: float,
         longitude: float,
+        heading: float,
     ):
         self.count = 0
         self.lat = latitude
         self.lon = longitude
+        self.heading = heading
 
     def get_current_position(self):
         return self.lon, self.lat
@@ -32,16 +34,19 @@ class GeoPosition:
         self.count += 1
         lon_drift = 0
         lat_drift = 0
+        heading_drift = 0
         if self.count % 5 == 0:
             # 0.000002° of delta is ~0.2226m at the equator, ~0.2219m at the poles
             lon_drift = round(random.uniform(-0.000002, 0.000002), 6)
             lat_drift = round(random.uniform(-0.000002, 0.000002), 6)
+            # 0.5° of heading drift.
+            heading_drift = round(random.uniform(-0.5, 0.5), 3)
             self.count = 0
         lon, lat = self.get_current_position()
         lon = lon + lon_drift
         lat = lat + lat_drift
         speed = 0.103
         alt = 131.693
-        heading = 130.7275
+        heading = self.heading + heading_drift
         position_time = datetime.utcnow()
         return lon, lat, speed, alt, heading, position_time

--- a/python/its_client/position/static.py
+++ b/python/its_client/position/static.py
@@ -14,7 +14,12 @@ from datetime import datetime
 
 
 class GeoPosition:
-    def __init__(self, latitude: float, longitude: float):
+    def __init__(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+    ):
         self.count = 0
         self.lat = latitude
         self.lon = longitude

--- a/python/its_client/test/its_client.cfg
+++ b/python/its_client/test/its_client.cfg
@@ -23,6 +23,7 @@ static=false
 latitude=44.50779
 longitude=2.209381
 heading=130.7275
+speed=0.103
 # if static is false, we use the gps daemon
 
 [log]

--- a/python/its_client/test/its_client.cfg
+++ b/python/its_client/test/its_client.cfg
@@ -24,6 +24,7 @@ latitude=44.50779
 longitude=2.209381
 heading=130.7275
 speed=0.103
+altitude=131.693
 # if static is false, we use the gps daemon
 
 [log]

--- a/python/its_client/test/its_client.cfg
+++ b/python/its_client/test/its_client.cfg
@@ -22,6 +22,7 @@ static=false
 # if static is true, we use a fix position
 latitude=44.50779
 longitude=2.209381
+heading=130.7275
 # if static is false, we use the gps daemon
 
 [log]

--- a/python/its_client/test/test_configuration.py
+++ b/python/its_client/test/test_configuration.py
@@ -82,6 +82,7 @@ class TestConfiguration(unittest.TestCase):
             position_latitude=44.50779,
             position_longitude=2.209381,
             position_heading=130.7275,
+            position_speed=0.103,
             log_default_level=log_default_level,
         )
 
@@ -139,6 +140,7 @@ class TestConfiguration(unittest.TestCase):
         position_latitude=44.50779,
         position_longitude=2.209381,
         position_heading=130.7275,
+        position_speed=0.103,
         log_default_level="DEBUG",
     ):
         self.assertEqual(self.config.get("broker", "host"), broker_host)
@@ -155,4 +157,5 @@ class TestConfiguration(unittest.TestCase):
             self.config.getfloat("position", "longitude"), position_longitude
         )
         self.assertEqual(self.config.getfloat("position", "heading"), position_heading)
+        self.assertEqual(self.config.getfloat("position", "speed"), position_speed)
         self.assertEqual(self.config.get("log", "default_level"), log_default_level)

--- a/python/its_client/test/test_configuration.py
+++ b/python/its_client/test/test_configuration.py
@@ -81,6 +81,7 @@ class TestConfiguration(unittest.TestCase):
             position_static=False,
             position_latitude=44.50779,
             position_longitude=2.209381,
+            position_heading=130.7275,
             log_default_level=log_default_level,
         )
 
@@ -137,6 +138,7 @@ class TestConfiguration(unittest.TestCase):
         position_static=False,
         position_latitude=44.50779,
         position_longitude=2.209381,
+        position_heading=130.7275,
         log_default_level="DEBUG",
     ):
         self.assertEqual(self.config.get("broker", "host"), broker_host)
@@ -152,4 +154,5 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(
             self.config.getfloat("position", "longitude"), position_longitude
         )
+        self.assertEqual(self.config.getfloat("position", "heading"), position_heading)
         self.assertEqual(self.config.get("log", "default_level"), log_default_level)

--- a/python/its_client/test/test_configuration.py
+++ b/python/its_client/test/test_configuration.py
@@ -81,6 +81,7 @@ class TestConfiguration(unittest.TestCase):
             position_static=False,
             position_latitude=44.50779,
             position_longitude=2.209381,
+            position_altitude=131.693,
             position_heading=130.7275,
             position_speed=0.103,
             log_default_level=log_default_level,
@@ -139,6 +140,7 @@ class TestConfiguration(unittest.TestCase):
         position_static=False,
         position_latitude=44.50779,
         position_longitude=2.209381,
+        position_altitude=131.693,
         position_heading=130.7275,
         position_speed=0.103,
         log_default_level="DEBUG",
@@ -155,6 +157,9 @@ class TestConfiguration(unittest.TestCase):
         )
         self.assertEqual(
             self.config.getfloat("position", "longitude"), position_longitude
+        )
+        self.assertEqual(
+            self.config.getfloat("position", "altitude"), position_altitude
         )
         self.assertEqual(self.config.getfloat("position", "heading"), position_heading)
         self.assertEqual(self.config.getfloat("position", "speed"), position_speed)


### PR DESCRIPTION
New features
-----------------

* **python**: add configuration items to fake altitude, heading, and speed

How to test
---------------

1. Create a test config file, replace the MQTT settings to match your setup:
    ```
    [broker]
    host=test_host
    port=18
    tls_port=88
    username=test_user
    password=test_password
    client_id=test_client_id
    
    [position]
    static=true
    latitude=44.50779
    longitude=2.209381
    heading=130.7275
    speed=0.103
    altitude=131.693
    
    [log]
    directory=.
    default_level=DEBUG
    ```
2. Start the its-client with that config file:
    ```
    $ its-client -c /path/to/config/
    ```
3. Check the values emitted in the MQTT broker shall match the values from the config file:
    ```
    $ mosquitto_sub -h test_host -p 18 -v -t '#'
    ```

**Notes:** the black change can be seen in [this job](https://github.com/Orange-OpenSource/its-client/actions/runs/3043425631/jobs/4902675925).