### PR TITLE
python/its-status: fix API of {cellular,system} collectors

### DIFF
--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -8,7 +8,7 @@ from its_status import helpers
 
 
 class Status:
-    def __init__(self, *, _cfg):
+    def __init__(self, *, cfg):
         pass
 
     def capture(self):

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -9,7 +9,7 @@ from its_status import helpers
 
 
 class Status:
-    def __init__(self, *, _cfg):
+    def __init__(self, *, cfg):
         hw = None
 
         # This is the ugly-dirty code style unamically dictated by black


### PR DESCRIPTION
**Bug fix:**

* `its-status`: fix API of {cellular,system} collectors

Fixes: 295544cefde1841b7947e7f8aa53cdcb6847df5f and #54

---
**How to test:**

1. build and install `python/its-status` with standard setuptools procedure, e.g.:
    ```sh
    $ pip3 wheel .
    $ pip3 install its_status-0.0.0-py3-none-any.whl
    ```
   Also take not of where the script has been installed (e.g. `${HOME}/.local/bin`)
2. create a configuration file, using `its-status.cfg` as startup point, adapt with your
   MQTT broker and credentials, enable the `stdout` emitter;
3. subscribe an MQTT client to your broker, on the status topic, e.g. with mosquitto CLI clients:
    ```sh
    $ mosquitto_sub -h BROKER -p PORT -u USERNAME -P PASSWORD -i ID -t 'status/#'
    ```
4. run `its-status` using your custom configuration file:
    ```sh
    $ ${HOME}/.local/bin/its-status -c /path/to/its-status.custom.cfg
    ```

---
**Expected results:**

1. The `its-status` package is installed;
2. You have a custom configuration file with your MQTT settings;
3. The MQTT client is connected to your MQTT broker;
4. The `its-status` program runs, and the messages are visible both on the
   `its-status`' own `stdout`, as well as on the MQTT client.