### PR TITLE
python/its-client: new options for configurable MQTT topics and for log files size and number

### DIFF
--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -145,10 +145,8 @@ def build(args=None) -> ConfigParser:
     if args.log_level is not None:
         config.set(section="log", option="default_level", value=args.log_level)
     # set up the logger with the configuration to be able to well log as soon as possible
-    logger.log_setup(
-        directory=config.get(section="log", option="directory"),
-        log_level=config.get(section="log", option="default_level"),
-    )
+    # this only initiliases the stdout logger for now
+    logger.log_setup(log_level=config.get(section="log", option="default_level"))
     logging.info(f"config loaded from {config_file}")
 
     logging.info("argument configuration:")
@@ -222,6 +220,12 @@ def build(args=None) -> ConfigParser:
         )
     if config.get("mirror-broker", "host", fallback=None) is None:
         config.remove_section("mirror-broker")
+
+    # Configure the rest of the loggers
+    logger.log_setup2(
+        directory=config.get(section="log", option="directory"),
+        log_level=config.get(section="log", option="default_level"),
+    )
 
     # list all used contents
     logging.info("used configuration:")

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -47,6 +47,18 @@ def build(args=None) -> ConfigParser:
         help="identifier of MQTT client. This must be unique in the broker",
     )
     parser.add_argument(
+        "--mqtt-root-pub",
+        help="root of all MQTT published topics",
+    )
+    parser.add_argument(
+        "--mqtt-root-sub",
+        help="root of all MQTT subscribed topics",
+    )
+    parser.add_argument(
+        "--mqtt-prefix",
+        help="prefix to all MQTT topics, subscribed or published, after --mqtt-root",
+    )
+    parser.add_argument(
         "--mqtt-mirror-host",
         help="mirror all messages sent to and received from --mqtt-host to this broker",
     )
@@ -161,6 +173,12 @@ def build(args=None) -> ConfigParser:
         config.set(section="broker", option="username", value=args.mqtt_username)
     if args.mqtt_password is not None:
         config.set(section="broker", option="password", value=args.mqtt_password)
+    if args.mqtt_root_pub is not None:
+        config.set(section="broker", option="root_pub", value=args.mqtt_root_pub)
+    if args.mqtt_root_sub is not None:
+        config.set(section="broker", option="root_sub", value=args.mqtt_root_sub)
+    if args.mqtt_prefix is not None:
+        config.set(section="broker", option="prefix", value=args.mqtt_prefix)
 
     if not config.has_section("mirror-broker"):
         config.add_section("mirror-broker")

--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -120,6 +120,36 @@ def build(args=None) -> ConfigParser:
         help="logging level: CRITICAL, ERROR, WARNING, INFO or DEBUG",
     )
     parser.add_argument(
+        "--log-sending-max-bytes",
+        type=int,
+        help="rotate sending logfiles after max-bytes",
+    )
+    parser.add_argument(
+        "--log-sending-max-files",
+        type=int,
+        help="keep the last max-files sending logfiles",
+    )
+    parser.add_argument(
+        "--log-reception-max-bytes",
+        type=int,
+        help="rotate reception logfiles after max-bytes",
+    )
+    parser.add_argument(
+        "--log-reception-max-files",
+        type=int,
+        help="keep the last max-files reception logfiles",
+    )
+    parser.add_argument(
+        "--log-monitoring-max-bytes",
+        type=int,
+        help="rotate monitoring logfiles after max-bytes",
+    )
+    parser.add_argument(
+        "--log-monitoring-max-files",
+        type=int,
+        help="keep the last max-files monitoring logfiles",
+    )
+    parser.add_argument(
         "--config-path",
         "-c",
         default=os.path.dirname(os.path.realpath(__file__)),
@@ -221,10 +251,63 @@ def build(args=None) -> ConfigParser:
     if config.get("mirror-broker", "host", fallback=None) is None:
         config.remove_section("mirror-broker")
 
+    if not config.has_section("log.sending"):
+        config.add_section("log.sending")
+    if args.log_sending_max_bytes is not None:
+        config.set(
+            section="log.sending", option="max_bytes", value=args.log_sending_max_bytes
+        )
+    if args.log_sending_max_files is not None:
+        config.set(
+            section="log.sending", option="max_files", value=args.log_sending_max_files
+        )
+
+    if not config.has_section("log.reception"):
+        config.add_section("log.reception")
+    if args.log_reception_max_bytes is not None:
+        config.set(
+            section="log.reception",
+            option="max_bytes",
+            value=args.log_reception_max_bytes,
+        )
+    if args.log_reception_max_files is not None:
+        config.set(
+            section="log.reception",
+            option="max_files",
+            value=args.log_reception_max_files,
+        )
+
+    if not config.has_section("log.monitoring"):
+        config.add_section("log.monitoring")
+    if args.log_monitoring_max_bytes is not None:
+        config.set(
+            section="log.monitoring",
+            option="max_bytes",
+            value=args.log_monitoring_max_bytes,
+        )
+    if args.log_monitoring_max_files is not None:
+        config.set(
+            section="log.monitoring",
+            option="max_files",
+            value=args.log_monitoring_max_files,
+        )
+
     # Configure the rest of the loggers
     logger.log_setup2(
         directory=config.get(section="log", option="directory"),
         log_level=config.get(section="log", option="default_level"),
+        sending={
+            "max_bytes": config.getint(section="log.sending", option="max_bytes"),
+            "max_files": config.getint(section="log.sending", option="max_files"),
+        },
+        reception={
+            "max_bytes": config.getint(section="log.reception", option="max_bytes"),
+            "max_files": config.getint(section="log.reception", option="max_files"),
+        },
+        monitoring={
+            "max_bytes": config.getint(section="log.monitoring", option="max_bytes"),
+            "max_files": config.getint(section="log.monitoring", option="max_files"),
+        },
     )
 
     # list all used contents

--- a/python/its-client/its_client/its_client.cfg
+++ b/python/its-client/its_client/its_client.cfg
@@ -16,6 +16,9 @@ tls = false
 username = its_user
 password = password
 client_id = its_client
+root_pub = 5GCroCo/inQueue
+root_sub = 5GCroCo/outQueue
+prefix = v2x
 
 # Uncomment this section to mirror all messages sent to, or received
 # from [broker], above, to this [mirror-broker]. Ensure they are not

--- a/python/its-client/its_client/its_client.cfg
+++ b/python/its-client/its_client/its_client.cfg
@@ -43,3 +43,15 @@ longitude = 1.209381
 directory = /data
 # logging level without quote: CRITICAL, ERROR, WARNING, INFO or DEBUG
 default_level = INFO
+
+[log.sending]
+max_bytes = 2000000
+max_files = 10
+
+[log.reception]
+max_bytes = 200000000
+max_files = 10
+
+[log.monitoring]
+max_bytes = 2000000
+max_files = 10

--- a/python/its-client/its_client/logger/logger.py
+++ b/python/its-client/its_client/logger/logger.py
@@ -39,7 +39,22 @@ def filter_default(record):
     )
 
 
-def log_setup(directory: str = "/data", log_level=logging.WARNING):
+def log_setup(log_level=logging.WARNING):
+    # default log
+    logger = logging.getLogger()
+    logger_handler = logging.StreamHandler(stream=sys.stdout)
+    # this is just to make the output look nice
+    logger_formatter = logging.Formatter(fmt="%(asctime)s %(levelname)s: %(message)s")
+    logger_handler.setFormatter(logger_formatter)
+    logger_handler.addFilter(filter_default)
+    logger.addHandler(logger_handler)
+    logger.setLevel(log_level)
+
+
+def log_setup2(
+    directory: str = "/data",
+    log_level=logging.WARNING,
+):
     path = Path(directory + "/its_client")
     path.mkdir(parents=True, exist_ok=True)
     # monitoring
@@ -73,13 +88,3 @@ def log_setup(directory: str = "/data", log_level=logging.WARNING):
     sending_handler.addFilter(filter_sending)
     sending_logger.addHandler(sending_handler)
     sending_logger.setLevel(log_level)
-
-    # default log
-    logger = logging.getLogger()
-    logger_handler = logging.StreamHandler(stream=sys.stdout)
-    # this is just to make the output look nice
-    logger_formatter = logging.Formatter(fmt="%(asctime)s %(levelname)s: %(message)s")
-    logger_handler.setFormatter(logger_formatter)
-    logger_handler.addFilter(filter_default)
-    logger.addHandler(logger_handler)
-    logger.setLevel(log_level)

--- a/python/its-client/its_client/logger/logger.py
+++ b/python/its-client/its_client/logger/logger.py
@@ -54,6 +54,9 @@ def log_setup(log_level=logging.WARNING):
 def log_setup2(
     directory: str = "/data",
     log_level=logging.WARNING,
+    sending: dict = {},
+    reception: dict = {},
+    monitoring: dict = {},
 ):
     path = Path(directory + "/its_client")
     path.mkdir(parents=True, exist_ok=True)
@@ -61,8 +64,8 @@ def log_setup2(
     monitoring_logger = logging.getLogger("monitoring")
     monitoring_handler = logging.handlers.RotatingFileHandler(
         filename=path / "monitoring.csv",
-        maxBytes=2000000,
-        backupCount=10,
+        maxBytes=monitoring["max_bytes"],
+        backupCount=monitoring["max_files"],
     )
     monitoring_handler.addFilter(filter_monitoring)
     monitoring_logger.addHandler(monitoring_handler)
@@ -72,7 +75,9 @@ def log_setup2(
     # reception
     reception_logger = logging.getLogger("reception")
     reception_handler = logging.handlers.RotatingFileHandler(
-        filename=path / "reception.txt", maxBytes=200000000, backupCount=10
+        filename=path / "reception.txt",
+        maxBytes=reception["max_bytes"],
+        backupCount=reception["max_files"],
     )
     reception_handler.addFilter(filter_reception)
     reception_logger.addHandler(reception_handler)
@@ -82,8 +87,8 @@ def log_setup2(
     sending_logger = logging.getLogger("sending")
     sending_handler = logging.handlers.RotatingFileHandler(
         filename=path / "sending.txt",
-        maxBytes=2000000,
-        backupCount=10,
+        maxBytes=sending["max_bytes"],
+        backupCount=sending["max_files"],
     )
     sending_handler.addFilter(filter_sending)
     sending_logger.addHandler(sending_handler)

--- a/python/its-client/its_client/main.py
+++ b/python/its-client/its_client/main.py
@@ -80,6 +80,9 @@ def main():
         "username": config.get(section="broker", option="username"),
         "password": config.get(section="broker", option="password"),
         "client_id": config.get(section="broker", option="client_id"),
+        "root_pub": config.get(section="broker", option="root_pub"),
+        "root_sub": config.get(section="broker", option="root_sub"),
+        "prefix": config.get(section="broker", option="prefix"),
     }
     if config.has_section("mirror-broker"):
         if config.getboolean("mirror-broker", "tls", fallback=False):

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -45,6 +45,7 @@ class MQTTClient(object):
         self.mirror_client = None
         self.new_connection = False
         self.recv_queues = {
+            "INFO": MQTTClient.SUB_ROOT + "/info/broker",
             "CAM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cam",
             "CPM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cpm",
             "DENM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/denm",
@@ -64,8 +65,7 @@ class MQTTClient(object):
         if rc == 0:
             logging.info("connected to mqtt broker")
             # gather the gateway name
-            topic = "5GCroCo/outQueue/info/broker"
-            self.subscribe(topic)
+            self.subscribe(topic=self.recv_queues["INFO"])
             # save the new connection status to trigger the subscriptions
             self.new_connection = True
 
@@ -110,7 +110,7 @@ class MQTTClient(object):
             logging.debug(f"mid: {message.mid}, empty payload, skipping message")
             return
 
-        if message.topic.endswith("5GCroCo/outQueue/info/broker"):
+        if self.recv_queues["INFO"] in message.topic:
             logging.debug(
                 self._format_log(f"Instance id: {message_dict['instance_id']}")
             )

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -298,5 +298,14 @@ class MQTTClient(object):
         # We're only interested about the connection to the main broker
         return self.client.is_connected()
 
+    def get_recv_queue(self, name):
+        if name == "CAM":
+            return self.CAM_RECEPTION_QUEUE
+        if name == "CPM":
+            return self.CPM_RECEPTION_QUEUE
+        if name == "DENM":
+            return self.DENM_RECEPTION_QUEUE
+        return None
+
     def _format_log(self, message=""):
         return f"{type(self).__name__}[{self.broker['client_id']}]::{getouterframes(currentframe())[1][3]} {message}"

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -26,6 +26,7 @@ class MQTTClient(object):
     MQTT client.
     """
 
+    PUB_ROOT = "5GCroCo/inQueue"
     SUB_ROOT = "5GCroCo/outQueue"
     PREFIX = "v2x"
 
@@ -49,6 +50,9 @@ class MQTTClient(object):
             "CAM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cam",
             "CPM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cpm",
             "DENM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/denm",
+        }
+        self.send_queues = {
+            "CAM": MQTTClient.PUB_ROOT + "/" + MQTTClient.PREFIX + "/cam",
         }
 
     def on_disconnect(self, client, userdata, rc):
@@ -305,6 +309,10 @@ class MQTTClient(object):
     def get_recv_queue(self, name):
         # Let the caller handle KeyError is they asked for a non-existing queue
         return self.recv_queues[name]
+
+    def get_send_queue(self, name):
+        # Let the caller handle KeyError is they asked for a non-existing queue
+        return self.send_queues[name]
 
     def _format_log(self, message=""):
         return f"{type(self).__name__}[{self.broker['client_id']}]::{getouterframes(currentframe())[1][3]} {message}"

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -26,10 +26,6 @@ class MQTTClient(object):
     MQTT client.
     """
 
-    PUB_ROOT = "5GCroCo/inQueue"
-    SUB_ROOT = "5GCroCo/outQueue"
-    PREFIX = "v2x"
-
     def __init__(
         self,
         broker: dict,
@@ -46,13 +42,13 @@ class MQTTClient(object):
         self.mirror_client = None
         self.new_connection = False
         self.recv_queues = {
-            "INFO": MQTTClient.SUB_ROOT + "/info/broker",
-            "CAM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cam",
-            "CPM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/cpm",
-            "DENM": MQTTClient.SUB_ROOT + "/" + MQTTClient.PREFIX + "/denm",
+            "INFO": broker["root_sub"] + "/info/broker",
+            "CAM": broker["root_sub"] + "/" + broker["prefix"] + "/cam",
+            "CPM": broker["root_sub"] + "/" + broker["prefix"] + "/cpm",
+            "DENM": broker["root_sub"] + "/" + broker["prefix"] + "/denm",
         }
         self.send_queues = {
-            "CAM": MQTTClient.PUB_ROOT + "/" + MQTTClient.PREFIX + "/cam",
+            "CAM": broker["root_pub"] + "/" + broker["prefix"] + "/cam",
         }
 
     def on_disconnect(self, client, userdata, rc):

--- a/python/its-client/its_client/mqtt/mqtt_worker.py
+++ b/python/its-client/its_client/mqtt/mqtt_worker.py
@@ -20,8 +20,6 @@ from its_client.position import GeoPosition
 
 
 class MqttWorker:
-    QUEUE = "5GCroCo/inQueue/v2x/cam"
-
     def __init__(self, mqtt_client, client_name, geo_position: GeoPosition):
         self.mqtt_client = mqtt_client
         self.client_name = client_name
@@ -67,7 +65,9 @@ class MqttWorker:
             )
             if heading is not None and alt is not None:
                 # topic
-                root_cam_topic = f"{self.QUEUE}/{self.client_name}"
+                root_cam_topic = (
+                    f"{self.mqtt_client.get_send_queue('CAM')}/{self.client_name}"
+                )
                 cam_topic = f"{root_cam_topic}{quadtree.lat_lng_to_quad_key(lat, lon, 22, True)}"
                 # time
                 now = datetime.now()

--- a/python/its-client/its_client/roi.py
+++ b/python/its-client/its_client/roi.py
@@ -73,12 +73,12 @@ class RegionOfInterest:
         )
         if new_position != self.cam_position:
             self.cam_position = self._update_subscription(
-                new_position, self.cam_position, client.CAM_RECEPTION_QUEUE, client
+                new_position, self.cam_position, client.get_recv_queue("CAM"), client
             )
             self._update_neighborhood_subscription(
                 set(self.cam_subscription),
                 set(quadtree.get_neighborhood(self.cam_position)),
-                client.CAM_RECEPTION_QUEUE,
+                client.get_recv_queue("CAM"),
                 client,
             )
 
@@ -91,12 +91,12 @@ class RegionOfInterest:
         )
         if new_position != self.cpm_position:
             self.cpm_position = self._update_subscription(
-                new_position, self.cpm_position, client.CPM_RECEPTION_QUEUE, client
+                new_position, self.cpm_position, client.get_recv_queue("CPM"), client
             )
             self._update_neighborhood_subscription(
                 set(self.cpm_subscription),
                 set(quadtree.get_neighborhood(self.cpm_position)),
-                client.CPM_RECEPTION_QUEUE,
+                client.get_recv_queue("CPM"),
                 client,
             )
 
@@ -109,12 +109,12 @@ class RegionOfInterest:
         )
         if new_position != self.denm_position:
             self.denm_position = self._update_subscription(
-                new_position, self.denm_position, client.DENM_RECEPTION_QUEUE, client
+                new_position, self.denm_position, client.get_recv_queue("DENM"), client
             )
             self._update_neighborhood_subscription(
                 set(self.denm_subscription),
                 set(quadtree.get_neighborhood(self.denm_position)),
-                client.DENM_RECEPTION_QUEUE,
+                client.get_recv_queue("DENM"),
                 client,
             )
 

--- a/python/its-client/its_client/test/its_client.cfg
+++ b/python/its-client/its_client/test/its_client.cfg
@@ -32,3 +32,14 @@ directory=.
 # logging level without quote: CRITICAL, ERROR, WARNING, INFO or DEBUG
 default_level=DEBUG
 
+[log.sending]
+max_bytes = 20000
+max_files = 3
+
+[log.reception]
+max_bytes = 40000
+max_files = 4
+
+[log.monitoring]
+max_bytes = 10000
+max_files = 2


### PR DESCRIPTION
**New features:**
* `its-client`: make the MQTT topics configurable
* `its-client`: make the logfiles rotation configurable

---
**How to test:**

1. build and install `python/its-clients` with standard setuptools procedure;
2. Start a local broker and listen on it:
    ```
    $ mosquitto -c /dev/null -p 11883 -d
    $ mosquitto_sub -p 11883 -t '5GCroCo/#'
    ```
3. Prepare a configuration file (or used the default one) with log settings and
    and MQTT topic settings, then start `its-client` with the configuration file:
    ```
    $ its-client -c /path/to/its_client/
    ```
4. Check the log file rotation
5. Check the MQTT topics

Note: do not forget to kill the MQTT broker that is in the background...

---
**Expected results:**

1. The `its-client` package is installed
2. The MQTT broker starts, the MQTT listener, well, listens...
3. `its-client` starts
4. The log files are rotated according to the setting in the configuration file
5. The MQTT topics match the configured ones