### PR TITLE
python/iqm: fix #103, #107; misc fixes and cleanups

### DIFF
--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -31,10 +31,9 @@ port = 1883
 # for now, mqtt is not implemented
 type = file
 
-# Period in seconds at which to reload the file; if unset or 0,
-# don't reload; default: unset
-# (valid for type: file, htt; not vazlid for type: mqttp)
-#reload = 60
+# Period in seconds at which to reload the file; mandatory;
+# (valid for type: file, http; not valid for type: mqtt)
+reload = 60
 
 # For type == file:
 # - path of the fle containing the neighbours configuration

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -55,6 +55,8 @@ path = /etc/its/neighbours.cfg
 #password = secret
 # - MQTT client-id to connect as
 #client_id = CLIENT_ID
+# - topic to listen on; mandatory
+#topic = 5GCroCo/neighbours/v2x/ora_geo_1234
 
 [neighbours]
 # The MQTT client ID to identify to neighbours; default: general.instance-id

--- a/python/its-interqueuemanager/its_iqm/authority/__init__.py
+++ b/python/its-interqueuemanager/its_iqm/authority/__init__.py
@@ -1,3 +1,28 @@
-import its_iqm.authority.file
-import its_iqm.authority.http
-import its_iqm.authority.mqtt
+from __future__ import annotations
+import its_iqm.authority.file as _file
+import its_iqm.authority.http as _http
+import its_iqm.authority.mqtt as _mqtt
+
+
+class Authority:
+    def __new__(
+        cls,
+        cfg: dict,
+        update_cb: Callable[[list[Any]], None],
+    ):
+        authority_type = cfg["authority"]["type"]
+        if authority_type == "file":
+            return _file.Authority(cfg, update_cb)
+        if authority_type == "http":
+            return _http.Authority(cfg, update_cb)
+        if authority_type == "mqtt":
+            return _mqtt.Authority(cfg, update_cb)
+        raise ValueError(f"unknown central authority type {authority_type}")
+
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("Trying to initialise an Authority demuxer...")
+
+
+__all__ = [
+    "Authority",
+]

--- a/python/its-interqueuemanager/its_iqm/authority/__init__.py
+++ b/python/its-interqueuemanager/its_iqm/authority/__init__.py
@@ -7,16 +7,17 @@ import its_iqm.authority.mqtt as _mqtt
 class Authority:
     def __new__(
         cls,
+        instance_id: str,
         cfg: dict,
         update_cb: Callable[[list[Any]], None],
     ):
-        authority_type = cfg["authority"]["type"]
+        authority_type = cfg["type"]
         if authority_type == "file":
-            return _file.Authority(cfg, update_cb)
+            return _file.Authority(instance_id, cfg, update_cb)
         if authority_type == "http":
-            return _http.Authority(cfg, update_cb)
+            return _http.Authority(instance_id, cfg, update_cb)
         if authority_type == "mqtt":
-            return _mqtt.Authority(cfg, update_cb)
+            return _mqtt.Authority(instance_id, cfg, update_cb)
         raise ValueError(f"unknown central authority type {authority_type}")
 
     def __init__(self, *args, **kwargs):

--- a/python/its-interqueuemanager/its_iqm/authority/__init__.py
+++ b/python/its-interqueuemanager/its_iqm/authority/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import its_iqm.authority.file as _file
 import its_iqm.authority.http as _http
 import its_iqm.authority.mqtt as _mqtt
+import its_iqm.iqm
 
 
 class Authority:
@@ -9,7 +10,7 @@ class Authority:
         cls,
         instance_id: str,
         cfg: dict,
-        update_cb: Callable[[list[Any]], None],
+        update_cb: Callable[[its_iqm.iqm.IQM, dict], None],
     ):
         authority_type = cfg["type"]
         if authority_type == "file":

--- a/python/its-interqueuemanager/its_iqm/authority/file.py
+++ b/python/its-interqueuemanager/its_iqm/authority/file.py
@@ -60,5 +60,6 @@ class Authority:
         except FileNotFoundError:
             # No file -> no neigbour defined, i.e. empty list
             pass
-        logging.debug(f"loaded {len(loaded_nghbs)} neighbour(s)")
+        # .sections() does not contain the "DEFAULT" section
+        logging.debug(f"loaded {len(loaded_nghbs.sections())} neighbour(s)")
         self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})

--- a/python/its-interqueuemanager/its_iqm/authority/file.py
+++ b/python/its-interqueuemanager/its_iqm/authority/file.py
@@ -13,6 +13,7 @@ import time
 class Authority:
     def __init__(
         self,
+        _instance_id: str,
         cfg: dict,
         update_cb: Callable[[list[Any]], None],
     ):
@@ -27,12 +28,12 @@ class Authority:
 
     def start(self):
         logging.info(
-            f"starting authority file client to {self.cfg['authority']['path']}@{self.cfg['authority']['reload']}"
+            f"starting authority file client to {self.cfg['path']}@{self.cfg['reload']}"
         )
         self.thread.start()
 
     def stop(self):
-        logging.info(f"stopping file client to {self.cfg['authority']['path']}")
+        logging.info(f"stopping authority file client to {self.cfg['path']}")
         # We're a daemon thread, we'll get killed automatically eventually...
 
     def join(self):
@@ -49,14 +50,14 @@ class Authority:
         # frequently anyway, and we just need to reload it in a
         # "timely manner"...
         while True:
-            time.sleep(int(self.cfg["authority"]["reload"]))
+            time.sleep(int(self.cfg["reload"]))
             self.load()
 
     def load(self):
         logging.info("loading neighbours")
         loaded_nghbs = configparser.ConfigParser()
         try:
-            with open(self.cfg["authority"]["path"], "r") as fd:
+            with open(self.cfg["path"], "r") as fd:
                 loaded_nghbs.read_file(fd)
         except FileNotFoundError:
             # No file -> no neigbour defined, i.e. empty list

--- a/python/its-interqueuemanager/its_iqm/authority/file.py
+++ b/python/its-interqueuemanager/its_iqm/authority/file.py
@@ -15,7 +15,7 @@ class Authority:
         self,
         _instance_id: str,
         cfg: dict,
-        update_cb: Callable[[list[Any]], None],
+        update_cb: Callable[[its_iqm.iqm.IQM, dict], None],
     ):
         self.cfg = cfg
         self.update_cb = update_cb
@@ -61,4 +61,4 @@ class Authority:
             # No file -> no neigbour defined, i.e. empty list
             pass
         logging.debug(f"loaded {len(loaded_nghbs)} neighbour(s)")
-        self.update_cb(loaded_nghbs)
+        self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})

--- a/python/its-interqueuemanager/its_iqm/authority/file.py
+++ b/python/its-interqueuemanager/its_iqm/authority/file.py
@@ -42,8 +42,6 @@ class Authority:
 
     def run(self):
         self.load()
-        if "reload" not in self.cfg["authority"]:
-            return
         # This does not give us a period that is perfectly "reload"
         # seconds, but we do not care much here, as it is solely to
         # update the list of neighbours, which does not happen so

--- a/python/its-interqueuemanager/its_iqm/authority/http.py
+++ b/python/its-interqueuemanager/its_iqm/authority/http.py
@@ -14,6 +14,7 @@ import time
 class Authority:
     def __init__(
         self,
+        _instance_id: str,
         cfg: dict,
         update_cb: Callable[[Sequence[Any]], None],
     ):
@@ -28,14 +29,12 @@ class Authority:
 
     def start(self):
         logging.info(
-            f"starting authority http client to {self.cfg['authority']['uri']}@{self.cfg['authority']['reload']}"
+            f"starting authority http client to {self.cfg['uri']}@{self.cfg['reload']}"
         )
         self.thread.start()
 
     def stop(self):
-        logging.info(
-            f"stopping authority http client to {self.cfg['authority']['uri']}"
-        )
+        logging.info(f"stopping authority http client to {self.cfg['uri']}")
         # We're a daemon thread, we'll get killed automatically eventually...
 
     def join(self):
@@ -52,14 +51,14 @@ class Authority:
             # update the list of neighbours, which does not happen so
             # frequently anyway, and we just need to reload it in a
             # "timely manner"...
-            time.sleep(int(self.cfg["authority"]["reload"]))
+            time.sleep(int(self.cfg["reload"]))
             self.load()
 
     def load(self):
         logging.info("loading neighbours")
         loaded_nghbs = configparser.ConfigParser()
         try:
-            r = requests.get(self.cfg["authority"]["uri"])
+            r = requests.get(self.cfg["uri"])
             loaded_nghbs.read_string(r.text)
         except Exception:
             # Can't download -> don't change the current state;

--- a/python/its-interqueuemanager/its_iqm/authority/http.py
+++ b/python/its-interqueuemanager/its_iqm/authority/http.py
@@ -43,8 +43,6 @@ class Authority:
 
     def run(self):
         self.load()
-        if "reload" not in self.cfg["authority"]:
-            return
         while True:
             # This does not give us a period that is perfectly "reload"
             # seconds, but we do not care much here, as it is solely to

--- a/python/its-interqueuemanager/its_iqm/authority/http.py
+++ b/python/its-interqueuemanager/its_iqm/authority/http.py
@@ -16,7 +16,7 @@ class Authority:
         self,
         _instance_id: str,
         cfg: dict,
-        update_cb: Callable[[Sequence[Any]], None],
+        update_cb: Callable[[its_iqm.iqm.IQM, dict], None],
     ):
         self.cfg = cfg
         self.update_cb = update_cb
@@ -63,4 +63,4 @@ class Authority:
             # just keep using the neighbours we have, if any.
             logging.debug("failed to download the list of neighbours; changing nothing")
         logging.debug(f"loaded {len(loaded_nghbs)} neighbour(s)")
-        self.update_cb(loaded_nghbs)
+        self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})

--- a/python/its-interqueuemanager/its_iqm/authority/http.py
+++ b/python/its-interqueuemanager/its_iqm/authority/http.py
@@ -62,5 +62,6 @@ class Authority:
             # Can't download -> don't change the current state;
             # just keep using the neighbours we have, if any.
             logging.debug("failed to download the list of neighbours; changing nothing")
-        logging.debug(f"loaded {len(loaded_nghbs)} neighbour(s)")
+        # .sections() does not contain the "DEFAULT" section
+        logging.debug(f"loaded {len(loaded_nghbs.sections())} neighbour(s)")
         self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -13,6 +13,7 @@ import paho.mqtt.subscribe
 class Authority:
     def __init__(
         self,
+        instance_id: str,
         cfg: configparser.ConfigParser,
         update_cb: Callable[[Sequence[Any]], None],
     ):
@@ -20,9 +21,9 @@ class Authority:
         self.update_cb = update_cb
 
         try:
-            client_id = self.cfg["authority"]["client_id"]
+            client_id = self.cfg["client_id"]
         except KeyError:
-            client_id = self.cfg["general"]["instance_id"]
+            client_id = instance_id
 
         self.authority_client = paho.mqtt.client.Client(
             client_id=client_id,
@@ -30,8 +31,8 @@ class Authority:
         )
         self.authority_client.reconnect_delay_set()
         self.authority_client.username_pw_set(
-            self.cfg["authority"]["username"] or None,
-            self.cfg["authority"]["password"] or None,
+            self.cfg["username"] or None,
+            self.cfg["password"] or None,
         )
         self.authority_client.on_connect = self._on_connect
         self.authority_client.on_disconnect = self._on_disconnect
@@ -39,20 +40,20 @@ class Authority:
         self.authority_client.on_message = self._on_message
 
         self.authority_client.connect_async(
-            host=self.cfg["authority"]["host"],
-            port=int(self.cfg["authority"]["port"]),
+            host=self.cfg["host"],
+            port=int(self.cfg["port"]),
             clean_start=True,
         )
 
     def start(self):
         logging.info(
-            f"starting authority MQTT client to {self.cfg['authority']['host']}:{self.cfg['authority']['port']}"
+            f"starting authority MQTT client to {self.cfg['host']}:{self.cfg['port']}"
         )
         self.authority_client.loop_start()
 
     def stop(self):
         logging.info(
-            f"stopping authority MQTT client to {self.cfg['authority']['host']}:{self.cfg['authority']['port']}"
+            f"stopping authority MQTT client to {self.cfg['host']}:{self.cfg['port']}"
         )
         self.authority_client.disconnect()
         self.authority_client.loop_stop()
@@ -61,7 +62,7 @@ class Authority:
         pass
 
     def _on_connect(self, _client, _userdata, _flags, _rc, _properties=None):
-        self.authority_client.subscribe(self.cfg["authority"]["topic"])
+        self.authority_client.subscribe(self.cfg["topic"])
 
     def _on_disconnect(self, _client, _userdata, _rc, _properties=None):
         pass

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -79,7 +79,7 @@ class Authority:
     def join(self):
         pass
 
-    def _on_connect(self, client, userdata, flags, rc, properties=None):
+    def _on_connect(self, _client, _userdata, _flags, _rc, _properties=None):
         self.authority_client.subscribe(self.topic)
 
     def _on_disconnect(self, _client, _userdata, _rc, _properties=None):

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -4,12 +4,10 @@
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
 from __future__ import annotations
-import configparser
 import json
 import logging
 import paho.mqtt.client
 import paho.mqtt.subscribe
-import time
 
 
 class Authority:

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -73,4 +73,8 @@ class Authority:
     def _on_message(self, _client, _userdata, message):
         logging.info("received neighbours")
         loaded_nghbs = json.loads(message.payload)
+        # Contrary to the 'file' or 'http' methods, which use a .cfg style
+        # content, the 'mqtt' method uses a json blob. So there is no
+        # "DEFAULT" section to ignore here.
+        logging.debug(f"loaded {len(loaded_nghbs)} neighbour(s)")
         self.update_cb(loaded_nghbs)

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -14,8 +14,8 @@ class Authority:
     def __init__(
         self,
         instance_id: str,
-        cfg: configparser.ConfigParser,
-        update_cb: Callable[[Sequence[Any]], None],
+        cfg: dict,
+        update_cb: Callable[[its_iqm.iqm.IQM, dict], None],
     ):
         self.cfg = cfg
         self.update_cb = update_cb

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -24,23 +24,6 @@ class Authority:
         except KeyError:
             client_id = self.cfg["general"]["instance_id"]
 
-        self.prefix = str()
-        self.suffix = str()
-        # Compare against "not None" instead of truthness, as an
-        # empty prefix is valid and means starting the topic with a /
-        if self.cfg["general"]["prefix"] is not None:
-            self.prefix = f"{self.cfg['general']['prefix']}"
-            # prefix must end with a '/'
-            if self.prefix == "" or self.prefix[-1] != "/":
-                self.prefix += "/"
-        # Test for truthness, because an empty suffix is the same as no suffix
-        if self.cfg["general"]["suffix"]:
-            self.suffix = self.cfg["general"]["suffix"]
-            if self.suffix[-1] != "/":
-                self.suffix += "/"
-
-        self.topic = f"{self.prefix}neighbours/{self.suffix}{self.username}"
-
         self.authority_client = paho.mqtt.client.Client(
             client_id=client_id,
             protocol=paho.mqtt.client.MQTTv5,
@@ -78,7 +61,7 @@ class Authority:
         pass
 
     def _on_connect(self, _client, _userdata, _flags, _rc, _properties=None):
-        self.authority_client.subscribe(self.topic)
+        self.authority_client.subscribe(self.cfg["authority"]["topic"])
 
     def _on_disconnect(self, _client, _userdata, _rc, _properties=None):
         pass

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -55,15 +55,7 @@ class IQM:
         # will need to have a valid local_qm to pass to the neighbours
         # queue managers, so we need to handle the central authority
         # after we create the local QM.
-        authority_type = self.cfg["authority"]["type"]
-        if authority_type == "file":
-            self.authority = its_iqm.authority.file.Authority(self.cfg, self.update_cb)
-        elif authority_type == "http":
-            self.authority = its_iqm.authority.http.Authority(self.cfg, self.update_cb)
-        elif authority_type == "mqtt":
-            self.authority = its_iqm.authority.mqtt.Authority(self.cfg, self.update_cb)
-        else:
-            raise ValueError(f"unknown central authority type {authority_type}")
+        self.authority = its_iqm.authority.Authority(self.cfg, self.update_cb)
 
     def run_forever(self):
         self.neighbours = dict()

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -119,18 +119,24 @@ class IQM:
                     f"only mqtt neighbours supported, not {n_type} for {nghb_id}"
                 )
             self.neighbours[nghb_id] = loaded_nghbs[nghb_id]
+            creds = {
+                "username": None,
+                "password": None,
+            }
+            for k in creds:
+                if k in loaded_nghbs[nghb_id]:
+                    creds[k] = loaded_nghbs[nghb_id][k]
             self.neighbours_clients[nghb_id] = its_iqm.mqtt_client.MQTTClient(
                 name=nghb_id,
                 host=loaded_nghbs[nghb_id]["host"],
                 port=int(loaded_nghbs[nghb_id]["port"]),
                 socket=None,
-                username=loaded_nghbs[nghb_id]["username"],
-                password=loaded_nghbs[nghb_id]["password"],
                 client_id=self.cfg["neighbours"]["client_id"],
                 local_qm=self.local_qm,
                 prefix=self.cfg["general"]["prefix"],
                 suffix=self.cfg["general"]["suffix"],
                 copy_from=loaded_nghbs[nghb_id]["queue"],
                 copy_to=["outQueue"],
+                **creds,
             )
             self.neighbours_clients[nghb_id].start()

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -24,11 +24,19 @@ class IQM:
         self.instance_id = self.cfg["general"]["instance-id"]
 
         logging.info("create local qm")
+        conn = {
+            "host": None,
+            "port": None,
+            "socket": None,
+        }
+        try:
+            conn["host"] = cfg["local"]["host"]
+            conn["port"] = int(cfg["local"]["port"])
+        except TypeError:
+            conn["socket"] = cfg["local"]["socket-path"]
+
         self.local_qm = its_iqm.mqtt_client.MQTTClient(
             name="local",
-            host=cfg["local"]["host"],
-            port=cfg["local"]["port"],
-            socket=cfg["local"]["socket-path"],
             username=cfg["local"]["username"],
             password=cfg["local"]["password"],
             client_id=cfg["local"]["client_id"],
@@ -40,6 +48,7 @@ class IQM:
                 "outQueue",
                 cfg["local"]["interqueue"],
             ],
+            **conn,
         )
 
         # The central authority will call our update_cb(), for which we
@@ -113,7 +122,7 @@ class IQM:
             self.neighbours_clients[nghb_id] = its_iqm.mqtt_client.MQTTClient(
                 name=nghb_id,
                 host=loaded_nghbs[nghb_id]["host"],
-                port=loaded_nghbs[nghb_id]["port"],
+                port=int(loaded_nghbs[nghb_id]["port"]),
                 socket=None,
                 username=loaded_nghbs[nghb_id]["username"],
                 password=loaded_nghbs[nghb_id]["password"],

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -55,7 +55,11 @@ class IQM:
         # will need to have a valid local_qm to pass to the neighbours
         # queue managers, so we need to handle the central authority
         # after we create the local QM.
-        self.authority = its_iqm.authority.Authority(self.cfg, self.update_cb)
+        self.authority = its_iqm.authority.Authority(
+            self.instance_id,
+            self.cfg["authority"],
+            self.update_cb,
+        )
 
     def run_forever(self):
         self.neighbours = dict()

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -94,7 +94,7 @@ class IQM:
         # or those which description changed.
         new_nghbs_ids = [
             nghb_id
-            for nghb_id in loaded_nghbs.sections()  # Avoids section "DEFAULT"
+            for nghb_id in loaded_nghbs
             if nghb_id not in self.neighbours
             or self.neighbours[nghb_id] != loaded_nghbs[nghb_id]
         ]

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -54,7 +54,7 @@ class IQM:
         elif authority_type == "mqtt":
             self.authority = its_iqm.authority.mqtt.Authority(self.cfg, self.update_cb)
         else:
-            raise ValueError(f"unknown central authority type {central_type}")
+            raise ValueError(f"unknown central authority type {authority_type}")
 
     def run_forever(self):
         self.neighbours = dict()

--- a/python/its-interqueuemanager/its_iqm/main.py
+++ b/python/its-interqueuemanager/its_iqm/main.py
@@ -27,6 +27,7 @@ DEFAULTS = {
     "authority": {
         "type": "file",
         "path": "/etc/its/neighbours.cfg",
+        "reload": 60,
         "username": None,
         "password": None,
         "client_id": None,

--- a/python/its-interqueuemanager/its_iqm/mqtt_client.py
+++ b/python/its-interqueuemanager/its_iqm/mqtt_client.py
@@ -20,9 +20,9 @@ class MQTTClient:
     def __init__(
         self,
         name: str,
-        host: str,
-        port: int,
-        socket: str,
+        host: typing.Union[str, None],
+        port: typing.Union[int, None],
+        socket: typing.Union[str, None],
         username: typing.Union[str, None],
         password: typing.Union[str, None],
         client_id: str,

--- a/python/its-interqueuemanager/its_iqm/mqtt_client.py
+++ b/python/its-interqueuemanager/its_iqm/mqtt_client.py
@@ -10,10 +10,10 @@ import re
 
 try:
     import paho_socket
-
-    paho_socket_available = True
 except ModuleNotFoundError:
     paho_socket_available = False
+else:
+    paho_socket_available = True
 
 
 class MQTTClient:

--- a/python/its-interqueuemanager/its_iqm/mqtt_client.py
+++ b/python/its-interqueuemanager/its_iqm/mqtt_client.py
@@ -83,7 +83,7 @@ class MQTTClient:
         else:
             self.client.connect_async(
                 host=self.host,
-                port=int(self.port),
+                port=self.port,
                 clean_start=True,
             )
 

--- a/python/its-interqueuemanager/its_iqm/mqtt_client.py
+++ b/python/its-interqueuemanager/its_iqm/mqtt_client.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 import logging
 import paho.mqtt.client
-import re
 
 try:
     import paho_socket
@@ -27,8 +26,6 @@ class MQTTClient:
         password: typing.Union[str, None],
         client_id: str,
         local_qm: typing.Union[MQTTClient, None],
-        prefix: typing.Union[str, None],
-        suffix: typing.Union[str, None],
         copy_from: str,
         copy_to: list[str],
     ):
@@ -37,10 +34,7 @@ class MQTTClient:
         self.port = port
         self.socket = socket
         self.local_qm = local_qm
-        self.prefix = prefix
-        self.suffix = suffix
         self.copy_from = copy_from
-        self.re = re.compile(rf"(^|/){copy_from}/")
         self.copy_to = copy_to
 
         if self.socket:
@@ -55,14 +49,10 @@ class MQTTClient:
             raise LookupError(
                 "Either host and port, or socket-path, are required for local MQTT client"
             )
-        logging.info(f"[{self.name}]: create to {self.path}")
 
-        self.topic_root = str()
-        if self.prefix is not None:  # can be an empty string for a /-rooted queue
-            self.topic_root += f"{self.prefix}/"
-        self.topic_root += f"{self.copy_from}"
-        if self.suffix:  # can *not* be an empty string
-            self.topic_root += f"/{self.suffix}"
+        logging.info(
+            f"[{self.name}]: create to {self.path}, listening on {self.copy_from}"
+        )
 
         self.connected = False
         self.client = (paho_socket.Client if self.socket else paho.mqtt.client.Client)(
@@ -117,17 +107,18 @@ class MQTTClient:
         logging.debug(
             f"[{self.name}]: received message on {message.topic}: {abbrev(message.payload)}"
         )
+        interqueue_topic = message.topic
         for cp_to in self.copy_to:
-            topic = self.re.sub(rf"\1{cp_to}/", message.topic, count=1)
-            logging.debug(f"[{self.name}]:  -> forwarding to {topic}")
-            (self.local_qm or self).publish(topic, message.payload)
+            new_topic = cp_to + interqueue_topic[len(self.copy_from) :]
+            logging.debug(f"[{self.name}]:  -> forwarding to {new_topic}")
+            (self.local_qm or self).publish(new_topic, message.payload)
 
     def __on_connect(self, _client, _userdata, _flags, _rc, _properties=None):
         logging.info(f"[{self.name}]: connected to {self.path}")
         # For neighbours, we'll eventually restrict that to sub-quad-keys,
         # but for now, we subscribe to the whole of the sub-tree. For the
         # local broker, we will always want to listen to the full sub-tree.
-        topic = self.topic_root + "/#"
+        topic = self.copy_from + "/#"
         self.client.subscribe(topic)
         logging.debug(f"[{self.name}]: subscribed to {topic}")
         self.connected = True

--- a/python/its-interqueuemanager/its_iqm/mqtt_client.py
+++ b/python/its-interqueuemanager/its_iqm/mqtt_client.py
@@ -119,6 +119,7 @@ class MQTTClient:
         )
         for cp_to in self.copy_to:
             topic = self.re.sub(rf"\1{cp_to}/", message.topic, count=1)
+            logging.debug(f"[{self.name}]:  -> forwarding to {topic}")
             (self.local_qm or self).publish(topic, message.payload)
 
     def __on_connect(self, _client, _userdata, _flags, _rc, _properties=None):

--- a/python/its-interqueuemanager/neighbours.cfg
+++ b/python/its-interqueuemanager/neighbours.cfg
@@ -11,7 +11,7 @@ host = france-42.geoserver.its.eu
 #  - TCP port the MQTT broker listens on (non-TLS)
 port = 1883
 #  - MQTT username and password to authenticate as against
-#    the MQTT broker; do not empty for no authentication
+#    the MQTT broker; for no authentication, do not set.
 username = login
 password = secret
 #  - queue to listen on and copy from

--- a/python/its-interqueuemanager/neighbours.cfg
+++ b/python/its-interqueuemanager/neighbours.cfg
@@ -1,4 +1,4 @@
-# All fields are mandatory
+# Unless otherwise stated, all fields are mandatory
 
 # ID of the neighbour as section name
 [france-42]
@@ -14,8 +14,13 @@ port = 1883
 #    the MQTT broker; for no authentication, do not set.
 username = login
 password = secret
+#  - prefix to queue names, can be an empty string for /-rooted queues;
+#    optional, default: use the IQM's prefix
+prefix = 5GCroCo
 #  - queue to listen on and copy from
 queue = interQueue
+#  - suffix to queue names; optional, default: use the IQM's suffix
+suffix = v2x
 
 [germany-27]
 type = mqtt

--- a/python/its-interqueuemanager/neighbours.json
+++ b/python/its-interqueuemanager/neighbours.json
@@ -1,0 +1,18 @@
+{
+  "france-42": {
+    "type": "mqtt",
+    "host": "france-42.geoserver.its.eu",
+    "port": 1883,
+    "username": "login",
+    "password": "secret",
+    "prefix": "RGCroCo",
+    "queue": "interQueue",
+    "suffix": "v2x"
+  },
+  "germany-27": {
+    "type": "mqtt",
+    "host": "1.2.3.4",
+    "port": 1883,
+    "queue": "backOutQueue"
+  }
+}

--- a/python/its-interqueuemanager/setup.py
+++ b/python/its-interqueuemanager/setup.py
@@ -32,6 +32,7 @@ setup(
     platforms="LINUX",
     install_requires=[
         "paho-mqtt==1.6.1",
+        "requests",
     ],
     entry_points={"console_scripts": ["its-iqm = its_iqm.main:main"]},
 )


### PR DESCRIPTION
**Changes:**

- closes #103 
- closes #107
- preemptive fixups in MQTT authority client
- code reorganisation
- coding style cleanups

---
**How to test:**

Note: you'll need an MQTT broker that allows anonymous connections, listening on port 1883 on local host. To display the traffic on the broker, start a mosquitto client (`%t` displays the topic, `%p` the payload): `mosquitto_sub -t '#' -F '%t %p'`

1. Build and install its-iqm:
    ```sh
    $ pip3 install .
    ```
   Note the installation path (e.g. /home/login/.local/bin).
2. Prepare configuration files:
   1. the `iqm.cfg` configuration file:
    ```ini
    [general]
    instance-id = iqm-1
    prefix = 5G-root
    suffix = v2x
    [local]
    host = 127.0.0.1
    port = 1883
    [authority]
    type = file
    reload = 5
    path = neighbours.cfg
    [neighbours]
    client_id = neighbour-1
    ```
   2. the `neighbours.cfg.tmp` configuration file (note the extension `.tmp`):
    ```ini
    [neighbour-1]
    type = mqtt
    host = 127.0.0.1
    port = 1883
    prefix = other-pfx
    suffix = other-sfx
    queue = other-queue
    ```
3. Start the IQM with the above configuration, in debug mode:
    ```sh
    $ /home/login/.local/bin/its-iqm --debug -c iqm.cfg
    ```
4. Send a message on the local _inQueue_, and on the neighbour's _interQueue_:
    ```sh
    $ mosquitto_pub -t '5G-root/inQueue/v2x/cam/0/1/2/3' -m '{"type": "cam", "source": "local"}'
    $ mosquitto_pub -t 'other-pfx/other-queue/other-sfx/cam/0/1/2/3' -m '{"type": "cam", "source": "remote"}'
    ```
5. Tell the IQM about its neighbour:
    ```sh
    $ cp neighbours.cfg.tmp neighbours.cfg
    ```
6. Send a message on the local _inQueue_, and on the neighbour's _interQueue_:
    ```sh
    $ mosquitto_pub -t '5G-root/inQueue/v2x/cam/0/1/2/3' -m '{"type": "cam", "source": "local"}'
    $ mosquitto_pub -t 'other-pfx/other-queue/other-sfx/cam/0/1/2/3' -m '{"type": "cam", "source": "remote"}'
    ```
7. Change the neighbour configuration (e.g. change its suffix):
    ```sh
    $ sed -r -i -e 's/suffix =.*/suffix = yadayada/; s/queue = .*/queue = couic/' neighbours.cfg
    ```
8. Send a message on the local _inQueue_, and on the neighbour's new _interQueue_:
    ```sh
    $ mosquitto_pub -t '5G-root/inQueue/v2x/cam/0/1/2/3' -m '{"type": "cam", "source": "local"}'
    $ mosquitto_pub -t 'other-pfx/couic/yadayada/cam/0/1/2/3' -m '{"type": "cam", "source": "remote"}'
    ```
9. remove the neighbour:
    ```sh
    $ rm neighbours.cfg
    ```
10. Send a message on the local _inQueue_, and on the neighbour's new _interQueue_:
    ```sh
    $ mosquitto_pub -t '5G-root/inQueue/v2x/cam/0/1/2/3' -m '{"type": "cam", "source": "local"}'
    $ mosquitto_pub -t 'other-pfx/couic/yadayada/cam/0/1/2/3' -m '{"type": "cam", "source": "remote"}'
    ```
11. Stop the IQM, by typing `Ctrl-C`.
12. Configure the IQM to use an MQTT central authority:
    1. the `iqm.cfg` configuration file:
        ```ini
        [general]
        instance-id = iqm-1
        prefix = 5G-root
        suffix = v2x
        [local]
        host = 127.0.0.1
        port = 1883
        [authority]
        type = mqtt
        host = 127.0.0.1
        port = 1883
        client_id = iqm-1-central
        topic = 5G-root/neighbours/iqm-1-central
        [neighbours]
        client_id = neighbour-1
        ```
    2. the `neighbours.json` configuration file:
        ```json
        {
          "neighbour-1": {
            "type": "mqtt",
            "host": "127.0.0.1",
            "port": 1883,
            "prefix": "other-pfx",
            "suffix": "other-sfx",
            "queue": "other-queue"
          }
        }
        ```
13. Start the IQM with the above configuration, in debug mode:
    ```sh
    $ /home/login/.local/bin/its-iqm --debug -c iqm.cfg
    ```
14. Send the neighbours configuration:
    ```sh
    $ mosquitto_pub -t 5G-root/neighbours/iqm-1-central -f neighbours.json
    ```
15. Send an empty neighbours configuration:
    ```sh
    $ mosquitto_pub -t 5G-root/neighbours/iqm-1-central -m '{}'
    ```
16. Stop the IQM, by typing `Ctrl-C`.

---
**Expected results:**

1. its-iqm has been installed.
2. The configuration files are ready and available in the current directory.
3. The IQM is running, and reports loading _0 neighbour(s)_.
4. The local CAM is forwarded to the local `outQueue` and `interQueue`, the remote CAM is not forwarded:
    ```
    5G-root/inQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/interQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    other-pfx/other-queue/other-sfx/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    ```
5. The IQM reports loading _1 neighbour(s)_, and report subscribing to topic `other-pfx/interQueue/other-sfx/#`.
6. The local CAM is forwarded to the local `outQueue` and `interQueue`, the remote CAM is forwarded to the local `outQueue`:
    ```
    5G-root/inQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/interQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    other-pfx/other-queue/other-sfx/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    ```
7. The IQM reports loading _1 neighbour(s)_, and stops and starts the neighbour on the new topic `other-pfx/couic/yadayada/#`.
8. The local CAM is forwarded to the local `outQueue` and `interQueue`, the remote CAM is forwarded to the local `outQueue`:
    ```
    5G-root/inQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/interQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    other-pfx/couic/yadayada/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    ```
9. The IQM reports loading _0 neighbour(s)_, and stops the previous neighbour.
10. The local CAM is forwarded to the local `outQueue` and `interQueue`, the remote CAM is not forwarded:
    ```
    5G-root/inQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/outQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    5G-root/interQueue/v2x/cam/0/1/2/3 {"type": "cam", "source": "local"}
    other-pfx/couic/yadayada/cam/0/1/2/3 {"type": "cam", "source": "remote"}
    ```
11. The IQM stops.
12. The configuration files are ready and available in the current directory.
13. The IQM is running, and does not report anything about loading any neighbours.
14. The IQM reports receiving and loading _1 neighbour(s)_, and starts subscribing to the expected topic:
    ```
    2024-02-21 09:38:56,361 mqtt: received neighbours
    2024-02-21 09:38:56,362 mqtt: loaded 1 neighbour(s)
    2024-02-21 09:38:56,362 iqm: stopping old neighbours (if any)...
    2024-02-21 09:38:56,362 iqm: starting new neighbours (if any)...
    2024-02-21 09:38:56,362 iqm: creating qm for neighbour-1
    2024-02-21 09:38:56,362 mqtt_client: [neighbour-1]: create to 127.0.0.1:1883, listening on other-pfx/other-queue/other-sfx
    2024-02-21 09:38:56,362 mqtt_client: [neighbour-1]: starting for 127.0.0.1:1883
    2024-02-21 09:38:56,363 mqtt_client: [neighbour-1]: connected to 127.0.0.1:1883
    2024-02-21 09:38:56,364 mqtt_client: [neighbour-1]: subscribed to other-pfx/other-queue/other-sfx/#
    ```
15. The IQM reports receiving and loading _0 neighbour(s)_, and stops the previous neighbour.
16. The IQM stops.