### PR TITLE
python/its-client: mirror MQTT traffic to another broker

### DIFF
--- a/.github/workflows/python_its-client.yml
+++ b/.github/workflows/python_its-client.yml
@@ -1,10 +1,6 @@
 name: Python its-client
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -84,6 +84,18 @@ def build(args=None) -> ConfigParser:
         ),
     )
     parser.add_argument(
+        "--mqtt-mirror-self",
+        action="store_true",
+        default=None,  # store_true defaults to False, but we don't want a default
+        help="do forward self messages received back from main broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-no-self",
+        action="store_false",
+        dest="mqtt_mirror_self",
+        help="don't forward self messages received back from main broker",
+    )
+    parser.add_argument(
         "--static",
         "-s",
         action="store_true",
@@ -183,6 +195,12 @@ def build(args=None) -> ConfigParser:
             section="mirror-broker",
             option="client_id",
             value=args.mqtt_mirror_client_id or "",
+        )
+    if args.mqtt_mirror_self is not None:
+        config.set(
+            section="mirror-broker",
+            option="mirror-self",
+            value=str(args.mqtt_mirror_self),
         )
     if config.get("mirror-broker", "host", fallback=None) is None:
         config.remove_section("mirror-broker")

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -21,10 +21,16 @@ def build(args=None) -> ConfigParser:
         help="port of the MQTT broker",
     )
     parser.add_argument(
-        "--mqtt-tls-port",
-        "-T",
-        type=int,
-        help="TLS port of the MQTT broker",
+        "--mqtt-tls",
+        action="store_true",
+        default=None,  # store_true defaults to False, but we don't want a default
+        help="use TLS when connecting to the MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-no-tls",
+        action="store_false",
+        dest="mqtt_tls",
+        help="use TLS when connecting to the MQTT broker",
     )
     parser.add_argument(
         "--mqtt-username",
@@ -100,8 +106,8 @@ def build(args=None) -> ConfigParser:
         config.set(section="broker", option="host", value=args.mqtt_host)
     if args.mqtt_port is not None:
         config.set(section="broker", option="port", value=str(args.mqtt_port))
-    if args.mqtt_tls_port is not None:
-        config.set(section="broker", option="tls_port", value=str(args.mqtt_tls_port))
+    if args.mqtt_tls is not None:
+        config.set(section="broker", option="tls", value=str(args.mqtt_tls))
     if args.mqtt_username is not None:
         config.set(section="broker", option="username", value=args.mqtt_username)
     if args.mqtt_password is not None:

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -10,60 +10,51 @@ def build(args=None) -> ConfigParser:
     # argument parser
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
-        "-H",
         "--mqtt-host",
-        dest="mqtt_hostname",
+        "-H",
         help="hostname of the MQTT broker",
     )
     parser.add_argument(
-        "-P",
         "--mqtt-port",
+        "-P",
         type=int,
-        dest="mqtt_port",
         help="port of the MQTT broker",
     )
     parser.add_argument(
-        "-T",
         "--mqtt-tls-port",
+        "-T",
         type=int,
-        dest="mqtt_tls_port",
         help="TLS port of the MQTT broker",
     )
     parser.add_argument(
-        "-u",
         "--mqtt-username",
-        dest="mqtt_username",
+        "-u",
         help="username to use when connecting to the MQTT broker",
     )
     parser.add_argument(
-        "-p",
         "--mqtt-password",
-        dest="mqtt_password",
+        "-p",
         help="password to use when connecting to the MQTT broker",
     )
     parser.add_argument(
         "--mqtt-client-id",
-        dest="mqtt_client_id",
         help="identifier of MQTT client. This must be unique in the broker",
     )
     parser.add_argument(
-        "-s",
         "--static",
-        dest="static",
+        "-s",
         action="store_true",
         default=None,
         help="use a static position store in configuration instead of the gps daemon",
     )
     parser.add_argument(
-        "-l",
         "--log-level",
-        dest="log_level",
+        "-l",
         help="logging level: CRITICAL, ERROR, WARNING, INFO or DEBUG",
     )
     parser.add_argument(
-        "-c",
         "--config-path",
-        dest="config_path",
+        "-c",
         default=os.path.dirname(os.path.realpath(__file__)),
         help="path to the its_config.cfg file",
     )
@@ -105,8 +96,8 @@ def build(args=None) -> ConfigParser:
         config.set(section="position", option="static", value=str(args.static))
     if args.mqtt_client_id is not None:
         config.set(section="broker", option="client_id", value=args.mqtt_client_id)
-    if args.mqtt_hostname is not None:
-        config.set(section="broker", option="host", value=args.mqtt_hostname)
+    if args.mqtt_host is not None:
+        config.set(section="broker", option="host", value=args.mqtt_host)
     if args.mqtt_port is not None:
         config.set(section="broker", option="port", value=str(args.mqtt_port))
     if args.mqtt_tls_port is not None:

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -47,6 +47,43 @@ def build(args=None) -> ConfigParser:
         help="identifier of MQTT client. This must be unique in the broker",
     )
     parser.add_argument(
+        "--mqtt-mirror-host",
+        help="mirror all messages sent to and received from --mqtt-host to this broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-port",
+        type=int,
+        default=1883,
+        help="port of the mirror MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-tls",
+        action="store_true",
+        default=None,  # store_true defaults to False, but we don't want a default
+        help="use TLS when connecting to the mirror MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-no-tls",
+        action="store_false",
+        dest="mqtt_mirror_tls",
+        help="use TLS when connecting to the mirror MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-username",
+        help="username to use when connecting to the mirror MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-password",
+        help="password to use when connecting to the mirror MQTT broker",
+    )
+    parser.add_argument(
+        "--mqtt-mirror-client-id",
+        help=(
+            "unique MQTT client ID on the mirror MQTT broker,"
+            " if different from --mqtt-client-id."
+        ),
+    )
+    parser.add_argument(
         "--static",
         "-s",
         action="store_true",
@@ -112,6 +149,43 @@ def build(args=None) -> ConfigParser:
         config.set(section="broker", option="username", value=args.mqtt_username)
     if args.mqtt_password is not None:
         config.set(section="broker", option="password", value=args.mqtt_password)
+
+    if not config.has_section("mirror-broker"):
+        config.add_section("mirror-broker")
+    if args.mqtt_mirror_host is not None:
+        config.set(section="mirror-broker", option="host", value=args.mqtt_mirror_host)
+    if args.mqtt_mirror_port is not None:
+        config.set(
+            section="mirror-broker",
+            option="port",
+            value=str(args.mqtt_mirror_port),
+        )
+    if args.mqtt_mirror_tls is not None:
+        config.set(
+            section="mirror-broker",
+            option="tls",
+            value=str(args.mqtt_mirror_tls),
+        )
+    if args.mqtt_mirror_username is not None:
+        config.set(
+            section="mirror-broker",
+            option="username",
+            value=args.mqtt_mirror_username or "",
+        )
+    if args.mqtt_mirror_password is not None:
+        config.set(
+            section="mirror-broker",
+            option="password",
+            value=args.mqtt_mirror_password or "",
+        )
+    if args.mqtt_mirror_client_id is not None:
+        config.set(
+            section="mirror-broker",
+            option="client_id",
+            value=args.mqtt_mirror_client_id or "",
+        )
+    if config.get("mirror-broker", "host", fallback=None) is None:
+        config.remove_section("mirror-broker")
 
     # list all used contents
     logging.info("used configuration:")

--- a/python/its-client/its_client/its_client.cfg
+++ b/python/its-client/its_client/its_client.cfg
@@ -17,6 +17,17 @@ username = its_user
 password = password
 client_id = its_client
 
+# Uncomment this section to mirror all messages sent to, or received
+# from [broker], above, to this [mirror-broker]. Ensure they are not
+# the same broker, and that there is otherwise no loop!
+#[mirror-broker]
+#host = localhost
+#port = 8883
+#tls = false
+#username = its_user
+#password = password
+#client_id = its_client
+
 [position]
 static = true
 # if static is true, we use a fix position

--- a/python/its-client/its_client/its_client.cfg
+++ b/python/its-client/its_client/its_client.cfg
@@ -12,7 +12,7 @@
 [broker]
 host = localhost
 port = 1883
-tls_port = 8883
+tls = false
 username = its_user
 password = password
 client_id = its_client

--- a/python/its-client/its_client/its_client.cfg
+++ b/python/its-client/its_client/its_client.cfg
@@ -27,6 +27,7 @@ client_id = its_client
 #username = its_user
 #password = password
 #client_id = its_client
+#mirror-self = false
 
 [position]
 static = true

--- a/python/its-client/its_client/main.py
+++ b/python/its-client/its_client/main.py
@@ -81,9 +81,29 @@ def main():
         "password": config.get(section="broker", option="password"),
         "client_id": config.get(section="broker", option="client_id"),
     }
+    if config.has_section("mirror-broker"):
+        if config.getboolean("mirror-broker", "tls", fallback=False):
+            logging.error("TLS not yet supported on mirror broker")
+            exit(1)
+        mirror_broker = {
+            # Not handling TLS, as we're not ready for it yet.
+            "host": config.get("mirror-broker", "host"),
+            "port": config.getint("mirror-broker", "port"),
+            "username": config.get("mirror-broker", "username", fallback=""),
+            "password": config.get("mirror-broker", "password", fallback=""),
+            "client_id": config.get(
+                "mirror-broker",
+                "client_id",
+                fallback=config.get(section="broker", option="client_id"),
+            ),
+        }
+    else:
+        mirror_broker = None
+
     logging.info("starting mqtt client...")
     mqtt_client = MQTTClient(
         broker=broker,
+        mirror_broker=mirror_broker,
         geo_position=position_client,
         stop_signal=stop_signal,
     )

--- a/python/its-client/its_client/main.py
+++ b/python/its-client/its_client/main.py
@@ -44,6 +44,10 @@ def main():
 
     config = configuration.build()
 
+    if config.getboolean("broker", "tls", fallback=False):
+        logging.error("TLS not yet supported")
+        exit(1)
+
     logging.info(f"started at {int(round(start_time * 1000))}")
 
     if config.getboolean("position", "static"):

--- a/python/its-client/its_client/main.py
+++ b/python/its-client/its_client/main.py
@@ -96,6 +96,11 @@ def main():
                 "client_id",
                 fallback=config.get(section="broker", option="client_id"),
             ),
+            "mirror-self": config.getboolean(
+                "mirror-broker",
+                "mirror-self",
+                fallback=False,
+            ),
         }
     else:
         mirror_broker = None

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -90,12 +90,17 @@ class MQTTClient(object):
             message_dict = dict()
 
         if self.mirror_client:
-            self.mirror_client.publish(
-                message.topic,
-                message.payload,
-                message.qos,
-                message.retain,
-            )
+            if (
+                message_dict.get("source_uuid", "") != self.broker["client_id"]
+                or self.mirror_broker["mirror-self"]
+            ):
+                logging.debug(f"mid: {message.mid}: forwarding to mirror broker")
+                self.mirror_client.publish(
+                    message.topic,
+                    message.payload,
+                    message.qos,
+                    message.retain,
+                )
 
         if not message.payload:
             logging.debug(f"mid: {message.mid}, empty payload, skipping message")

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -55,10 +55,6 @@ class MQTTClient(object):
         logging.debug(
             self._format_log(f" called for {client.socket()} with {userdata}")
         )
-        if rc != 0:
-            logging.warning("unexpected disconnection")
-            self.loop_stop()
-            self.stop_signal.set()
 
     def on_connect(self, client, userdata, flags, rc):
         logging.debug(

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -193,6 +193,7 @@ class MQTTClient(object):
         self.client.on_socket_register_write = self.on_socket_register_write
         self.client.max_inflight_messages_set(20)
         self.client.max_queued_messages_set(100)
+        self.client.reconnect_delay_set(1, 2)
         self.client.connect(
             host=self.broker["host"],
             port=self.broker["port"],

--- a/python/its-client/its_client/test/its_client.cfg
+++ b/python/its-client/its_client/test/its_client.cfg
@@ -12,7 +12,7 @@
 [broker]
 host=test_host
 port=18
-tls_port=88
+tls=true
 username=test_user
 password=test_password
 client_id=test_client_id

--- a/python/its-client/its_client/test/test_configuration.py
+++ b/python/its-client/its_client/test/test_configuration.py
@@ -7,7 +7,7 @@ from its_client import configuration
 def _create_args(
     broker_host=None,
     broker_port=None,
-    broker_tls_port=None,
+    broker_tls=None,
     broker_username=None,
     broker_password=None,
     broker_client_id=None,
@@ -21,9 +21,8 @@ def _create_args(
     if broker_port is not None:
         args.append("--mqtt-port")
         args.append(str(broker_port))
-    if broker_tls_port is not None:
-        args.append("--mqtt-tls-port")
-        args.append(str(broker_tls_port))
+    if broker_tls is not None:
+        args.append("--mqtt-tls")
     if broker_username is not None:
         args.append("--mqtt-username")
         args.append(broker_username)
@@ -56,7 +55,7 @@ class TestConfiguration(unittest.TestCase):
     def test_from_parameter(self):
         broker_host = "parameter_host"
         broker_port = 19
-        broker_tls_port = 89
+        broker_tls = True
         broker_username = "parameter_user"
         broker_password = "parameter_password"
         broker_client_id = "parameter_client_id"
@@ -64,7 +63,7 @@ class TestConfiguration(unittest.TestCase):
         args = _create_args(
             broker_host=broker_host,
             broker_port=broker_port,
-            broker_tls_port=broker_tls_port,
+            broker_tls=broker_tls,
             broker_username=broker_username,
             broker_password=broker_password,
             broker_client_id=broker_client_id,
@@ -74,7 +73,7 @@ class TestConfiguration(unittest.TestCase):
         self._check_parameter_list(
             broker_host=broker_host,
             broker_port=broker_port,
-            broker_tls_port=broker_tls_port,
+            broker_tls=broker_tls,
             broker_username=broker_username,
             broker_password=broker_password,
             broker_client_id=broker_client_id,
@@ -99,11 +98,11 @@ class TestConfiguration(unittest.TestCase):
         self.config = configuration.build(args)
         self._check_parameter_list(broker_port=broker_port)
 
-    def test_broker_tls_port_from_parameter(self):
-        broker_tls_port = 90
-        args = _create_args(broker_tls_port=broker_tls_port)
+    def test_broker_tls_from_parameter(self):
+        broker_tls = True
+        args = _create_args(broker_tls=broker_tls)
         self.config = configuration.build(args)
-        self._check_parameter_list(broker_tls_port=broker_tls_port)
+        self._check_parameter_list(broker_tls=broker_tls)
 
     def test_broker_username_from_parameter(self):
         broker_username = "unique_name"
@@ -133,7 +132,7 @@ class TestConfiguration(unittest.TestCase):
         self,
         broker_host="test_host",
         broker_port=18,
-        broker_tls_port=88,
+        broker_tls=True,
         broker_username="test_user",
         broker_password="test_password",
         broker_client_id="test_client_id",
@@ -147,7 +146,7 @@ class TestConfiguration(unittest.TestCase):
     ):
         self.assertEqual(self.config.get("broker", "host"), broker_host)
         self.assertEqual(self.config.getint("broker", "port"), broker_port)
-        self.assertEqual(self.config.getint("broker", "tls_port"), broker_tls_port)
+        self.assertEqual(self.config.getboolean("broker", "tls"), broker_tls)
         self.assertEqual(self.config.get("broker", "username"), broker_username)
         self.assertEqual(self.config.get("broker", "password"), broker_password)
         self.assertEqual(self.config.get("broker", "client_id"), broker_client_id)


### PR DESCRIPTION
**New features:**
* `its-client`: mirror MQTT traffic to another broker

---
**How to test:**

1. build and install `python/its-clients` with standard setuptools procedure;
2. Start a local broker and listen on it:
    ```
    $ mosquitto -c /dev/null -p 11883 -d
    $ mosquitto_sub -p 11883 -t '5GCroCo/#'
    ```
3. Uncomment and update the `mirror-boker` section in `its_client.cfg`:
    ```
    [mirror-broker]
    host = localhost
    port = 11883
    mirror-self = false
    ```
4. Start `its-client` with that config file (warning, the path to the config file is in fact the path to the directory containing the config file):
    ```
    $ its-client -c /path/to/its_client/
    ```

Note: do not forget to kill the MQTT broker that is in the background...

---
**Expected results:**

1. The `its-client` package is installed
2. The MQTT broker starts, the MQTT listeners, well, listens...
3. The `its-client.cfg` config file is updated
4. `its-client` starts, the MQTT listener reports messages both in the `inQueue` and `outQueue`.