### PR TITLE
Cpm missing structs

### DIFF
--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -33,6 +33,10 @@
 - [Source code](https://github.com/andygrove/rust-navigation)
 - Copyright (c) Andy Grove
 
+#### ndarray
+- [Source code](https://github.com/rust-ndarray/ndarray)
+- Copyright (c) 2015 - 2021 Ulrik Sverdrup "bluss", Jim Turner, and ndarray developers
+
 #### pin-utils
 - [Source code](https://github.com/rust-lang/pin-utils)
 - Copyright (c) 2018 The pin-utils authors
@@ -83,6 +87,10 @@
 #### navigation
 - [Source code](https://github.com/andygrove/rust-navigation)
 - Copyright (c) Andy Grove
+
+#### ndarray
+- [Source code](https://github.com/rust-ndarray/ndarray)
+- Copyright (c) 2015 - 2021 Ulrik Sverdrup "bluss", Jim Turner, and ndarray developers
 
 #### pin-utils
 - [Source code](https://github.com/rust-lang/pin-utils)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "integer-sqrt",
  "log",
  "navigation",
+ "ndarray",
  "pin-utils",
  "rumqttc",
  "rustls 0.19.1",
@@ -783,6 +784,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +844,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92766d205f94d049cdcdfe119a0b186afd957ecf445f83f0103f84261b2033c1"
 dependencies = [
  "rand 0.3.23",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1010,6 +1042,12 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rdrand"

--- a/rust/libits-client/Cargo.toml
+++ b/rust/libits-client/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4"
+ndarray = "0.15"
 serde_json = "1.0"
 serde_repr = "0.1"
 rumqttc = "0.19"

--- a/rust/libits-client/src/reception/exchange/collective_perception_message.rs
+++ b/rust/libits-client/src/reception/exchange/collective_perception_message.rs
@@ -158,6 +158,14 @@ pub struct VehicleSensorProperty {
     pub vertical_opening_angle_end: Option<u16>,
 }
 
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Offset {
+    pub x: i32,
+    pub y: i32,
+    pub z: Option<i32>,
+}
+
 impl Mobile for CollectivePerceptionMessage {
     fn mobile_id(&self) -> u32 {
         self.station_id
@@ -199,7 +207,7 @@ impl Typed for CollectivePerceptionMessage {
 #[cfg(test)]
 mod tests {
     use crate::reception::exchange::collective_perception_message::{
-        CollectivePerceptionMessage, DetectionArea, ManagementContainer,
+        CollectivePerceptionMessage, DetectionArea, ManagementContainer, Offset,
         OriginatingVehicleContainer, SensorInformation, StationDataContainer, VehicleSensor,
         VehicleSensorProperty,
     };
@@ -1143,6 +1151,41 @@ mod tests {
             Err(e) => {
                 panic!("Failed to deserialize CPM: '{}'", e);
             }
+        }
+    }
+
+    #[test]
+    fn test_deserialize_minimal_offset() {
+        let data = r#"{
+            "x": 123456,
+            "y": 654321
+        }"#;
+
+        match serde_json::from_str::<Offset>(data) {
+            Ok(offset) => {
+                assert_eq!(offset.x, 123456);
+                assert_eq!(offset.y, 654321);
+                assert!(offset.z.is_none());
+            }
+            Err(e) => panic!("Failed to deserialize minimal Offset: '{}'", e),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_full_offset() {
+        let data = r#"{
+            "x": 123456,
+            "y": 654321,
+            "z": 456789
+        }"#;
+
+        match serde_json::from_str::<Offset>(data) {
+            Ok(offset) => {
+                assert_eq!(offset.x, 123456);
+                assert_eq!(offset.y, 654321);
+                assert_eq!(offset.z, Some(456789));
+            }
+            Err(e) => panic!("Failed to deserialize minimal Offset: '{}'", e),
         }
     }
 }

--- a/rust/libits-client/src/reception/exchange/collective_perception_message.rs
+++ b/rust/libits-client/src/reception/exchange/collective_perception_message.rs
@@ -139,6 +139,7 @@ pub struct DetectionArea {
     pub stationary_sensor_radial: Option<StationarySensorRadial>,
     pub stationary_sensor_circular: Option<CircularArea>,
     pub stationary_sensor_ellipse: Option<EllipticArea>,
+    pub stationary_sensor_rectangle: Option<RectangleArea>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -183,6 +184,16 @@ pub struct CircularArea {
 #[serde_with::skip_serializing_none]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EllipticArea {
+    pub semi_major_range_length: u16,
+    pub semi_minor_range_length: u16,
+    pub semi_major_range_orientation: u16,
+    pub node_center_point: Option<Offset>,
+    pub semi_height: Option<u16>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RectangleArea {
     pub semi_major_range_length: u16,
     pub semi_minor_range_length: u16,
     pub semi_major_range_orientation: u16,
@@ -240,7 +251,7 @@ impl Typed for CollectivePerceptionMessage {
 mod tests {
     use crate::reception::exchange::collective_perception_message::{
         CircularArea, CollectivePerceptionMessage, DetectionArea, EllipticArea,
-        ManagementContainer, Offset, OriginatingVehicleContainer, SensorInformation,
+        ManagementContainer, Offset, OriginatingVehicleContainer, RectangleArea, SensorInformation,
         StationDataContainer, StationarySensorRadial, VehicleSensor, VehicleSensorProperty,
     };
     use crate::reception::exchange::mobile_perceived_object::MobilePerceivedObject;
@@ -409,6 +420,17 @@ mod tests {
                         }),
                     }),
                     stationary_sensor_ellipse: Some(EllipticArea {
+                        semi_major_range_length: 1,
+                        semi_minor_range_length: 2,
+                        semi_major_range_orientation: 3,
+                        semi_height: Some(4),
+                        node_center_point: Some(Offset {
+                            x: 5,
+                            y: 6,
+                            z: None,
+                        }),
+                    }),
+                    stationary_sensor_rectangle: Some(RectangleArea {
                         semi_major_range_length: 1,
                         semi_minor_range_length: 2,
                         semi_major_range_orientation: 3,
@@ -1416,6 +1438,51 @@ mod tests {
                 assert!(elliptic_area.semi_height.is_some());
             }
             Err(e) => panic!("Failed to deserialize EllipticArea: '{}'", e),
+        }
+    }
+
+    #[test]
+    fn deserialize_minimal_rectangle_area() {
+        let data = r#"{
+            "semi_major_range_length": 1,
+            "semi_minor_range_length": 2,
+            "semi_major_range_orientation": 3
+        }"#;
+
+        match serde_json::from_str::<RectangleArea>(data) {
+            Ok(elliptic_area) => {
+                assert_eq!(elliptic_area.semi_major_range_length, 1);
+                assert_eq!(elliptic_area.semi_minor_range_length, 2);
+                assert_eq!(elliptic_area.semi_major_range_orientation, 3);
+                assert!(elliptic_area.node_center_point.is_none());
+                assert!(elliptic_area.semi_height.is_none());
+            }
+            Err(e) => panic!("Failed to deserialize RectangleArea: '{}'", e),
+        }
+    }
+
+    #[test]
+    fn deserialize_full_rectangle_area() {
+        let data = r#"{
+            "semi_major_range_length": 1,
+            "semi_minor_range_length": 2,
+            "semi_major_range_orientation": 3,
+            "semi_height": 4,
+            "node_center_point": {
+                "x": 5,
+                "y": 6
+            }
+        }"#;
+
+        match serde_json::from_str::<RectangleArea>(data) {
+            Ok(elliptic_area) => {
+                assert_eq!(elliptic_area.semi_major_range_length, 1);
+                assert_eq!(elliptic_area.semi_minor_range_length, 2);
+                assert_eq!(elliptic_area.semi_major_range_orientation, 3);
+                assert!(elliptic_area.node_center_point.is_some());
+                assert!(elliptic_area.semi_height.is_some());
+            }
+            Err(e) => panic!("Failed to deserialize RectangleArea: '{}'", e),
         }
     }
 }

--- a/rust/libits-client/src/reception/exchange/collective_perception_message.rs
+++ b/rust/libits-client/src/reception/exchange/collective_perception_message.rs
@@ -135,6 +135,7 @@ pub struct SensorInformation {
 #[derive(Default, Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DetectionArea {
     pub vehicle_sensor: Option<VehicleSensor>,
+    pub stationary_sensor_polygon: Option<Vec<Offset>>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -339,6 +340,23 @@ mod tests {
                             vertical_opening_angle_end: None,
                         }],
                     }),
+                    stationary_sensor_polygon: Some(vec![
+                        Offset {
+                            x: 1,
+                            y: 2,
+                            z: Some(0),
+                        },
+                        Offset {
+                            x: 11,
+                            y: 22,
+                            z: Some(1),
+                        },
+                        Offset {
+                            x: 111,
+                            y: 222,
+                            z: Some(2),
+                        },
+                    ]),
                 },
             }],
             perceived_object_container: vec![

--- a/rust/libits-client/src/reception/exchange/collective_perception_message.rs
+++ b/rust/libits-client/src/reception/exchange/collective_perception_message.rs
@@ -137,6 +137,7 @@ pub struct DetectionArea {
     pub vehicle_sensor: Option<VehicleSensor>,
     pub stationary_sensor_polygon: Option<Vec<Offset>>,
     pub stationary_sensor_radial: Option<StationarySensorRadial>,
+    pub stationary_sensor_circular: Option<CircularArea>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -169,6 +170,13 @@ pub struct StationarySensorRadial {
     pub vertical_opening_angle_start: Option<u16>,
     pub vertical_opening_angle_end: Option<u16>,
     pub sensor_position_offset: Option<Offset>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CircularArea {
+    pub node_center_point: Option<Offset>,
+    pub radius: u16,
 }
 
 #[serde_with::skip_serializing_none]
@@ -220,7 +228,7 @@ impl Typed for CollectivePerceptionMessage {
 #[cfg(test)]
 mod tests {
     use crate::reception::exchange::collective_perception_message::{
-        CollectivePerceptionMessage, DetectionArea, ManagementContainer, Offset,
+        CircularArea, CollectivePerceptionMessage, DetectionArea, ManagementContainer, Offset,
         OriginatingVehicleContainer, SensorInformation, StationDataContainer,
         StationarySensorRadial, VehicleSensor, VehicleSensorProperty,
     };
@@ -376,6 +384,14 @@ mod tests {
                         vertical_opening_angle_start: None,
                         vertical_opening_angle_end: None,
                         sensor_position_offset: Some(Offset {
+                            x: 1,
+                            y: 2,
+                            z: None,
+                        }),
+                    }),
+                    stationary_sensor_circular: Some(CircularArea {
+                        radius: 10000,
+                        node_center_point: Some(Offset {
                             x: 1,
                             y: 2,
                             z: None,
@@ -1299,6 +1315,40 @@ mod tests {
                 "Failed to deserialize minimal StationarySensorRadial: '{}'",
                 e
             ),
+        }
+    }
+
+    #[test]
+    fn deserialize_minimal_circular_area() {
+        let data = r#"{
+            "radius": 999
+        }"#;
+
+        match serde_json::from_str::<CircularArea>(data) {
+            Ok(circular_area) => {
+                assert_eq!(circular_area.radius, 999);
+                assert!(circular_area.node_center_point.is_none());
+            }
+            Err(e) => panic!("Failed to deserialize: '{}'", e),
+        }
+    }
+
+    #[test]
+    fn deserialize_full_circular_area() {
+        let data = r#"{
+            "radius": 999,
+            "node_center_point": {
+                "x": 1,
+                "y": 2
+            }
+        }"#;
+
+        match serde_json::from_str::<CircularArea>(data) {
+            Ok(circular_area) => {
+                assert_eq!(circular_area.radius, 999);
+                assert!(circular_area.node_center_point.is_some());
+            }
+            Err(e) => panic!("Failed to deserialize: '{}'", e),
         }
     }
 }

--- a/rust/libits-client/src/reception/exchange/map_extended_message.rs
+++ b/rust/libits-client/src/reception/exchange/map_extended_message.rs
@@ -84,6 +84,7 @@ pub struct Lane {
     ///
     /// [1]: https://en.wikipedia.org/wiki/World_Geodetic_System#WGS84
     pub geom: Vec<[f32; 2]>,
+    pub is_pedestrian_lane: Option<bool>,
     pub is_vehicle_lane: Option<bool>,
     pub is_bus_lane: Option<bool>,
     pub is_bike_lane: Option<bool>,
@@ -497,7 +498,8 @@ mod test {
                 ],
                 "id": 4,
                 "ingress": true,
-                "isVehicleLane": true,
+                "isVehicleLane": false,
+                "isPedestrianLane": true,
                 "left": false,
                 "nextChange": 0,
                 "right": false,

--- a/rust/libits-client/src/reception/exchange/mobile_perceived_object.rs
+++ b/rust/libits-client/src/reception/exchange/mobile_perceived_object.rs
@@ -37,8 +37,8 @@ impl MobilePerceivedObject {
         let compute_mobile_id = compute_id(perceived_object.object_id, cpm_station_id);
         let computed_reference_position = match cpm_station_type {
             15 => cpm_position.get_offset_destination(
-                perceived_object.x_distance.into(),
-                perceived_object.y_distance.into(),
+                (perceived_object.x_distance / 100).into(),
+                (perceived_object.y_distance / 100).into(),
             ),
             _ => compute_position_from_mobile(
                 perceived_object.x_distance,

--- a/rust/libits-client/src/reception/exchange/reference_position.rs
+++ b/rust/libits-client/src/reception/exchange/reference_position.rs
@@ -12,14 +12,15 @@ use std::f64::consts;
 use cheap_ruler::{CheapRuler, DistanceUnit};
 use geo::Point;
 use navigation::Location;
+use ndarray::{arr1, arr2};
 use serde::{Deserialize, Serialize};
 
-const EARTH_RADIUS: u32 = 6371000;
-// in meters
-const LG_MOD: u8 = 180;
-// Max longitude on WGS 84
-const COORDINATE_SIGNIFICANT_DIGIT: u8 = 7;
+const EARTH_RADIUS: u32 = 6_371_000; // in meters
+const EQUATORIAL_RADIUS: f64 = 6_378_137.0; // in meters
+const POLAR_RADIUS: f64 = 6_356_752.3; // in meters
 
+const LG_MOD: u8 = 180; // Max longitude on WGS 84
+const COORDINATE_SIGNIFICANT_DIGIT: u8 = 7;
 const ALTITUDE_SIGNIFICANT_DIGIT: u8 = 3;
 
 #[derive(Clone, Default, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -102,6 +103,69 @@ impl ReferencePosition {
             altitude: self.altitude,
         }
     }
+
+    /// Converts this position to its [East North Up (ENU) coordinates][1]
+    /// from the reference position `anchor`
+    ///
+    /// Computation is done by first converting the geodetic coordinates (lat, lon, alt)
+    /// of both this point and the reference point to [ECEF][2] coordinates
+    /// Then the [ENU computation][3] can be done
+    ///
+    /// [1]: https://en.wikipedia.org/wiki/Local_tangent_plane_coordinates
+    /// [2]: https://en.wikipedia.org/wiki/Earth-centered,_Earth-fixed_coordinate_system
+    /// [3]: https://gssc.esa.int/navipedia/index.php/Transformations_between_ECEF_and_ENU_coordinates
+    pub fn to_enu(&self, anchor: &ReferencePosition) -> (f64, f64, f64) {
+        let reference_ecef = anchor.to_ecef();
+        let relative_ecef = self.to_ecef();
+
+        let latitude = get_coordinate(anchor.latitude).to_radians();
+        let longitude = get_coordinate(anchor.longitude).to_radians();
+
+        let reference_matrix = arr2(&[
+            [-longitude.sin(), longitude.cos(), 0.],
+            [
+                -latitude.sin() * longitude.cos(),
+                -latitude.sin() * longitude.sin(),
+                latitude.cos(),
+            ],
+            [
+                latitude.cos() * longitude.cos(),
+                latitude.cos() * longitude.sin(),
+                latitude.sin(),
+            ],
+        ]);
+        let relative_vector = arr1(&[
+            relative_ecef.0 - reference_ecef.0,
+            relative_ecef.1 - reference_ecef.1,
+            relative_ecef.2 - reference_ecef.2,
+        ]);
+
+        let enu = reference_matrix.dot(&relative_vector).to_vec();
+        let as_vec = enu.to_vec();
+
+        let x_distance = as_vec[0];
+        let y_distance = as_vec[1];
+        let z_distance = as_vec[2];
+
+        (x_distance.round(), y_distance.round(), z_distance.round())
+    }
+
+    /// Returns the corresponding [Earth Centered, Earth Fixed][1] coordinates for this position
+    ///
+    /// [1]: https://en.wikipedia.org/wiki/Earth-centered,_Earth-fixed_coordinate_system
+    pub fn to_ecef(&self) -> (f64, f64, f64) {
+        let latitude = get_coordinate(self.latitude).to_radians();
+        let longitude = get_coordinate(self.longitude).to_radians();
+        let altitude = get_altitude(self.altitude);
+
+        let n_phi = prime_vertical_radius(latitude);
+
+        let x = (n_phi + altitude) * latitude.cos() * longitude.cos();
+        let y = (n_phi + altitude) * latitude.cos() * longitude.sin();
+        let z = ((1. - ellipsoid_flattening()).powf(2.) * n_phi + altitude) * latitude.sin();
+
+        (x, y, z)
+    }
 }
 
 impl fmt::Display for ReferencePosition {
@@ -129,6 +193,19 @@ fn get_etsi_coordinate(coordinate: f64) -> i32 {
 fn get_altitude(etsi_altitude: i32) -> f64 {
     let base: i32 = 10;
     etsi_altitude as f64 / base.pow(ALTITUDE_SIGNIFICANT_DIGIT as u32) as f64
+}
+
+fn prime_vertical_radius(phi: f64) -> f64 {
+    let e_square: f64 = 1. - (POLAR_RADIUS.powf(2.) / EQUATORIAL_RADIUS.powf(2.));
+    let sin_phi = phi.sin();
+
+    let n_phi = EQUATORIAL_RADIUS / (1. - e_square * sin_phi.powf(2.)).sqrt();
+
+    n_phi
+}
+
+fn ellipsoid_flattening() -> f64 {
+    1. - POLAR_RADIUS / EQUATORIAL_RADIUS
 }
 
 #[cfg(test)]
@@ -335,5 +412,143 @@ mod tests {
 
         assert_eq!(offset_destination.latitude, expected_destination.latitude);
         assert_eq!(offset_destination.longitude, expected_destination.longitude);
+    }
+
+    #[test]
+    fn geodetic_to_enu_150m_east_200m_north() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031881568425872),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63996919589),
+            longitude: get_etsi_coordinate(1.40504710005),
+            altitude: 0,
+        };
+        let expected_x_distance = 150.;
+        let expected_y_distance = 200.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
+    }
+
+    #[test]
+    fn geodetic_to_enu_150m_west_200m_south() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63996919589),
+            longitude: get_etsi_coordinate(1.40504710005),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031881568425872),
+            altitude: 0,
+        };
+        let expected_x_distance = -150.;
+        let expected_y_distance = -200.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
+    }
+
+    #[test]
+    fn geodetic_to_enu_150m_east() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031881568425872),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816910008),
+            longitude: get_etsi_coordinate(1.40504707684),
+            altitude: 0,
+        };
+        let expected_x_distance = 150.;
+        let expected_y_distance = 0.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
+    }
+
+    #[test]
+    fn geodetic_to_enu_200m_north() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816910008),
+            longitude: get_etsi_coordinate(1.40504707684),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63996919589),
+            longitude: get_etsi_coordinate(1.40504710005),
+            altitude: 0,
+        };
+        let expected_x_distance = 0.;
+        let expected_y_distance = 200.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
+    }
+
+    #[test]
+    fn geodetic_to_enu_150m_west() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816910008),
+            longitude: get_etsi_coordinate(1.40504707684),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031881568425872),
+            altitude: 0,
+        };
+        let expected_x_distance = -150.;
+        let expected_y_distance = 0.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
+    }
+
+    #[test]
+    fn geodetic_to_enu_200m_south() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63996919589),
+            longitude: get_etsi_coordinate(1.40504710005),
+            altitude: 0,
+        };
+        let relative_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816910008),
+            longitude: get_etsi_coordinate(1.40504707684),
+            altitude: 0,
+        };
+        let expected_x_distance = 0.;
+        let expected_y_distance = -200.;
+        let expected_z_distance = 0.;
+
+        let (x_distance, y_distance, z_distance) = relative_point.to_enu(&reference_point);
+
+        assert_eq!(x_distance, expected_x_distance);
+        assert_eq!(y_distance, expected_y_distance);
+        assert_eq!(z_distance, expected_z_distance);
     }
 }

--- a/rust/libits-client/src/reception/exchange/reference_position.rs
+++ b/rust/libits-client/src/reception/exchange/reference_position.rs
@@ -133,6 +133,7 @@ fn get_altitude(etsi_altitude: i32) -> f64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::reception::exchange::reference_position::{get_coordinate, get_etsi_coordinate};
     use navigation::Location;
 
     use crate::reception::exchange::ReferencePosition;
@@ -296,5 +297,43 @@ mod tests {
         };
         assert_eq!(position.get_destination(100.0, 270.0), other_position);
         assert_eq!(position.get_destination(100.0, -90.0), other_position);
+    }
+
+    #[test]
+    fn offset_destination_hunder_meters_north() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031882),
+            altitude: 0,
+        };
+        let expected_destination = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63906919748),
+            longitude: get_etsi_coordinate(1.4031882),
+            altitude: 0,
+        };
+
+        let offset_destination = reference_point.get_offset_destination(0., 100.);
+
+        assert_eq!(offset_destination.latitude, expected_destination.latitude);
+        assert_eq!(offset_destination.longitude, expected_destination.longitude);
+    }
+
+    #[test]
+    fn offset_destination_hundred_meters_east() {
+        let reference_point = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816914950018),
+            longitude: get_etsi_coordinate(1.4031881568425872),
+            altitude: 0,
+        };
+        let expected_destination = ReferencePosition {
+            latitude: get_etsi_coordinate(43.63816910008),
+            longitude: get_etsi_coordinate(1.4044273),
+            altitude: 0,
+        };
+
+        let offset_destination = reference_point.get_offset_destination(100., 0.);
+
+        assert_eq!(offset_destination.latitude, expected_destination.latitude);
+        assert_eq!(offset_destination.longitude, expected_destination.longitude);
     }
 }


### PR DESCRIPTION
What's new
----------------

* Add missing `free_space_addendum_container` in `CollectivePerceptionMessage`
* Add missing `stationary_sensor_*` fields in `DetectionArea`
* Add corresponding structs definitions for
  * StationarySensorRadial
  * CircularArea
  * EllipticArea
  * RectangleArea
  * Offset
* Add `is_pedestrian_lane` in `MAPExtendedMessage`