### PR TITLE
python/status: fix status messages to comply with schema 1.1.0

### DIFF
--- a/python/its-status/its_status/collector.gnss.py
+++ b/python/its-status/its_status/collector.gnss.py
@@ -137,7 +137,7 @@ class Status:
         now = time.time()
 
         data = {
-            "version": f"gpsd {self.version}" if self.version else "unknown",
+            "software": f"gpsd {self.version}" if self.version else "unknown",
             "model": self.model or "unknown",
             "mode": 0,
         }

--- a/python/its-status/its_status/collector.static.py
+++ b/python/its-status/its_status/collector.static.py
@@ -7,7 +7,7 @@
 class Status:
     def __init__(self, cfg):
         self.data = {
-            "version": "1.0.0",
+            "version": "1.1.0",
             "type": "status",
             "id": cfg["generic"]["id"],
         }


### PR DESCRIPTION
**Bug fix:**

* GNSS reports software identification as `version` instead of `software` as defined in schema 1.1.0.
* status messages still advertise being version 1.0.0, even though they are version 1.1.0

---
**How to test:**

See #43.

---
**Expected results:**

See #43.