### PR TITLE
python/its-client: send own messages to the outQueue of the local broker

### DIFF
--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -277,6 +277,14 @@ class MQTTClient(object):
                 f"message not sent on topic {topic} because we aren't connected"
             )
         if self.mirror_client is not None:
+            # If we mirror ourselves, then we will propagate the message
+            # on the outQueue when we receive it from the central broker,
+            # so here we will want to keep the original topic unchanged.
+            # However, if we do not mirror ourselves, then we need to
+            # send the message on the outQueue, as if it were coming
+            # from the central broker.
+            if not self.mirror_broker["mirror-self"]:
+                topic = topic.replace("/inQueue/", "/outQueue/")
             self.mirror_client.publish(topic, payload, qos, retain, properties)
 
     def loop_start(self):


### PR DESCRIPTION
**Bug fix:**

* #57

---
**How to test:**

Pre-requisites: an MQTT broker running

1. Check the messages on your MQTT broker, displaying topic (`%t`) and payload (`%p`):
    ```sh
    $ mosquitto_sub -t '#' -F '%t %p'
    ```
2. Configure its-client to connect to your MQTT broker as a mirror broker, without mirroring self; run its-client
3. Configure its-client to connect to your MQTT broker as a mirror broker, with mirroring self; run its-client

---
**Expected results:**

1. The messages are displayed as they are emitted
2. The messages are all on the outQueue
3. The messages are all on the outQueue, and the CAM is duplicated from the one on the inQueue.