### PR TITLE
python/its-client: expect explicit port for mirror broker

### DIFF
--- a/python/its-client/its_client/configuration.py
+++ b/python/its-client/its_client/configuration.py
@@ -65,7 +65,6 @@ def build(args=None) -> ConfigParser:
     parser.add_argument(
         "--mqtt-mirror-port",
         type=int,
-        default=1883,
         help="port of the mirror MQTT broker",
     )
     parser.add_argument(


### PR DESCRIPTION
Bug fix:

* MQTT port for mirror broker from config file unused

---
**How to test:**

1. Build and install `python/its-client` with standard setuptools procedure, e.g. (replace XXXXX by appropriate values):
    ```sh
    $ cd python/its-client
    $ pip3 wheel .
    $ pip3 install its_client-XXXXX.whl
    ```
   Also take note of where the script has been installed (e.g. `${HOME}/.local/bin`)
2. In the config file, enable the mirroring to a broker running on a non-standard port.
3. Run `its-client` using your custom config file.

---
**Expected results:**

1. The `its-client` package is installed;
2. The config file contains an entry with, most notably (port depends on your setup):
    ```ini
    [mirror-broker]
    port = 1234
    ```
3. The `its-client` runs and sends messages to the mirror broker.