### PR TITLE
python/its-status: add config option for the data directory

### DIFF
--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -27,6 +27,10 @@ client_id = its-status
 # The topic on which to post the status; default: system/status
 topic = status/system
 
+[system]
+# The directory for which to report size and free space
+data-dir = /
+
 [timesources]
 # Number of seconds to keep last timesources info if not able to retrieve current state (default: 10.0s)
 validity = 10.0

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -10,6 +10,8 @@ from its_status import helpers
 
 class Status:
     def __init__(self, *, cfg):
+        self.cfg = cfg
+
         hw = None
 
         # This is the ugly-dirty code style unamically dictated by black
@@ -65,7 +67,7 @@ class Status:
         data["cpu_load"] = psutil.getloadavg()
         mem = psutil.virtual_memory()
         data["memory"] = (mem.total, mem.available)
-        disk = psutil.disk_usage("/data")
+        disk = psutil.disk_usage(self.cfg["system"]["data-dir"])
         data["storage"] = (disk.total, disk.free)
 
         return data

--- a/python/its-status/its_status/collector.system.py
+++ b/python/its-status/its_status/collector.system.py
@@ -35,13 +35,20 @@ class Status:
         ret = helpers.run(lshw_cmd)
         if ret.returncode == 0:
             lshw = json.loads(ret.stdout)
+            if type(lshw) is list:
+                # Very old version of lshw, let's hope for the best...
+                lshw = lshw[0]
             if "product" in lshw:
                 hw = lshw["product"]
             else:
-                for child in lshw["children"]:
-                    if child["id"] == "core" and "product" in child:
-                        hw = child["product"]
-                        break
+                try:
+                    for child in lshw["children"]:
+                        if child["id"] == "core" and "product" in child:
+                            hw = child["product"]
+                            break
+                except TypeError:
+                    # lshw output does not match our expectations, ignore
+                    pass
         if hw is None:
             try:
                 with open("/proc/self/cgroup", "rb") as f:


### PR DESCRIPTION
**New feature:**

* `its-status`:
  * add config option for the data directory (#63)
  * be resilient against older lshw versions

---
**How to test:**

1. build and install `python/its-status` with standard setuptools procedure, e.g.:
    ```sh
    $ pip3 wheel .
    $ pip3 install its_status-0.0.0-py3-none-any.whl
    ```
   Also take note of where the script has been installed (e.g. `${HOME}/.local/bin`)
2. create a configuration file, using `its-status.cfg` as startup point, adapt with your
   MQTT broker and credentials, change the data directory to a writable location, and
   enable the `stdout` emitter;
3. subscribe an MQTT client to your broker, on the status topic, e.g. with mosquitto_sub
   CLI client:
    ```sh
    $ mosquitto_sub -h BROKER -p PORT -u USERNAME -P PASSWORD -i ID -t 'status/#'
    ```
5. run `its-status` using your custom configuration file:
    ```sh
    $ ${HOME}/.local/bin/its-status -c /path/to/its-status.custom.cfg
    ```

---
**Expected results:**

1. The `its-status` package is installed;
2. You have a custom configuration file with your MQTT settings;
3. The MQTT client is connected to your MQTT broker;
4. The `its-status` program runs, and the messages are visible both on the `its-status`'
   own `stdout`, as well as on the MQTT client; the total and free space for the data
   directory is reported.