### PR TITLE
python/its-client: fix acceleration

### DIFF
--- a/python/its-client/its_client/cam.py
+++ b/python/its-client/its_client/cam.py
@@ -37,7 +37,7 @@ class CooperativeAwarenessMessage:
         longitude=0.0,
         altitude=0.0,
         speed=0.0,
-        acceleration=0.0,
+        acceleration=None,
         heading=0.0,
     ):
         self.uuid = uuid
@@ -46,7 +46,9 @@ class CooperativeAwarenessMessage:
         self.longitude = int(round(longitude * 10000000))
         self.altitude = int(round(altitude * 100))
         self.speed = int(round(kmph_to_mps(speed) * 100))
-        self.acceleration = int(round(acceleration * 10))
+        self.acceleration = (
+            int(round(acceleration * 10)) if acceleration is not None else 161
+        )
         self.heading = int(round(heading * 10))
         self.station_id = station_id(uuid)
 

--- a/python/its-client/its_client/mobility.py
+++ b/python/its-client/its_client/mobility.py
@@ -37,23 +37,12 @@ def compute_velocity(distance, time_start, time_end) -> float:
 
 
 def compute_acceleration(
-    latitude_start: float,
-    longitude_start: float,
-    latitude_end: float,
-    longitude_end: float,
+    speed_start: float,
+    speed_end: float,
     time_start,
     time_end,
 ) -> float:
-    return compute_velocity(
-        distance=compute_distance(
-            latitude_start=latitude_start,
-            longitude_start=longitude_start,
-            latitude_end=latitude_end,
-            longitude_end=longitude_end,
-        ),
-        time_start=time_start,
-        time_end=time_end,
-    )
+    return (speed_end - speed_start) / (time_end - time_start)
 
 
 def kmph_to_mps(kmph):

--- a/python/its-client/its_client/mqtt/mqtt_client.py
+++ b/python/its-client/its_client/mqtt/mqtt_client.py
@@ -11,6 +11,7 @@
 # for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
 import json
 import logging
+import os
 import time
 from inspect import currentframe
 from inspect import getouterframes
@@ -55,6 +56,9 @@ class MQTTClient(object):
         logging.debug(
             self._format_log(f" called for {client.socket()} with {userdata}")
         )
+        if not self.stop_signal.is_set():
+            logging.error("Unexpected MQTT disconnect; emergency exit.")
+            os._exit(42)
 
     def on_connect(self, client, userdata, flags, rc):
         logging.debug(
@@ -197,6 +201,9 @@ class MQTTClient(object):
         logging.debug(
             self._format_log(f" called for {client.socket()} with {userdata}")
         )
+        if not self.stop_signal.is_set():
+            logging.error("Unexpected MQTT disconnect; emergency exit.")
+            os._exit(42)
 
     def on_socket_register_write(self, client, userdata, _sock):
         logging.debug(

--- a/python/its-client/its_client/mqtt/mqtt_worker.py
+++ b/python/its-client/its_client/mqtt/mqtt_worker.py
@@ -86,7 +86,7 @@ class MqttWorker:
                     or self.previous_step_lat is None
                     or self.previous_step_lon is None
                 ):
-                    acceleration = 161
+                    acceleration = None
                 else:
                     acceleration = mobility.compute_acceleration(
                         latitude_start=self.previous_step_lat,

--- a/python/its-client/its_client/mqtt/mqtt_worker.py
+++ b/python/its-client/its_client/mqtt/mqtt_worker.py
@@ -27,6 +27,7 @@ class MqttWorker:
         self.previous_step_timestamp = None
         self.previous_step_lon = None
         self.previous_step_lat = None
+        self.previous_speed = None
         self.previous_alt = None
         self.previous_alt_step_counter = 0
         self.previous_heading = None
@@ -81,18 +82,12 @@ class MqttWorker:
                     )
 
                 # acceleration
-                if (
-                    self.previous_step_timestamp is None
-                    or self.previous_step_lat is None
-                    or self.previous_step_lon is None
-                ):
+                if self.previous_step_timestamp is None or self.previous_speed is None:
                     acceleration = None
                 else:
                     acceleration = mobility.compute_acceleration(
-                        latitude_start=self.previous_step_lat,
-                        longitude_start=self.previous_step_lon,
-                        latitude_end=lat,
-                        longitude_end=lon,
+                        speed_start=self.previous_speed,
+                        speed_end=speed,
                         time_start=self.previous_step_timestamp,
                         time_end=now.timestamp(),
                     )
@@ -135,6 +130,7 @@ class MqttWorker:
                 self.previous_step_timestamp = now.timestamp()
                 self.previous_step_lat = lat
                 self.previous_step_lon = lon
+                self.previous_speed = speed
                 # threading
                 publish.join()
                 del publish


### PR DESCRIPTION
Bug fix:

* #75 
* #76 

Fixes: #76 #75

---
**How to test:**

1. Build and install `python/its-client` with standard setuptools procedure, e.g. (replace XXXXX by appropriate values):
    ```sh
    $ cd python/its-client
    $ pip3 wheel .
    $ pip3 install its_client-XXXXX.whl
    ```
   Also take note of where the script has been installed (e.g. `${HOME}/.local/bin`)
2. Run its-client in a setup where there is an actual GNSS device driven by gpsd
3. Move around a large area (preferably with a car in an area of at least 200m × 200m)

---
**Expected results:**

1. The `its-client` package is installed;
2. The `its-client` program runs, receives data from gpsd, and emits CAM messages
3. The CAM messages contain correct acceleration values; the `its-client` program
   terminates immediately when there is an MQTT issue (and if managed by a service
   manager, it gets restarted).