### PR TITLE
python/its-status: new client, to publish ITS status messages

### DIFF
--- a/.github/workflows/python_its-status.yml
+++ b/.github/workflows/python_its-status.yml
@@ -1,0 +1,31 @@
+name: Python its-status
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          cd python/its-status
+          python -m pip install --upgrade pip
+          pip install black wheel
+      - name: Run black
+        run: |
+          cd python/its-status
+          black --diff --check .
+      - name: Run package creation
+        run: |
+          cd python/its-status
+          python setup.py bdist_wheel
+      - name: Archive package
+        uses: actions/upload-artifact@v2
+        with:
+          name: its_status
+          path: python/its-status/dist

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -5,3 +5,10 @@ timestamp_collect = true  # or false, the default; whether to include precise ti
 
 [stdout]
 enabled = true  # or false, the default
+
+[mqtt]
+enabled = false  # or true, the default
+host = HOSTNAME  # hostname or IP of the MQTT broker to connect to; default: 127.0.0.1
+port = 1234  # port of the MQTT broker; default: 1883
+client_id = its-status  # The MQTT client ID to use; default: its-status
+topic = status/system  # The topic on which to post the status; default: system/status

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -1,3 +1,6 @@
 # Sample configuration file
 [generic]
 id = string  # The ID of the device, must be unique across the fleet/world
+
+[stdout]
+enabled = true  # or false, the default

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -1,6 +1,7 @@
 # Sample configuration file
 [generic]
 id = string  # The ID of the device, must be unique across the fleet/world
+frequency = 1.0  # The frequency, in Hz, at which the status should be assembled and emitted
 timestamp_collect = true  # or false, the default; whether to include precise timing of the collect step
 
 [stdout]

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -10,5 +10,7 @@ enabled = true  # or false, the default
 enabled = false  # or true, the default
 host = HOSTNAME  # hostname or IP of the MQTT broker to connect to; default: 127.0.0.1
 port = 1234  # port of the MQTT broker; default: 1883
+username = USERNAME  # Username with which to authenticate to the MQTT broker; if not provided, or empty (the default), do not authenticate
+password = PASSWORD  # Password with which to authenticate to the MQTT broker; default: empty
 client_id = its-status  # The MQTT client ID to use; default: its-status
 topic = status/system  # The topic on which to post the status; default: system/status

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -15,3 +15,6 @@ username = USERNAME  # Username with which to authenticate to the MQTT broker; i
 password = PASSWORD  # Password with which to authenticate to the MQTT broker; default: empty
 client_id = its-status  # The MQTT client ID to use; default: its-status
 topic = status/system  # The topic on which to post the status; default: system/status
+
+[timesources]
+validity = 10.0  # Number of seconds to keep last timesources info if not able to retrieve current state (default: 10.0s)

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -1,6 +1,7 @@
 # Sample configuration file
 [generic]
 id = string  # The ID of the device, must be unique across the fleet/world
+timestamp_collect = true  # or false, the default; whether to include precise timing of the collect step
 
 [stdout]
 enabled = true  # or false, the default

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -1,0 +1,3 @@
+# Sample configuration file
+[generic]
+id = string  # The ID of the device, must be unique across the fleet/world

--- a/python/its-status/its_status/__init__.py
+++ b/python/its-status/its_status/__init__.py
@@ -7,7 +7,10 @@ import glob
 import importlib.util
 import os.path
 
-plugins = {'collectors': {}}
+plugins = {
+    'collectors': {},
+    'emitters': {}
+}
 
 
 def init(*args, **kwargs):
@@ -19,6 +22,9 @@ def init(*args, **kwargs):
         if f_name.startswith('collector.'):
             name = f_name[10:]
             plugin_type = 'collectors'
+        elif f_name.startswith('emitter.'):
+            name = f_name[8:]
+            plugin_type = 'emitters'
         else:
             continue
         spec = importlib.util.spec_from_file_location(name, f)

--- a/python/its-status/its_status/__init__.py
+++ b/python/its-status/its_status/__init__.py
@@ -8,23 +8,26 @@ import importlib.util
 import os.path
 
 plugins = {
-    'collectors': {},
-    'emitters': {}
+    "collectors": {},
+    "emitters": {},
 }
 
 
 def init(*args, **kwargs):
-    files = [f for f in glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
-             if os.path.isfile(f) and not os.path.basename(f) == "__init__.py"]
+    files = [
+        f
+        for f in glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
+        if os.path.isfile(f) and not os.path.basename(f) == "__init__.py"
+    ]
 
     for f in files:
         f_name = os.path.basename(f)[:-3]
-        if f_name.startswith('collector.'):
+        if f_name.startswith("collector."):
             name = f_name[10:]
-            plugin_type = 'collectors'
-        elif f_name.startswith('emitter.'):
+            plugin_type = "collectors"
+        elif f_name.startswith("emitter."):
             name = f_name[8:]
-            plugin_type = 'emitters'
+            plugin_type = "emitters"
         else:
             continue
         spec = importlib.util.spec_from_file_location(name, f)

--- a/python/its-status/its_status/__init__.py
+++ b/python/its-status/its_status/__init__.py
@@ -1,0 +1,27 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import glob
+import importlib.util
+import os.path
+
+plugins = {'collectors': {}}
+
+
+def init(*args, **kwargs):
+    files = [f for f in glob.glob(os.path.join(os.path.dirname(__file__), "*.py"))
+             if os.path.isfile(f) and not os.path.basename(f) == "__init__.py"]
+
+    for f in files:
+        f_name = os.path.basename(f)[:-3]
+        if f_name.startswith('collector.'):
+            name = f_name[10:]
+            plugin_type = 'collectors'
+        else:
+            continue
+        spec = importlib.util.spec_from_file_location(name, f)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        plugins[plugin_type][name] = mod.Status(*args, **kwargs)

--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -8,7 +8,7 @@ import subprocess
 
 
 class Status():
-    def __init__(self):
+    def __init__(self, cfg):
         self.data = list()
 
     def capture(self):

--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -4,7 +4,7 @@
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
 import json
-import subprocess
+from its_status import helpers
 
 
 class Status():
@@ -61,12 +61,4 @@ class Status():
 
     def _mmcli(self, *args):
         cmd = ['mmcli', '-J'] + list(args)
-        try:
-            return subprocess.run(cmd, capture_output=True)
-        except FileNotFoundError:
-            return subprocess.CompletedProcess(
-                args=cmd,
-                returncode=127,
-                stdout=b'',
-                stderr=f'{cmd[0]}: command not found'.encode()
-            )
+        return helpers.run(cmd)

--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -1,0 +1,72 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import json
+import subprocess
+
+
+class Status():
+    def __init__(self):
+        self.data = list()
+
+    def capture(self):
+        data = list()
+        for modem in self._modem_list():
+            m_ret = self._mmcli('-m', modem)
+            if m_ret.returncode:
+                continue
+            m_j = json.loads(m_ret.stdout.decode())
+            item = {
+                'hardware': {
+                    'vendor': m_j['modem']['generic']['manufacturer'],
+                    'model': m_j['modem']['generic']['model'],
+                    'revision': m_j['modem']['generic']['hardware-revision'],
+                },
+            }
+            if m_j['modem']['generic']['state'] == 'connected':
+                item['operator'] = {
+                    'code': m_j['modem']['3gpp']['operator-code'],
+                    'name': m_j['modem']['3gpp']['operator-name'],
+                }
+                tech = m_j['modem']['generic']['access-technologies'][0]
+                item['connection'] = {
+                    'technology': tech,
+                    'signal': {
+                    },
+                }
+                s_ret = self._mmcli('-m', modem, '--signal-get')
+                if s_ret.returncode == 0:
+                    s_j = json.loads(s_ret.stdout.decode())
+                    if int(s_j['modem']['signal']['refresh']['rate']) == 0:
+                        self._mmcli('-m', modem, '--signal-setup', '5')
+                    else:
+                        for k in s_j['modem']['signal'][tech]:
+                            try:
+                                v = float(s_j['modem']['signal'][tech][k])
+                            except ValueError:
+                                continue
+                            item['connection']['signal'][k] = v
+            data.append(item)
+        self.data = data
+
+    def collect(self):
+        return self.data
+
+    def _modem_list(self):
+        ret = self._mmcli('-L')
+        if ret.returncode == 0:
+            yield from json.loads(ret.stdout.decode())['modem-list']
+
+    def _mmcli(self, *args):
+        cmd = ['mmcli', '-J'] + list(args)
+        try:
+            return subprocess.run(cmd, capture_output=True)
+        except FileNotFoundError:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=127,
+                stdout=b'',
+                stderr=f'{cmd[0]}: command not found'.encode()
+            )

--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -7,47 +7,46 @@ import json
 from its_status import helpers
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
         self.data = list()
 
     def capture(self):
         data = list()
         for modem in self._modem_list():
-            m_ret = self._mmcli('-m', modem)
+            m_ret = self._mmcli("-m", modem)
             if m_ret.returncode:
                 continue
             m_j = json.loads(m_ret.stdout.decode())
             item = {
-                'hardware': {
-                    'vendor': m_j['modem']['generic']['manufacturer'],
-                    'model': m_j['modem']['generic']['model'],
-                    'revision': m_j['modem']['generic']['hardware-revision'],
+                "hardware": {
+                    "vendor": m_j["modem"]["generic"]["manufacturer"],
+                    "model": m_j["modem"]["generic"]["model"],
+                    "revision": m_j["modem"]["generic"]["hardware-revision"],
                 },
             }
-            if m_j['modem']['generic']['state'] == 'connected':
-                item['operator'] = {
-                    'code': m_j['modem']['3gpp']['operator-code'],
-                    'name': m_j['modem']['3gpp']['operator-name'],
+            if m_j["modem"]["generic"]["state"] == "connected":
+                item["operator"] = {
+                    "code": m_j["modem"]["3gpp"]["operator-code"],
+                    "name": m_j["modem"]["3gpp"]["operator-name"],
                 }
-                tech = m_j['modem']['generic']['access-technologies'][0]
-                item['connection'] = {
-                    'technology': tech,
-                    'signal': {
-                    },
+                tech = m_j["modem"]["generic"]["access-technologies"][0]
+                item["connection"] = {
+                    "technology": tech,
+                    "signal": {},
                 }
-                s_ret = self._mmcli('-m', modem, '--signal-get')
+                s_ret = self._mmcli("-m", modem, "--signal-get")
                 if s_ret.returncode == 0:
                     s_j = json.loads(s_ret.stdout.decode())
-                    if int(s_j['modem']['signal']['refresh']['rate']) == 0:
-                        self._mmcli('-m', modem, '--signal-setup', '5')
+                    if int(s_j["modem"]["signal"]["refresh"]["rate"]) == 0:
+                        self._mmcli("-m", modem, "--signal-setup", "5")
                     else:
-                        for k in s_j['modem']['signal'][tech]:
+                        for k in s_j["modem"]["signal"][tech]:
                             try:
-                                v = float(s_j['modem']['signal'][tech][k])
+                                v = float(s_j["modem"]["signal"][tech][k])
                             except ValueError:
                                 continue
-                            item['connection']['signal'][k] = v
+                            item["connection"]["signal"][k] = v
             data.append(item)
         self.data = data
 
@@ -55,10 +54,10 @@ class Status():
         return self.data
 
     def _modem_list(self):
-        ret = self._mmcli('-L')
+        ret = self._mmcli("-L")
         if ret.returncode == 0:
-            yield from json.loads(ret.stdout.decode())['modem-list']
+            yield from json.loads(ret.stdout.decode())["modem-list"]
 
     def _mmcli(self, *args):
-        cmd = ['mmcli', '-J'] + list(args)
+        cmd = ["mmcli", "-J"] + list(args)
         return helpers.run(cmd)

--- a/python/its-status/its_status/collector.static.py
+++ b/python/its-status/its_status/collector.static.py
@@ -4,12 +4,12 @@
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
         self.data = {
-            'version': '1.0.0',
-            'type': 'obu',
-            'id': cfg['generic']['id'],
+            "version": "1.0.0",
+            "type": "obu",
+            "id": cfg["generic"]["id"],
         }
 
     def capture(self):

--- a/python/its-status/its_status/collector.static.py
+++ b/python/its-status/its_status/collector.static.py
@@ -1,0 +1,19 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+
+class Status():
+    def __init__(self, cfg):
+        self.data = {
+            'version': '1.0.0',
+            'type': 'obu',
+            'id': cfg['generic']['id'],
+        }
+
+    def capture(self):
+        pass
+
+    def collect(self):
+        return self.data

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -7,7 +7,7 @@ import psutil
 
 
 class Status():
-    def __init__(self):
+    def __init__(self, cfg):
         self.data = None
         self.static_data = {'hardware': 'oci'}
         with open('/etc/os-release', 'r') as f:

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -8,51 +8,63 @@ import psutil
 from its_status import helpers
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
         self.data = None
         hw = None
-        lshw_cmd = ['lshw', '-quiet', '-json',
-                    '-disable', 'usb',
-                    '-disable', 'pci',
-                    '-disable', 'pcilegacy',
-                    '-disable', 'isapnp',
-                    '-disable', 'network'
-                    ]
+
+        # This is the ugly-dirty code style unamically dictated by black
+        # which does not allow us to keep corresponding options side-by-side
+        # with their value... 😢
+        lshw_cmd = [
+            "lshw",
+            "-quiet",
+            "-json",
+            "-disable",
+            "usb",
+            "-disable",
+            "pci",
+            "-disable",
+            "pcilegacy",
+            "-disable",
+            "isapnp",
+            "-disable",
+            "network",
+        ]
         ret = helpers.run(lshw_cmd)
         if ret.returncode == 0:
             lshw = json.loads(ret.stdout)
-            if 'product' in lshw:
-                hw = lshw['product']
+            if "product" in lshw:
+                hw = lshw["product"]
             else:
-                for child in lshw['children']:
-                    if child['id'] == 'core' and 'product' in child:
-                        hw = child['product']
+                for child in lshw["children"]:
+                    if child["id"] == "core" and "product" in child:
+                        hw = child["product"]
                         break
         if hw is None:
             try:
-                with open('/proc/self/cgroup', 'rb') as f:
+                with open("/proc/self/cgroup", "rb") as f:
                     lines = f.readlines()
-                if lines[-1].decode().split(':')[2].startswith('/docker/'):
-                    hw = 'oci'
+                if lines[-1].decode().split(":")[2].startswith("/docker/"):
+                    hw = "oci"
             except Exception:
                 pass
 
-        self.static_data = {'hardware': hw or "Unknown"}
-        with open('/etc/os-release', 'r') as f:
-            self.static_data['os_release'] = dict()
+        self.static_data = {"hardware": hw or "Unknown"}
+        with open("/etc/os-release", "r") as f:
+            self.static_data["os_release"] = dict()
             for l in f.readlines():
-                key = l.split('=', maxsplit=1)[0]
-                val = l.split('=', maxsplit=1)[1].rstrip().strip('"')
-                self.static_data['os_release'][key] = val
+                key = l.split("=", maxsplit=1)[0]
+                val = l.split("=", maxsplit=1)[1].rstrip().strip('"')
+                self.static_data["os_release"][key] = val
 
     def capture(self):
         data = self.static_data
-        data['cpu_load'] = psutil.getloadavg()
+        data["cpu_load"] = psutil.getloadavg()
         mem = psutil.virtual_memory()
-        data['memory'] = (mem.total, mem.available)
-        disk = psutil.disk_usage('/data')
-        data['storage'] = (disk.total, disk.free)
+        data["memory"] = (mem.total, mem.available)
+        disk = psutil.disk_usage("/data")
+        data["storage"] = (disk.total, disk.free)
         self.data = data
 
     def collect(self):

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -5,7 +5,7 @@
 
 import json
 import psutil
-import subprocess
+from its_status import helpers
 
 
 class Status():
@@ -19,8 +19,8 @@ class Status():
                     '-disable', 'isapnp',
                     '-disable', 'network'
                     ]
-        try:
-            ret = subprocess.run(lshw_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        ret = helpers.run(lshw_cmd)
+        if ret.returncode == 0:
             lshw = json.loads(ret.stdout)
             if 'product' in lshw:
                 hw = lshw['product']
@@ -29,7 +29,7 @@ class Status():
                     if child['id'] == 'core' and 'product' in child:
                         hw = child['product']
                         break
-        except Exception:
+        if hw is None:
             try:
                 with open('/proc/self/cgroup', 'rb') as f:
                     lines = f.readlines()

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -1,0 +1,30 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import psutil
+
+
+class Status():
+    def __init__(self):
+        self.data = None
+        self.static_data = {'hardware': 'oci'}
+        with open('/etc/os-release', 'r') as f:
+            self.static_data['os_release'] = dict()
+            for l in f.readlines():
+                key = l.split('=', maxsplit=1)[0]
+                val = l.split('=', maxsplit=1)[1].rstrip().strip('"')
+                self.static_data['os_release'][key] = val
+
+    def capture(self):
+        data = self.static_data
+        data['cpu_load'] = psutil.getloadavg()
+        mem = psutil.virtual_memory()
+        data['memory'] = (mem.total, mem.available)
+        disk = psutil.disk_usage('/data')
+        data['storage'] = (disk.total, disk.free)
+        self.data = data
+
+    def collect(self):
+        return self.data

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -17,7 +17,7 @@ SRC_STATE = {
 
 
 class Status():
-    def __init__(self):
+    def __init__(self, cfg):
         self.data = list()
         self.refclocks = dict()
         with open('/etc/chrony.conf', 'r') as f:

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -6,33 +6,33 @@
 import time
 from its_status import helpers
 
-CHRONYC = ['chronyc', '-c', '-n', 'sources']
+CHRONYC = ["chronyc", "-c", "-n", "sources"]
 SRC_STATE = {
-    '*': 'best',
-    '+': 'combined',
-    '-': 'not_combined',
-    'x': 'maybe_error',
-    '~': 'unstable',
-    '?': 'unusable',
+    "*": "best",
+    "+": "combined",
+    "-": "not_combined",
+    "x": "maybe_error",
+    "~": "unstable",
+    "?": "unusable",
 }
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
         self.data = list()
-        self.validity = cfg.getfloat('timesources', 'validity', fallback=10.0)
+        self.validity = cfg.getfloat("timesources", "validity", fallback=10.0)
         self.last_valid = 0.0
         self.refclocks = dict()
         self.enabled = True
         try:
-            with open('/etc/chrony.conf', 'r') as f:
+            with open("/etc/chrony.conf", "r") as f:
                 for l in f.readlines():
-                    if not l.startswith('refclock '):
+                    if not l.startswith("refclock "):
                         continue
-                    fields = l.rstrip().split(' ')
+                    fields = l.rstrip().split(" ")
                     for i in range(len(fields)):
-                        if fields[i] == 'refid':
-                            self.refclocks[fields[i+1]] = fields[1].lower()
+                        if fields[i] == "refid":
+                            self.refclocks[fields[i + 1]] = fields[1].lower()
                             break
         except FileNotFoundError:
             # No chrony config file means chrony not installed
@@ -50,23 +50,23 @@ class Status():
 
         data = list()
         for l in ret.stdout.decode().splitlines():
-            fields = l.split(',')
+            fields = l.split(",")
             src = {
-                'state': SRC_STATE[fields[1]],
-                'error': float(fields[-1])
+                "state": SRC_STATE[fields[1]],
+                "error": float(fields[-1]),
             }
             name = fields[2]
             if name in self.refclocks:
-                if self.refclocks[name] == 'pps':
-                    src['type'] = 'pps'
-                    src['label'] = name
+                if self.refclocks[name] == "pps":
+                    src["type"] = "pps"
+                    src["label"] = name
                 else:  # Only SHM-NMEA is know apart PPS
-                    src['type'] = 'nmea'
-                src['stratum'] = 0
+                    src["type"] = "nmea"
+                src["stratum"] = 0
             else:
-                src['type'] = 'ntp'
-                src['host'] = name
-                src['stratum'] = int(fields[3])
+                src["type"] = "ntp"
+                src["host"] = name
+                src["stratum"] = int(fields[3])
             data.append(src)
         self.last_valid = now
         self.data = data

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -1,0 +1,60 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import subprocess
+
+CHRONYC = ['chronyc', '-c', '-n', 'sources']
+SRC_STATE = {
+    '*': 'best',
+    '+': 'combined',
+    '-': 'not_combined',
+    'x': 'maybe_error',
+    '~': 'unstable',
+    '?': 'unusable',
+}
+
+
+class Status():
+    def __init__(self):
+        self.data = list()
+        self.refclocks = dict()
+        with open('/etc/chrony.conf', 'r') as f:
+            for l in f.readlines():
+                if not l.startswith('refclock '):
+                    continue
+                fields = l.rstrip().split(' ')
+                for i in range(len(fields)):
+                    if fields[i] == 'refid':
+                        self.refclocks[fields[i+1]] = fields[1].lower()
+                        break
+
+    def capture(self):
+        data = list()
+        ret = subprocess.run(CHRONYC, capture_output=True)
+        if ret.returncode != 0:
+            return
+        for l in ret.stdout.decode().splitlines():
+            fields = l.split(',')
+            src = {
+                'state': SRC_STATE[fields[1]],
+                'error': float(fields[-1])
+            }
+            name = fields[2]
+            if name in self.refclocks:
+                if self.refclocks[name] == 'pps':
+                    src['type'] = 'pps'
+                    src['label'] = name
+                else:  # Only SHM-NMEA is know apart PPS
+                    src['type'] = 'nmea'
+                src['stratum'] = 0
+            else:
+                src['type'] = 'ntp'
+                src['host'] = name
+                src['stratum'] = int(fields[3])
+            data.append(src)
+        self.data = data
+
+    def collect(self):
+        return self.data

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -20,17 +20,24 @@ class Status():
     def __init__(self, cfg):
         self.data = list()
         self.refclocks = dict()
-        with open('/etc/chrony.conf', 'r') as f:
-            for l in f.readlines():
-                if not l.startswith('refclock '):
-                    continue
-                fields = l.rstrip().split(' ')
-                for i in range(len(fields)):
-                    if fields[i] == 'refid':
-                        self.refclocks[fields[i+1]] = fields[1].lower()
-                        break
+        self.enabled = True
+        try:
+            with open('/etc/chrony.conf', 'r') as f:
+                for l in f.readlines():
+                    if not l.startswith('refclock '):
+                        continue
+                    fields = l.rstrip().split(' ')
+                    for i in range(len(fields)):
+                        if fields[i] == 'refid':
+                            self.refclocks[fields[i+1]] = fields[1].lower()
+                            break
+        except FileNotFoundError:
+            # No chrony config file means chrony not installed
+            self.enabled = False
 
     def capture(self):
+        if not self.enabled:
+            return
         data = list()
         ret = helpers.run(CHRONYC)
         if ret.returncode != 0:

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
-import subprocess
+from its_status import helpers
 
 CHRONYC = ['chronyc', '-c', '-n', 'sources']
 SRC_STATE = {
@@ -32,7 +32,7 @@ class Status():
 
     def capture(self):
         data = list()
-        ret = subprocess.run(CHRONYC, capture_output=True)
+        ret = helpers.run(CHRONYC)
         if ret.returncode != 0:
             return
         for l in ret.stdout.decode().splitlines():

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -1,0 +1,18 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import json
+import paho.mqtt.client
+
+
+class Status():
+    def __init__(self):
+        self.client = paho.mqtt.client.Client(client_id='foo')
+        self.client.reconnect_delay_set()
+        self.client.connect(host='127.0.0.1', port=1883)
+        self.client.loop_start()
+
+    def emit(self, data):
+        self.client.publish('status/system', json.dumps(data))

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -13,11 +13,14 @@ class Status():
         if self.enabled:
             self.host = cfg.get('mqtt', 'host', fallback='127.0.0.1')
             self.port = cfg.getint('mqtt', 'port', fallback=1883)
+            self.username = cfg.get('mqtt', 'username', fallback=None)
+            self.password = cfg.get('mqtt', 'password', fallback=None)
             self.client_id = cfg.get('mqtt', 'client_id', fallback='its-status')
             self.topic = cfg.get('mqtt', 'topic', fallback='status/system')
 
             self.client = paho.mqtt.client.Client(client_id=self.client_id)
             self.client.reconnect_delay_set()
+            self.client.username_pw_set(self.username, self.password)
             self.client.connect(host=self.host, port=self.port)
             self.client.loop_start()
 

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -9,10 +9,18 @@ import paho.mqtt.client
 
 class Status():
     def __init__(self, cfg):
-        self.client = paho.mqtt.client.Client(client_id='foo')
-        self.client.reconnect_delay_set()
-        self.client.connect(host='127.0.0.1', port=1883)
-        self.client.loop_start()
+        self.enabled = cfg.get('mqtt', 'enabled', fallback=True)
+        if self.enabled:
+            self.host = cfg.get('mqtt', 'host', fallback='127.0.0.1')
+            self.port = cfg.getint('mqtt', 'port', fallback=1883)
+            self.client_id = cfg.get('mqtt', 'client_id', fallback='its-status')
+            self.topic = cfg.get('mqtt', 'topic', fallback='status/system')
+
+            self.client = paho.mqtt.client.Client(client_id=self.client_id)
+            self.client.reconnect_delay_set()
+            self.client.connect(host=self.host, port=self.port)
+            self.client.loop_start()
 
     def emit(self, data):
-        self.client.publish('status/system', json.dumps(data))
+        if self.enabled:
+            self.client.publish(self.topic, json.dumps(data))

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -8,7 +8,7 @@ import paho.mqtt.client
 
 
 class Status():
-    def __init__(self):
+    def __init__(self, cfg):
         self.client = paho.mqtt.client.Client(client_id='foo')
         self.client.reconnect_delay_set()
         self.client.connect(host='127.0.0.1', port=1883)

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -7,16 +7,16 @@ import json
 import paho.mqtt.client
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
-        self.enabled = cfg.get('mqtt', 'enabled', fallback=True)
+        self.enabled = cfg.get("mqtt", "enabled", fallback=True)
         if self.enabled:
-            self.host = cfg.get('mqtt', 'host', fallback='127.0.0.1')
-            self.port = cfg.getint('mqtt', 'port', fallback=1883)
-            self.username = cfg.get('mqtt', 'username', fallback=None)
-            self.password = cfg.get('mqtt', 'password', fallback=None)
-            self.client_id = cfg.get('mqtt', 'client_id', fallback='its-status')
-            self.topic = cfg.get('mqtt', 'topic', fallback='status/system')
+            self.host = cfg.get("mqtt", "host", fallback="127.0.0.1")
+            self.port = cfg.getint("mqtt", "port", fallback=1883)
+            self.username = cfg.get("mqtt", "username", fallback=None)
+            self.password = cfg.get("mqtt", "password", fallback=None)
+            self.client_id = cfg.get("mqtt", "client_id", fallback="its-status")
+            self.topic = cfg.get("mqtt", "topic", fallback="status/system")
 
             self.client = paho.mqtt.client.Client(client_id=self.client_id)
             self.client.reconnect_delay_set()
@@ -28,7 +28,7 @@ class Status():
         self._emit(self.topic, data)
 
     def error(self, data):
-        self._emit(self.topic + '/errors', data)
+        self._emit(self.topic + "/errors", data)
 
     def _emit(self, topic, data):
         if not self.enabled:
@@ -42,7 +42,7 @@ class Status():
 
     def _try_connect(self):
         if self.connected:
-            raise RuntimeError('MQTT connection already established')
+            raise RuntimeError("MQTT connection already established")
 
         try:
             self.client.connect(host=self.host, port=self.port)

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -25,6 +25,12 @@ class Status():
             self._try_connect()
 
     def emit(self, data):
+        self._emit(self.topic, data)
+
+    def error(self, data):
+        self._emit(self.topic + '/errors', data)
+
+    def _emit(self, topic, data):
         if not self.enabled:
             return
 
@@ -32,7 +38,7 @@ class Status():
             self._try_connect()
 
         if self.connected:
-            self.client.publish(self.topic, json.dumps(data))
+            self.client.publish(topic, json.dumps(data))
 
     def _try_connect(self):
         if self.connected:

--- a/python/its-status/its_status/emitter.stdout.py
+++ b/python/its-status/its_status/emitter.stdout.py
@@ -1,0 +1,14 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import json
+
+
+class Status():
+    def __init__(self):
+        pass
+
+    def emit(self, data):
+        print(json.dumps(data), flush=True)

--- a/python/its-status/its_status/emitter.stdout.py
+++ b/python/its-status/its_status/emitter.stdout.py
@@ -7,7 +7,7 @@ import json
 
 
 class Status():
-    def __init__(self):
+    def __init__(self, cfg):
         pass
 
     def emit(self, data):

--- a/python/its-status/its_status/emitter.stdout.py
+++ b/python/its-status/its_status/emitter.stdout.py
@@ -13,3 +13,6 @@ class Status():
     def emit(self, data):
         if self.enabled:
             print(json.dumps(data), flush=True)
+
+    def error(self, data):
+        self.emit(data)

--- a/python/its-status/its_status/emitter.stdout.py
+++ b/python/its-status/its_status/emitter.stdout.py
@@ -8,7 +8,8 @@ import json
 
 class Status():
     def __init__(self, cfg):
-        pass
+        self.enabled = cfg.getboolean('stdout', 'enabled', fallback=False)
 
     def emit(self, data):
-        print(json.dumps(data), flush=True)
+        if self.enabled:
+            print(json.dumps(data), flush=True)

--- a/python/its-status/its_status/emitter.stdout.py
+++ b/python/its-status/its_status/emitter.stdout.py
@@ -6,9 +6,9 @@
 import json
 
 
-class Status():
+class Status:
     def __init__(self, cfg):
-        self.enabled = cfg.getboolean('stdout', 'enabled', fallback=False)
+        self.enabled = cfg.getboolean("stdout", "enabled", fallback=False)
 
     def emit(self, data):
         if self.enabled:

--- a/python/its-status/its_status/helpers.py
+++ b/python/its-status/its_status/helpers.py
@@ -1,0 +1,18 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import subprocess
+
+
+def run(cmd):
+    try:
+        return subprocess.run(cmd, capture_output=True)
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=127,
+            stdout=b'',
+            stderr=f'{cmd[0]}: command not found'.encode()
+        )

--- a/python/its-status/its_status/helpers.py
+++ b/python/its-status/its_status/helpers.py
@@ -13,6 +13,6 @@ def run(cmd):
         return subprocess.CompletedProcess(
             args=cmd,
             returncode=127,
-            stdout=b'',
-            stderr=f'{cmd[0]}: command not found'.encode()
+            stdout=b"",
+            stderr=f"{cmd[0]}: command not found".encode(),
         )

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -15,12 +15,14 @@ STATIC_STATUS = {
 
 
 def main():
-    its_status.init()
-    basic_status = STATIC_STATUS
     with open('/etc/its-status/its-status.cfg') as f:
         cfg = configparser.ConfigParser()
         cfg.read_file(f)
-        basic_status['id'] = cfg['generic']['id']
+
+    basic_status = STATIC_STATUS
+    basic_status['id'] = cfg['generic']['id']
+
+    its_status.init()
 
     def tick(_signum, _frame):
         status = basic_status

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -1,0 +1,41 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import configparser
+import its_status
+import json
+import time
+
+STATIC_STATUS = {
+    'version': '1.0.0',
+    'type': 'obu',
+}
+
+
+def main():
+    its_status.init()
+    basic_status = STATIC_STATUS
+    with open('/etc/its-status/its-status.cfg') as f:
+        cfg = configparser.ConfigParser()
+        cfg.read_file(f)
+        basic_status['id'] = cfg['generic']['id']
+
+    while True:
+        status = basic_status
+        status['collect'] = {'start': time.time()}
+        for c in its_status.plugins['collectors']:
+            status['collect'][c] = {'start': time.time()}
+            its_status.plugins["collectors"][c].capture()
+            status['collect'][c]['duration'] = time.time() - status['collect'][c]['start']
+        for c in its_status.plugins['collectors']:
+            status[c] = its_status.plugins["collectors"][c].collect()
+        status['collect']['duration'] = time.time() - status['collect']['start']
+
+        # Here, we'd send them to MQTT or anywhere else
+        status['timestamp'] = time.time()
+        print(json.dumps(status), flush=True)
+
+        # Just one iteration for now, to debug the stuff
+        break

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -24,6 +24,7 @@ def main():
 
     its_status.init(cfg)
     collect_ts = cfg.getboolean('generic', 'timestamp_collect', fallback=False)
+    freq = cfg.getfloat('generic', 'frequency', fallback=1.0)
 
     def tick(_signum, _frame):
         status = dict()
@@ -52,7 +53,7 @@ def main():
             its_status.plugins['emitters'][e].emit(status)
 
     signal.signal(signal.SIGALRM, tick)
-    signal.setitimer(signal.ITIMER_REAL, 1.0, 1.0)
+    signal.setitimer(signal.ITIMER_REAL, 1/freq, 1/freq)
 
     while True:
         time.sleep(60)

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -10,13 +10,17 @@ import signal
 import sys
 import time
 
-CFG = '/etc/its-status/its-status.cfg'
+CFG = "/etc/its-status/its-status.cfg"
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--config', '-c', default=CFG,
-                        help=f'Path to the configuration file (default: {CFG})')
+    parser.add_argument(
+        "--config",
+        "-c",
+        default=CFG,
+        help=f"Path to the configuration file (default: {CFG})",
+    )
     args = parser.parse_args()
 
     with open(args.config) as f:
@@ -24,8 +28,8 @@ def main():
         cfg.read_file(f)
 
     its_status.init(cfg)
-    collect_ts = cfg.getboolean('generic', 'timestamp_collect', fallback=False)
-    freq = cfg.getfloat('generic', 'frequency', fallback=1.0)
+    collect_ts = cfg.getboolean("generic", "timestamp_collect", fallback=False)
+    freq = cfg.getfloat("generic", "frequency", fallback=1.0)
 
     def tick(_signum, _frame):
         tick.tick += 1
@@ -33,55 +37,60 @@ def main():
         errors = None
         if tick.in_tick:
             if tick.missed == 0:
-                print(f'tick: missed #{tick.tick}', file=sys.stderr)
+                print(f"tick: missed #{tick.tick}", file=sys.stderr)
             tick.missed += 1
             return
         elif tick.missed:
-            print(f'tick: resuming #{tick.tick} after {tick.missed} missed ticks', file=sys.stderr)
+            print(
+                f"tick: resuming #{tick.tick} after {tick.missed} missed ticks",
+                file=sys.stderr,
+            )
             errors = {
-                'timestamp': time.time(),
-                'type': 'status',
-                'tick': tick.tick,
-                'missed_ticks': tick.missed
+                "timestamp": time.time(),
+                "type": "status",
+                "tick": tick.tick,
+                "missed_ticks": tick.missed,
             }
             tick.missed = 0
         tick.in_tick = True
 
         status = dict()
         if collect_ts:
-            status['collect'] = {'start': time.time()}
-        for c in its_status.plugins['collectors']:
+            status["collect"] = {"start": time.time()}
+        for c in its_status.plugins["collectors"]:
             if collect_ts:
-                status['collect'][c] = {'start': time.time()}
+                status["collect"][c] = {"start": time.time()}
             its_status.plugins["collectors"][c].capture()
             if collect_ts:
-                status['collect'][c]['duration'] = time.time() - status['collect'][c]['start']
+                status["collect"][c]["duration"] = (
+                    time.time() - status["collect"][c]["start"]
+                )
 
-        for c in its_status.plugins['collectors']:
+        for c in its_status.plugins["collectors"]:
             s = its_status.plugins["collectors"][c].collect()
-            if c == 'static':
+            if c == "static":
                 status.update(s)
             else:
                 status[c] = s
 
         if collect_ts:
-            status['collect']['duration'] = time.time() - status['collect']['start']
+            status["collect"]["duration"] = time.time() - status["collect"]["start"]
 
         # Here, we'd send them to MQTT or anywhere else
-        status['timestamp'] = time.time()
-        for e in its_status.plugins['emitters']:
+        status["timestamp"] = time.time()
+        for e in its_status.plugins["emitters"]:
             if errors is not None:
-                its_status.plugins['emitters'][e].error(errors)
-            its_status.plugins['emitters'][e].emit(status)
+                its_status.plugins["emitters"][e].error(errors)
+            its_status.plugins["emitters"][e].emit(status)
 
         tick.in_tick = False
 
-    setattr(tick, 'in_tick', False)
-    setattr(tick, 'tick', 0)
-    setattr(tick, 'missed', 0)
+    setattr(tick, "in_tick", False)
+    setattr(tick, "tick", 0)
+    setattr(tick, "missed", 0)
 
     signal.signal(signal.SIGALRM, tick)
-    signal.setitimer(signal.ITIMER_REAL, 1/freq, 1/freq)
+    signal.setitimer(signal.ITIMER_REAL, 1 / freq, 1 / freq)
 
     while True:
         time.sleep(60)

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -5,6 +5,7 @@
 
 import configparser
 import its_status
+import signal
 import time
 
 STATIC_STATUS = {
@@ -21,7 +22,7 @@ def main():
         cfg.read_file(f)
         basic_status['id'] = cfg['generic']['id']
 
-    while True:
+    def tick(_signum, _frame):
         status = basic_status
         status['collect'] = {'start': time.time()}
         for c in its_status.plugins['collectors']:
@@ -37,5 +38,8 @@ def main():
         for e in its_status.plugins['emitters']:
             its_status.plugins['emitters'][e].emit(status)
 
-        # Just one iteration for now, to debug the stuff
-        break
+    signal.signal(signal.SIGALRM, tick)
+    signal.setitimer(signal.ITIMER_REAL, 1.0, 1.0)
+
+    while True:
+        time.sleep(60)

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -3,14 +3,22 @@
 # SPDX-License-Identifier: MIT
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
+import argparse
 import configparser
 import its_status
 import signal
 import time
 
+CFG = '/etc/its-status/its-status.cfg'
+
 
 def main():
-    with open('/etc/its-status/its-status.cfg') as f:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', '-c', default=CFG,
+                        help=f'Path to the configuration file (default: {CFG})')
+    args = parser.parse_args()
+
+    with open(args.config) as f:
         cfg = configparser.ConfigParser()
         cfg.read_file(f)
 

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -22,7 +22,7 @@ def main():
     basic_status = STATIC_STATUS
     basic_status['id'] = cfg['generic']['id']
 
-    its_status.init()
+    its_status.init(cfg)
 
     def tick(_signum, _frame):
         status = basic_status

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -23,14 +23,18 @@ def main():
         cfg.read_file(f)
 
     its_status.init(cfg)
+    collect_ts = cfg.getboolean('generic', 'timestamp_collect', fallback=False)
 
     def tick(_signum, _frame):
         status = dict()
-        status['collect'] = {'start': time.time()}
+        if collect_ts:
+            status['collect'] = {'start': time.time()}
         for c in its_status.plugins['collectors']:
-            status['collect'][c] = {'start': time.time()}
+            if collect_ts:
+                status['collect'][c] = {'start': time.time()}
             its_status.plugins["collectors"][c].capture()
-            status['collect'][c]['duration'] = time.time() - status['collect'][c]['start']
+            if collect_ts:
+                status['collect'][c]['duration'] = time.time() - status['collect'][c]['start']
 
         for c in its_status.plugins['collectors']:
             s = its_status.plugins["collectors"][c].collect()
@@ -39,7 +43,8 @@ def main():
             else:
                 status[c] = s
 
-        status['collect']['duration'] = time.time() - status['collect']['start']
+        if collect_ts:
+            status['collect']['duration'] = time.time() - status['collect']['start']
 
         # Here, we'd send them to MQTT or anywhere else
         status['timestamp'] = time.time()

--- a/python/its-status/its_status/main.py
+++ b/python/its-status/its_status/main.py
@@ -5,7 +5,6 @@
 
 import configparser
 import its_status
-import json
 import time
 
 STATIC_STATUS = {
@@ -35,7 +34,8 @@ def main():
 
         # Here, we'd send them to MQTT or anywhere else
         status['timestamp'] = time.time()
-        print(json.dumps(status), flush=True)
+        for e in its_status.plugins['emitters']:
+            its_status.plugins['emitters'][e].emit(status)
 
         # Just one iteration for now, to debug the stuff
         break

--- a/python/its-status/setup.cfg
+++ b/python/its-status/setup.cfg
@@ -1,0 +1,7 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+[bdist_wheel]
+python-tag = py3

--- a/python/its-status/setup.py
+++ b/python/its-status/setup.py
@@ -1,0 +1,37 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+from setuptools import setup, find_packages
+
+setup(
+    name="its_status",
+    version="0.0.0",
+    author="Yann E. MORIN",
+    author_email="yann(dot)morin(at)orange(dot)com",
+    maintainer="Yann E. MORIN",
+    maintainer_email="yann(dot)morin(at)orange(dot)com",
+    keywords="network, its, vehicle, mqtt, etsi",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Telecommunications Industry",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Communications",
+        "Topic :: Software Development :: Embedded Systems",
+    ],
+    url="https://github.com/Orange-OpenSource/its-client",
+    packages=find_packages(exclude=["*.tests.*"]),
+    include_package_data=True,
+    description="The Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) Python packages based on the "
+    "[JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription.",
+    long_description="The Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) Python packages based on "
+    "the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification "
+    "transcription. It sends the device status information to an MQTT broker.",
+    license="MIT",
+    platforms="LINUX",
+    install_requires=[
+        "paho-mqtt==1.6.1",
+    ],
+    entry_points={"console_scripts": ["its-status = its_status.main:main"]},
+)


### PR DESCRIPTION
**New features:**
* `its-status`: new python client to publish ITS status messages that match the status schema

---
**How to test:**

1. build and install `python/its-status` with standard setuptools procedure;
2. create a configuration file, using `its-status.cfg` as startup point, adapt with your MQTT broker and credentials, enable the `stdout` emitter;
3. subscribe an MQTT client to your broker, on the status topic, e.g. with mosquitto CLI clients:
    ```sh
    $ mosquitto_sub -h BROKER -p PORT -u USERNAME -P PASSWORD -i ID -t 'status/#'
    ```
4. run `its-status` using your custom configuration file:
    ```sh
    $ its-status -c /path/to/its-status.custom.cfg
    ```

---
**Expected results:**

1. The `its-status` package is installed;
2. You have a custom configuration file with your MQTT settings;
3. The MQTT client is connected to your MQTT broker;
4. The `its-status` program runs, and the messages are visible both on the `its-status`' own `stdout`, as well as on the MQTT client.