### PR TITLE
python/its-info: new client to send info messages

### DIFF
--- a/.github/workflows/python_its-info.yml
+++ b/.github/workflows/python_its-info.yml
@@ -1,0 +1,31 @@
+name: Python its-info
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          cd python/its-info
+          python -m pip install --upgrade pip
+          pip install black wheel
+      - name: Run black
+        run: |
+          cd python/its-info
+          black --diff --check .
+      - name: Run package creation
+        run: |
+          cd python/its-info
+          python setup.py bdist_wheel
+      - name: Archive package
+        uses: actions/upload-artifact@v2
+        with:
+          name: its_info
+          path: python/its-info/dist

--- a/python/its-info/its-info.cfg
+++ b/python/its-info/its-info.cfg
@@ -1,0 +1,44 @@
+[general]
+# Instance ID of the broker (not to be confused with the MQTT client ID); mandatory
+instance_id = ID
+
+# Type of the instance, default: local
+# instance_type = TYPE
+
+# Periodicity of info messages, in seconds; validity is twice periodicity
+# period = SECS
+
+# IP of the DNS server, optional; if unset, use IP from interface, below
+# dns_ip = IP
+
+# Hostname or IP of the NTP server, optional; if unset, use IP from interface, below
+# ntp_host = HOST
+
+# NIC to extract IPs adresses that will be NTP and DNS server; optional
+# interface = NIC
+
+# Notes:
+#  * if neither dns_ip nor interface are specified, then the domain_name_servers field will not be included in the info message
+#  * if neither ntp_host nor interface are specified, then the ntp_servers field will not be included in the info message
+
+[mqtt]
+# MQTT client ID to connect as; defaults to the instance ID, general.instance_id, above
+# client_id = ID
+
+# MQTT topic to post info message on; default: info
+# topic = TOPIC
+
+# hostname or IP address of the broker to connect to; default: 127.0.0.1
+# host = HOST
+
+# Port the MQTT broker listens on; default: 1883
+# port = PORT
+
+# Username to authenticate to the MQTT broker; default: unset, no authentication
+# username = USERNAME
+
+# Password to authenticate to the MQTT broker; default: unset, no authentication
+# password = PASSWORD
+
+# Maximum delay to wait before attempting to reconnect to the MQTT broker after the connection was lost, in seconds; default: 2
+# retry = SECS

--- a/python/its-info/its_info/main.py
+++ b/python/its-info/its_info/main.py
@@ -1,0 +1,132 @@
+# Software Name: its-info
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import argparse
+import configparser
+import json
+import linuxfd
+import netifaces
+import os
+import paho.mqtt.client
+import time
+
+
+def main():
+    try:
+        info = MQTTInfoClient()
+        info.loop_forever()
+    except Exception as e:
+        print(e)
+        os._exit(1)
+
+
+class MQTTInfoClient:
+    CFG = "/etc/its/its-info.cfg"
+
+    def __init__(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--config",
+            "-c",
+            default=MQTTInfoClient.CFG,
+            help=f"Path to the configuration file (default: {MQTTInfoClient.CFG})",
+        )
+        args = parser.parse_args()
+
+        cfg = configparser.ConfigParser()
+        with open(args.config) as f:
+            cfg.read_file(f)
+
+        self.instance_id = cfg.get("general", "instance_id")
+        self.instance_type = cfg.get("general", "instance_type", fallback="local")
+        self.period = cfg.getint("general", "period", fallback=600)
+        self.dns_ip = cfg.get("general", "dns_ip", fallback=None)
+        self.ntp_host = cfg.get("general", "ntp_host", fallback=None)
+        self.interface = cfg.get("general", "interface", fallback=None)
+
+        self.client_id = cfg.get("mqtt", "client_id", fallback=self.instance_id)
+        self.host = cfg.get("mqtt", "host", fallback="127.0.0.1")
+        self.port = cfg.getint("mqtt", "port", fallback=1883)
+        self.username = cfg.get("mqtt", "username", fallback=None)
+        self.password = cfg.get("mqtt", "password", fallback=None)
+        self.topic = cfg.get("mqtt", "topic", fallback="info")
+        self.retry = cfg.getint("mqtt", "retry", fallback=2)
+
+        self.client = paho.mqtt.client.Client(
+            client_id=self.client_id,
+        )
+        self.client.reconnect_delay_set(min_delay=1, max_delay=self.retry)
+        self.client.username_pw_set(self.username, self.password)
+        self.client.on_connect = self.on_connect
+        self.client.on_disconnect = self.on_disconnect
+        self.client.on_socket_close = self.on_socket_close
+        self.client.connect_async(host=self.host, port=self.port)
+
+        self.timer = linuxfd.timerfd(closeOnExec=True)
+
+    def loop_forever(self):
+        self.client.loop_start()
+        while True:
+            try:
+                # We don't care about the number of time the timer has
+                # fired that we missed; given the periodicity is in the
+                # order of many seconds, it is highly unlikely that we
+                # ever miss a tick...
+                self.timer.read()
+                self.info()
+            except InterruptedError:
+                # Someone sent a signal to this thread...
+                continue
+            except KeyboardInterrupt:
+                break
+
+        self.client.loop_stop()
+        self.client.disconnect()
+
+    def on_connect(self, _client, _userdata, _flags, _rc, _properties=None):
+        self.timer.settime(value=self.period, interval=self.period)
+        self.info()
+
+    def on_disconnect(self, _client, _userdata, _rc, _properties=None):
+        self.timer.settime(value=0)
+
+    def on_socket_close(self, _client, _userdata, _sock):
+        self.timer.settime(value=0)
+
+    def info(self):
+        data = {
+            "type": "broker",
+            "version": "1.2.0",
+            "instance_id": self.instance_id,
+            "instance_type": self.instance_type,
+            "running": True,
+            "timestamp": int(1000 * time.time()),
+            "validity_duration": int(self.period * 2),
+        }
+
+        # The IP adresses of the interface may change at runtime
+        # so we must grab them every time.
+        ips = list()
+        if self.interface:
+            ifa = netifaces.ifaddresses(self.interface)
+            for familly in [netifaces.AF_INET, netifaces.AF_INET6]:
+                if familly in ifa:
+                    # IPv6 addresses can look like: 01::EF%iface but we just want 01::EF
+                    ips += [i["addr"].split("%")[0] for i in ifa[familly]]
+
+        if self.dns_ip:
+            data["domain_name_servers"] = [self.dns_ip]
+        elif ips:
+            data["domain_name_servers"] = ips
+        if self.ntp_host:
+            data["ntp_servers"] = [self.ntp_host]
+        elif ips:
+            data["ntp_servers"] = ips
+
+        self.client.publish(
+            topic=self.topic,
+            payload=json.dumps(data),
+            retain=True,
+        )

--- a/python/its-info/setup.py
+++ b/python/its-info/setup.py
@@ -1,0 +1,39 @@
+# Software Name: its-info
+# SPDX-FileCopyrightText: Copyright (c) 2022 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+from setuptools import setup, find_packages
+
+setup(
+    name="its_info",
+    version="0.0.0",
+    author="Yann E. MORIN",
+    author_email="yann(dot)morin(at)orange(dot)com",
+    maintainer="Yann E. MORIN",
+    maintainer_email="yann(dot)morin(at)orange(dot)com",
+    keywords="network, its, vehicle, mqtt, etsi",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Telecommunications Industry",
+        "License :: OSI Approved :: MIT License",
+        "Topic :: Communications",
+        "Topic :: Software Development :: Embedded Systems",
+    ],
+    url="https://github.com/Orange-OpenSource/its-client",
+    packages=find_packages(exclude=["*.tests.*"]),
+    include_package_data=True,
+    description="The Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) Python packages based on the "
+    "[JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription.",
+    long_description="The Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) Python packages based on "
+    "the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification "
+    "transcription. It sends the device status information to an MQTT broker.",
+    license="MIT",
+    platforms="LINUX",
+    install_requires=[
+        "linuxfd==1.5",
+        "netifces==0.11.0",
+        "paho-mqtt==1.6.1",
+    ],
+    entry_points={"console_scripts": ["its-info = its_info.main:main"]},
+)

--- a/schema/information_schema_1-2-0.json
+++ b/schema/information_schema_1-2-0.json
@@ -34,6 +34,7 @@
       "description": "type of instance",
       "type": "string",
       "enum": [
+        "local",
         "edge",
         "central"
       ]

--- a/schema/information_schema_1-2-0.json
+++ b/schema/information_schema_1-2-0.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://Orange-OpenSource.github.io/its-client/schema/info",
+  "description": "Information JSon schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "version",
+    "instance_id",
+    "instance_type",
+    "running",
+    "timestamp",
+    "validity_duration"
+  ],
+  "properties": {
+    "type": {
+      "description": "type of server",
+      "type": "string",
+      "enum": [
+        "broker"
+      ]
+    },
+    "version": {
+      "type": "string",
+      "description": "json message format version",
+      "const": "1.1.99"
+    },
+    "instance_id": {
+      "description": "unique id all other the world for a server",
+      "type": "string"
+    },
+    "instance_type": {
+      "description": "type of instance",
+      "type": "string",
+      "enum": [
+        "edge",
+        "central"
+      ]
+    },
+    "central_instance_id": {
+      "description": "unique id all other the world for the central server if the instance is of type edge",
+      "type": "string"
+    },
+    "running": {
+      "description": "state of the server: true id running, false else.",
+      "type": "boolean",
+      "default": false
+    },
+    "timestamp": {
+      "description": "generation timestamp of the information, millisecond since epoch (1970/01/01)",
+      "type": "integer"
+    },
+    "validity_duration": {
+      "description": "validity period of the information relatively to the timestamp in seconds",
+      "type": "integer"
+    },
+    "public_ip_address": {
+      "description": "list of public IP address",
+      "type": "array",
+      "examples": [
+        "161.05.21.166",
+        "190.14.19.50",
+        "127.0.0.1"
+      ],
+      "items": {
+        "description": "public IP address",
+        "type": "string"
+      }
+    },
+    "mqtt_ip": {
+      "description": "list of MQTT IP address and port separated by a colon",
+      "type": "array",
+      "items": {
+        "description": "MQTT IP address and port (classically 1883) separated by a colon",
+        "type": "string",
+        "examples": [
+          "84.188.43.159:1883",
+          "172.116.12.182:11883"
+        ]
+      }
+    },
+    "mqtt_tls_ip": {
+      "description": "list of MQTT IP address and TLS port separated by a colon",
+      "type": "array",
+      "items": {
+        "description": "MQTT IP address and TLS port (classically 8883) separated by a colon",
+        "type": "string",
+        "examples": [
+          "84.188.43.159:8883",
+          "172.116.82.124:18883"
+        ]
+      }
+    },
+    "http_proxy": {
+      "description": "list of HTTP IP address and port separated by a colon",
+      "type": "array",
+      "items": {
+        "description": "HTTP IP address and port (classically 8080) separated by a colon",
+        "type": "string",
+        "examples": [
+          "84.188.43.159:8080",
+          "172.116.82.124:1280"
+        ]
+      }
+    },
+    "ntp_servers": {
+      "description": "list of Network Time Protocol server",
+      "type": "array",
+      "items": {
+        "description": "Network Time Protocol server",
+        "type": "string",
+        "examples": [
+          "ntp-sop.inria.fr",
+          "0.debian.pool.ntp.org",
+          "1.pool.ntp.org"
+        ]
+      }
+    },
+    "domain_name_servers": {
+      "description": "list of Domain Name Server",
+      "type": "array",
+      "items": {
+        "description": "Domain Name Server",
+        "type": "string",
+        "examples": [
+          "1.1.1.1",
+          "194.28.10.20"
+        ]
+      }
+    },
+    "gelf_loggers": {
+      "description": "list of Graylog Extended Log Format server and port separated by a colon",
+      "type": "array",
+      "items": {
+        "description": "Graylog Extended Log Format server and port (classically 2201) separated by a colon",
+        "type": "string",
+        "examples": [
+          "90.11.41.133:2201",
+          "81.169.166.64:12201"
+        ]
+      }
+    },
+    "udp_loggers": {
+      "description": "list of User Datagram Protocol server and port separated by a colon",
+      "type": "array",
+      "items": {
+        "description": "User Datagram Protocol server and port (classically 2202) separated by a colon",
+        "type": "string",
+        "examples": [
+          "90.11.41.133:2202",
+          "81.169.166.64:12202"
+        ]
+      }
+    },
+    "fbeat_loggers": {
+      "description": "list of Filebeat server and port separated by a colon",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "description": "Filebeat server and port (classically 2203) separated by a colon",
+        "type": "string",
+        "examples": [
+          "90.11.41.133:2203",
+          "81.16.11.164:12203"
+        ]
+      }
+    },
+    "service_area": {
+      "description": "handled service area of the server",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "description": "type of service area",
+          "type": "string",
+          "enum": [
+            "point",
+            "polygon",
+            "tiles"
+          ]
+        },
+        "coordinates": {
+          "description": "coordinates of the point",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "description": "coordinate of the point",
+            "type": "number"
+          }
+        },
+        "radius": {
+          "description": "radius of the point",
+          "type": "integer",
+          "default": 0
+        },
+        "vertices": {
+          "description": "vertices (corners) of the polygon",
+          "type": "array",
+          "minItems": 3,
+          "items": {
+            "coordinates": {
+              "description": "coordinates for a vertex (corner) of the polygon",
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "description": "coordinate",
+                "type": "number"
+              }
+            }
+          }
+        },
+        "quadkeys": {
+          "description": "list of quadkey of the tiles",
+          "type": "array",
+          "items": {
+            "description": "quadkey",
+            "type": "string",
+            "examples": [
+              "12020322313211",
+              "12020322313213",
+              "1203"
+            ]
+          }
+        }
+      }
+    },
+    "cells_id": {
+      "description": "list of cell id of the server",
+      "type": "array",
+      "items": {
+        "description": "cell id",
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/schema/information_schema_1-2-0.json
+++ b/schema/information_schema_1-2-0.json
@@ -24,7 +24,7 @@
     "version": {
       "type": "string",
       "description": "json message format version",
-      "const": "1.1.99"
+      "const": "1.2.0"
     },
     "instance_id": {
       "description": "unique id all other the world for a server",


### PR DESCRIPTION
**Features:**

* _its-info_: a new client to send ETSI information messages

---
**How to test:**

Preparatory steps: have a MQTT broker running.

1. Build and install the package in `python/its-info/` with the standard
   setup-tools procedure:
    ```sh
    $ cd python/its-info/
    $ pip3 wheel .
    $ pip3 install its_info-0.0.0-py3-none-any.whl
    ```
   Note where the `its-info` is installed, e.g. `${HOME}/.local/bin`
2. Update the configuration `its-info.cfg` to match your local setup,
   especially the MQTT broker settings; choose a short period, like a
   few seconds.
3. Run a MQTT client that listens on the `info` topic (or whatever you
   configured in `its-info.cfg`):
    ```sh
    $ mosquitto_sub -h BROKER -p PORT -u USERNAME -P PASSWORD -i ID -t info
    ```
4. Run the client, and wait for a few periods (as configured in `its-info.cfg`):
    ```sh
    $ ${HOME}/.local/bin/its-info --config its-info.cfg
    ```
5. Terminate `its-info` (with Ctrl-C)
6. Stop and restart the MQTT client

---
**Expected results:**

1. The wheel is built and installed.
2. The configuration file is set for your local setup.
3. The MQTT client listens for messages.
4. The `its-info` client runs (it's silent), the MQTT client display info messages
   to the cofigured period.
6. The info message is no longer updated.
7. The MQTT client displays the last info message that was retained in the broker.