### PR TITLE
schemas/status: extend with new fields

### DIFF
--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -18,3 +18,8 @@ topic = status/system  # The topic on which to post the status; default: system/
 
 [timesources]
 validity = 10.0  # Number of seconds to keep last timesources info if not able to retrieve current state (default: 10.0s)
+
+[gnss]
+host = 127.0.0.1  # the hostname or IP of the gpsd
+port = 2947  # the port gpsd listens on
+persistence = 5.0  # duration in seconds during which to continue reporting values after disconnection from gpsd (default: 5.0s)

--- a/python/its-status/its_status/collector.gnss.py
+++ b/python/its-status/its_status/collector.gnss.py
@@ -1,0 +1,207 @@
+# Software Name: its-status
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import json
+import socket
+import threading
+import time
+
+
+class Status:
+    def __init__(self, cfg):
+        self.cfg = cfg["gnss"]
+        self.data = None
+        self.version = None
+        self.model = None
+        self.rate = None
+        self.last_tpv = {
+            "tpv": None,
+            "timestamp": 0,
+        }
+        self.last_sky = {
+            "sky": None,
+            "timestamp": 0,
+        }
+
+        self.thread = threading.Thread(
+            target=self.__loop,
+            name="gnss",
+            daemon=True,
+        )
+        self.sock = None
+        self.__stop = False
+        self.cnt = 0
+        self.thread.start()
+
+    def __connect(self):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.settimeout(2.0)
+        self.sock.connect((self.cfg["host"], int(self.cfg["port"])))
+        self.sock_fd = self.sock.makefile("rwb")
+        # From here on, we're only manipulating the connection via sock_fd
+        self.sock.close()
+        self.sock_fd.write("?DEVICES;\n".encode())
+        self.sock_fd.write('?WATCH={"enable":true,"json":true};\n'.encode())
+        self.sock_fd.flush()
+
+    def __loop(self):
+        while True:
+            if self.__stop:
+                break
+
+            if self.sock is None:
+                try:
+                    self.__connect()
+                except (socket.timeout, TimeoutError, ConnectionRefusedError):
+                    self.sock = None
+                    time.sleep(1)
+                    continue
+
+            # Every so often, request the status of devices: gpsd refines its
+            # identification of devices as it receives more messages from the
+            # devices, so the identification can vary with time (especially
+            # at the beginning).
+            self.cnt += 1
+            if self.cnt % 50 == 0:
+                self.sock_fd.write("?DEVICES;\n".encode())
+                self.sock_fd.flush()
+
+            try:
+                msg_json = self.sock_fd.readline()
+                # When the socket got severed, we don't always notice (no idea
+                # why we don't always get TimeoutError or ConnectionResetError)
+                # but we get a short-read, which gives an empty message. When
+                # the socket is not in error, we never get a short read, so an
+                # empty message is a very good indication that the socket has
+                # some issue...
+                if not msg_json:
+                    raise ConnectionResetError("short read")
+            except (socket.timeout, TimeoutError, ConnectionResetError):
+                self.sock_fd.close()
+                self.sock = None
+                continue
+
+            try:
+                msg = json.loads(msg_json)
+            except json.decoder.JSONDecodeError:
+                # The GPSD protocol specifies a maximum length of messages, and
+                # that, as a consequence, the JSON sentence may get truncated.
+                continue
+
+            if msg["class"] == "VERSION":
+                self.version = msg["release"]
+
+            elif msg["class"] == "DEVICES" and msg["devices"]:
+                # We only expect exactly one device, no less, no more.
+                dev = msg["devices"][0]
+                model = ""
+                for field in ["driver", "subtype", "subtype1"]:
+                    try:
+                        model += dev[field] + " "
+                    except KeyError:
+                        pass
+                if model.rstrip():
+                    self.model = model.rstrip()
+
+                try:
+                    self.rate = dev["cycle"]
+                except KeyError:
+                    pass
+
+            elif msg["class"] == "TPV":
+                self.last_tpv = {
+                    "tpv": msg,
+                    "timestamp": time.time(),
+                }
+
+            elif msg["class"] == "SKY":
+                # Memorise the last SKY event only if it has both nSat
+                # and uSat, or if it has the list of satellites
+                if "satellites" in msg or ("nSat" in msg and "uSat" in msg):
+                    self.last_sky = {
+                        "sky": msg,
+                        "timestamp": time.time(),
+                    }
+
+        if self.sock is not None:
+            self.sock_fd.close()
+            self.sock = None
+
+    def stop(self):
+        self.__stop = True
+        self.thread.join()
+
+    def capture(self):
+        now = time.time()
+
+        data = {
+            "version": f"gpsd {self.version}" if self.version else "unknown",
+            "model": self.model or "unknown",
+            "mode": 0,
+        }
+        last_tpv = self.last_tpv
+        last_sky = self.last_sky
+
+        if self.rate:
+            data["rate"] = self.rate
+
+        if last_tpv["tpv"] and (
+            now - last_tpv["timestamp"] <= float(self.cfg["persistence"])
+        ):
+            data["mode"] = last_tpv["tpv"]["mode"]
+            try:
+                # TPV.status is never 0 or 1, by protocol definition;
+                # values 5 and above are not interesting for us
+                if last_tpv["tpv"]["status"] in range(2, 5):
+                    data["status"] = last_tpv["tpv"]["status"]
+            except KeyError:
+                # TPV.status may also be entirely missing
+                pass
+
+        if last_sky["sky"] and (
+            now - last_sky["timestamp"] <= float(self.cfg["persistence"])
+        ):
+            # We only memorised a SKY if it either:
+            #  - has both nSat and uSat, or
+            #  - has satellites data
+            try:
+                data["nSat"] = last_sky["sky"]["nSat"]
+                data["uSat"] = last_sky["sky"]["uSat"]
+            except KeyError:
+                data["nSat"] = len(last_sky["sky"]["satellites"])
+                data["uSat"] = len(
+                    [s for s in last_sky["sky"]["satellites"] if s["used"]]
+                )
+
+        self.data = data
+
+    def collect(self):
+        return self.data
+
+
+# To test this collector standalone:
+#   python3 /path/to/collector.gnss.py HOST PORT
+# Hit Ctrl-C to stop.
+if __name__ == "__main__":
+    import sys
+
+    try:
+        gnss = Status(
+            {
+                "gnss": {
+                    "host": sys.argv[1],
+                    "port": sys.argv[2],
+                    "persistence": 5.0,
+                }
+            }
+        )
+        while True:
+            gnss.capture()
+            data = gnss.collect()
+            if data:
+                print(json.dumps(data), flush=True)
+            time.sleep(1)
+    except KeyboardInterrupt:
+        gnss.stop()

--- a/python/its-status/its_status/collector.static.py
+++ b/python/its-status/its_status/collector.static.py
@@ -8,7 +8,7 @@ class Status:
     def __init__(self, cfg):
         self.data = {
             "version": "1.0.0",
-            "type": "obu",
+            "type": "status",
             "id": cfg["generic"]["id"],
         }
 

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -50,7 +50,10 @@ class Status:
             except Exception:
                 pass
 
-        self.static_data = {"hardware": hw or "Unknown"}
+        self.static_data = {
+            "type": "obu",
+            "hardware": hw or "Unknown",
+        }
         with open("/etc/os-release", "r") as f:
             self.static_data["os_release"] = dict()
             for l in f.readlines():

--- a/python/its-status/its_status/collector.time_sources.py
+++ b/python/its-status/its_status/collector.time_sources.py
@@ -53,6 +53,7 @@ class Status:
             fields = l.split(",")
             src = {
                 "state": SRC_STATE[fields[1]],
+                "offset": float(fields[-2]),
                 "error": float(fields[-1]),
             }
             name = fields[2]

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -24,9 +24,9 @@
       "type": "string"
     },
     "type": {
-      "description": "type of the server",
+      "description": "type of the message",
       "type": "string",
-      "enum": [ "obu", "other" ]
+      "const": "status"
     },
     "timestamp": {
       "description": "date the information was generated, in seconds since 1970-01-01 00:00:00 +00:00, with arbitrary sub-second precision",
@@ -38,6 +38,7 @@
       "type": "object",
       "additionalProperties": true,
       "required": [
+        "type",
         "hardware",
         "os_release",
         "memory",
@@ -45,6 +46,11 @@
         "cpu_load"
       ],
       "properties": {
+        "type": {
+          "description": "type of device",
+          "type": "string",
+          "enum": [ "obu", "other" ]
+        },
         "hardware": {
           "description": "type of hardware",
           "type": "string",

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -171,6 +171,7 @@
         "type",
         "stratum",
         "state",
+        "offset",
         "error"
       ],
       "properties": {
@@ -188,6 +189,10 @@
           "description": "state of the source",
           "type": "string",
           "enum": [ "best", "combined", "not_combined", "maybe_error", "unstable", "unusable" ]
+        },
+        "offset": {
+          "description": "measured offset in seconds, with arbitrary sub-second precision",
+          "type": "number"
         },
         "error": {
           "description": "estimated error in seconds, with arbitrary sub-second precision",

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -10,7 +10,8 @@
     "timestamp",
     "system",
     "time_sources",
-    "cellular"
+    "cellular",
+    "gnss"
   ],
   "properties": {
     "version": {
@@ -160,6 +161,65 @@
               }
             }
           }
+        }
+      }
+    },
+    "gnss": {
+      "description": "status of the GNSS subsystem",
+      "type": "object",
+      "$comment": "modelled after the gpsd protocol; references like {gpsd:XXX:YYY[:ZZZ...]} refer to gpsd object XXX, field YYY (sub-field ZZZ, etc...) as defined in the gpsd JSON protocol documentation: https://gpsd.io/gpsd_json.html",
+      "required": [
+        "software",
+        "model",
+        "mode"
+      ],
+      "properties": {
+        "software": {
+          "description": "name and version of the gnss daemon (free form)",
+          "type": "string",
+          "$comment": "typically: literal 'gpsd' followed by {gpsd:VERSION:release}"
+        },
+        "model": {
+          "description": "Brand and model of the GNSS device (free form)",
+          "type": "string",
+          "$comment": "concatenation of the three fields: {gpsd:DEVICE:driver}, {gpsd:DEVICE:subtype}, and {gpsd:DEVICE:subtype1}"
+        },
+        "rate": {
+          "description": "mesaurement rate {gpsd:DEVICE:cycle}",
+          "type": "number",
+          "$comment": "seconds with arbitrary sub-second precision",
+          "exclusiveMinimum": 0.0
+        },
+        "mode": {
+          "description": "FIX mode {gpsd:TPV:mode}",
+          "type": "integer",
+          "enum": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "$comment": "0: unkown; 1: none; 2: 2D-FIX; 3: 3D-FIX"
+        },
+        "status": {
+          "description": "FIX status {gpsd:TPV:status}",
+          "type": "integer",
+          "enum": [
+            2,
+            3,
+            4
+          ],
+          "$comment": "2: DGPS; 3: RTK-fixed; 4: RTK-floating"
+        },
+        "nSat": {
+          "description": "Number of satellites seen {gpsd:SKY:nSat}",
+          "type": "integer",
+          "minimum": 1
+        },
+        "uSat": {
+          "description": "Number of satellites used in navigation solution {gpsd:SKY:uSat}",
+          "type": "integer",
+          "minimum": 1
         }
       }
     }

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -17,8 +17,7 @@
     "version": {
       "description": "version of the format of this JSON message",
       "type": "string",
-      "const": "1.0.99",
-      "$comment": "Development version"
+      "const": "1.1.0"
     },
     "id": {
       "description": "unique id all over the world for this device",

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://Orange-OpenSource.github.io/its-client/schema/status",
+  "description": "Status JSON schema",
+  "type": "object",
+  "required": [
+    "version",
+    "id",
+    "type",
+    "timestamp",
+    "system",
+    "time_sources",
+    "cellular"
+  ],
+  "properties": {
+    "version": {
+      "description": "version of the format of this JSON message",
+      "type": "string",
+      "const": "1.0.99",
+      "$comment": "Development version"
+    },
+    "id": {
+      "description": "unique id all over the world for this device",
+      "type": "string"
+    },
+    "type": {
+      "description": "type of the server",
+      "type": "string",
+      "enum": [ "obu", "other" ]
+    },
+    "timestamp": {
+      "description": "date the information was generated, in seconds since 1970-01-01 00:00:00 +00:00, with arbitrary sub-second precision",
+      "type": "number",
+      "minimum": 0.0
+    },
+    "system": {
+      "description": "system low-level info",
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "hardware",
+        "os_release",
+        "memory",
+        "storage",
+        "cpu_load"
+      ],
+      "properties": {
+        "hardware": {
+          "description": "type of hardware",
+          "type": "string",
+          "examples": [ "vtc6221", "vtc7251", "rpi2" ]
+        },
+        "os_release": {
+          "description": "a key-value representation of the os-release of the running OS",
+          "type": "object",
+          "$comment": "all keys of os-release are optional; see https://www.freedesktop.org/software/systemd/man/os-release.html",
+          "additionalProperties": true,
+          "properties": {
+            "NAME": { "type": "string" },
+            "VERSION": { "type": "string" },
+            "ID": { "type": "string" },
+            "VERSION_ID": { "type": "string" },
+            "PRETTY_NAME": { "type": "string" }
+          }
+        },
+        "memory": {
+          "description": "RAM usage, in bytes, as a 2-tuple: [total_ram, available_ram]",
+          "type": "array",
+          "items": { "type": "integer" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "storage": {
+          "description": "writable storage for data, as a 2-tuple: [total_space, free_space]",
+          "type": "array",
+          "items": { "type": "integer" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "cpu_load": {
+          "description": "CPU load, as a 3-tuple: [1min_load, 5min_load, 15min_load]",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0.0
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      }
+    },
+    "time_sources": {
+      "description": "status of time-keeping services",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/$defs/ntpTimeSource" },
+          { "$ref": "#/$defs/ppsTimeSource" },
+          { "$ref": "#/$defs/nmeaTimeSource" }
+        ]
+      }
+    },
+    "cellular": {
+      "description": "cellular connections",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "cellular connection status",
+        "required": [
+          "hardware"
+        ],
+        "properties": {
+          "hardware": {
+            "description": "harddware informatsion",
+            "type": "object",
+            "properties": {
+              "vendor": { "type": "string" },
+              "model": { "type": "string" },
+              "revision": { "type": "string" }
+            }
+          },
+          "operator": {
+            "description": "cellular operator",
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "name": { "type": "string" }
+            }
+          },
+          "connection": {
+            "description": "connection details",
+            "type": "object",
+            "properties": {
+              "technology": {
+                "type": "string",
+                "examples": [
+                  "gsm", "cdma1x", "evdo", "umts", "lte", "5G"
+                ]
+              },
+              "signal": {
+                "description": "signal quality metrics",
+                "type": "object",
+                "properties": {
+                  "ecio": { "type": "number" },
+                  "io": { "type": "number" },
+                  "rscp": { "type": "number" },
+                  "rsrp": { "type": "number" },
+                  "rsrq": { "type": "number" },
+                  "rssi": { "type": "number" },
+                  "sinr": { "type": "number" },
+                  "snr": { "type": "number" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "genericTimeSource": {
+      "type": "object",
+      "required": [
+        "type",
+        "stratum",
+        "state",
+        "error"
+      ],
+      "properties": {
+        "type": {
+          "description": "type of the time source",
+          "type": "string",
+          "enum": [ "ntp", "pps", "nmea" ]
+        },
+        "stratum": {
+          "description": "stratum of the clock source",
+          "type": "integer",
+          "minimum": 0
+        },
+        "state": {
+          "description": "state of the source",
+          "type": "string",
+          "enum": [ "best", "combined", "not_combined", "maybe_error", "unstable", "unusable" ]
+        },
+        "error": {
+          "description": "estimated error in seconds, with arbitrary sub-second precision",
+          "type": "number"
+        }
+      }
+    },
+    "ntpTimeSource": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/genericTimeSource" },
+        {
+          "type": "object",
+          "required": [ "host" ],
+          "properties": {
+            "type": { "const": "ntp" },
+            "stratum": { "minimum": 1 },
+            "host": {
+              "description": "IP or hostname of the NTP server",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ppsTimeSource": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/genericTimeSource" },
+        {
+          "type": "object",
+          "required": [ "label" ],
+          "properties": {
+            "type": { "const": "pps" },
+            "stratum": { "const": 0 },
+            "label": {
+              "description": "PPS label/name",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "nmeaTimeSource": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "#/$defs/genericTimeSource" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "nmea" },
+            "stratum": { "const": 0 }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schema/status_schema_1-1-0.json
+++ b/schema/status_schema_1-1-0.json
@@ -112,7 +112,7 @@
         ],
         "properties": {
           "hardware": {
-            "description": "harddware informatsion",
+            "description": "hardware information",
             "type": "object",
             "properties": {
               "vendor": { "type": "string" },


### PR DESCRIPTION
**New features:**

* schemas: extend status schema with new data
  * add GNSS status
  * extend time sources
  * adjust top-level `type`, add hardware type
  * tag version 1.1.0
* `its-status`: extend for status schema 1.1.0 (above)

---
**How to test:**

1. build and install `python/its-status` with standard setuptools procedure;
2. create a configuration file, using `its-status.cfg` as startup point, adapt with your MQTT broker and credentials, enable the `stdout` emitter;
3. subscribe an MQTT client to your broker, on the status topic, e.g. with mosquitto CLI clients:
    ```sh
    $ mosquitto_sub -h BROKER -p PORT -u USERNAME -P PASSWORD -i ID -t 'status/#'
    ```
4. run `its-status` using your custom configuration file:
    ```sh
    $ its-status -c /path/to/its-status.custom.cfg
    ```

---
**Expected results:**

1. The `its-status` package is installed;
2. You have a custom configuration file with your MQTT settings;
3. The MQTT client is connected to your MQTT broker;
4. The `its-status` program runs, and the messages are visible both on the `its-status`' own `stdout`, as well as on the MQTT client.