### PR TITLE
rust: remove Ord impl for GeoExtension

### DIFF
--- a/rust/libits-client/src/mqtt/topic/geo_extension.rs
+++ b/rust/libits-client/src/mqtt/topic/geo_extension.rs
@@ -17,7 +17,7 @@ pub struct GeoExtension {
     pub(crate) tiles: Vec<Tile>,
 }
 
-#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
 pub(crate) enum Tile {
     Zero = 0,
     One = 1,
@@ -90,10 +90,6 @@ impl GeoExtension {
             ..Default::default()
         }
     }
-
-    fn len(&self) -> usize {
-        self.tiles.len()
-    }
 }
 
 impl str::FromStr for GeoExtension {
@@ -144,39 +140,6 @@ impl fmt::Display for GeoExtension {
     }
 }
 
-impl Ord for GeoExtension {
-    fn cmp(&self, other: &Self) -> Ordering {
-        let matching = self
-            .tiles
-            .iter()
-            .zip(other.tiles.iter())
-            .filter(|&(myself, other)| myself == other)
-            .count();
-
-        if self.len() == matching {
-            if self.len() == other.len() {
-                Ordering::Equal
-            } else {
-                Ordering::Greater
-            }
-        } else if other.len() == matching {
-            Ordering::Less
-        } else if self.len() == other.len() {
-            if let Some(self_significant) = self.tiles.get(matching) {
-                if let Some(other_significant) = other.tiles.get(matching) {
-                    return match self_significant.partial_cmp(other_significant) {
-                        Some(ordering) => ordering,
-                        None => Ordering::Equal,
-                    };
-                }
-            }
-            Ordering::Equal
-        } else {
-            self.len().cmp(&other.len())
-        }
-    }
-}
-
 impl PartialOrd for GeoExtension {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let matching = self
@@ -206,7 +169,7 @@ impl PartialOrd for GeoExtension {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Ordering::{Equal, Greater, Less};
+    use std::cmp::Ordering::{Greater, Less};
     use std::str::FromStr;
 
     use crate::mqtt::topic::geo_extension::{GeoExtension, Tile};
@@ -450,27 +413,10 @@ mod tests {
     }
 
     #[test]
-    fn test_equal_geo_extensions_are_equal() {
-        let twin_1 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1");
-        let twin_2 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1");
-
-        assert_eq!(twin_1.partial_cmp(&twin_2), Some(Equal));
-        assert_eq!(twin_1.cmp(&twin_2), Equal);
-    }
-
-    #[test]
     fn test_same_length_but_not_siblings_are_not_partially_ordered() {
         let linas = create_geo_extension("1/2/0/2/2/2/2/3/3/0/0/3/2/0/2/0/1/0/1/0/3/1");
         let barcelona = create_geo_extension("1/2/0/2/2/0/0/1/1/2/0/3/1/0/2/1/0/1/2/1/0/3");
         assert_eq!(linas.partial_cmp(&barcelona), None);
-    }
-
-    #[test]
-    fn test_same_length_but_not_siblings_are_ordered() {
-        let linas = create_geo_extension("1/2/0/2/2/2/2/3/3/0/0/3/2/0/2/0/1/0/1/0/3/1");
-        let barcelona = create_geo_extension("1/2/0/2/2/0/0/1/1/2/0/3/1/0/2/1/0/1/2/1/0/3");
-
-        assert_eq!(linas.cmp(&barcelona), Less);
     }
 
     #[test]
@@ -498,37 +444,11 @@ mod tests {
     }
 
     #[test]
-    fn test_siblings_are_ordered() {
-        let sibling_0 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/0");
-        let sibling_1 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1");
-        let sibling_2 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/2");
-        let sibling_3 = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/3");
-
-        assert_eq!(sibling_0.cmp(&sibling_1), Less);
-        assert_eq!(sibling_0.cmp(&sibling_2), Less);
-        assert_eq!(sibling_0.cmp(&sibling_3), Less);
-
-        assert_eq!(sibling_1.cmp(&sibling_0), Greater);
-        assert_eq!(sibling_1.cmp(&sibling_2), Less);
-        assert_eq!(sibling_1.cmp(&sibling_3), Less);
-
-        assert_eq!(sibling_2.cmp(&sibling_0), Greater);
-        assert_eq!(sibling_2.cmp(&sibling_1), Greater);
-        assert_eq!(sibling_2.cmp(&sibling_3), Less);
-
-        assert_eq!(sibling_3.cmp(&sibling_0), Greater);
-        assert_eq!(sibling_3.cmp(&sibling_1), Greater);
-        assert_eq!(sibling_3.cmp(&sibling_2), Greater);
-    }
-
-    #[test]
     fn test_deeper_is_lesser() {
         let less_deep = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0");
         let deeper = create_geo_extension("0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1/2/3/0/1");
 
         assert_eq!(less_deep.partial_cmp(&deeper), Some(Greater));
         assert_eq!(deeper.partial_cmp(&less_deep), Some(Less));
-        assert_eq!(less_deep.cmp(&deeper), Greater);
-        assert_eq!(deeper.cmp(&less_deep), Less);
     }
 }


### PR DESCRIPTION
What's new
---------------

* rust: GeoExtension struct no longer impl Ord
          Both Ord and PartialOrd were defining different behaviours
          While this was initially done intentionally the Ord implementation is no longer required and has been remove as it reduce the risk of confusion

Related to #101 

How to test
---------------

1. Run the copycat example 
    ```
    cargo run --bin its-client -- -H 90.84.199.250 -P 11883 -u <username> -p <password> --mqtt-client-id ora_copycat
    ```
    **=> You must received and send CAM messages**