### PR TITLE
python: implement IoT3 Core SDK

### DIFF
--- a/python/iot3/LICENSE
+++ b/python/iot3/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2024 Yann E. MORIN <yann.morin@orange.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice (including the
+next paragraph) shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/python/iot3/README.md
+++ b/python/iot3/README.md
@@ -1,0 +1,1 @@
+iot3 provides an abstraction of IoT3 for easy manipulation in Python.

--- a/python/iot3/pyproject.toml
+++ b/python/iot3/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
+    "paho-mqtt>=2.1.0",
 ]
 
 [project.urls]

--- a/python/iot3/pyproject.toml
+++ b/python/iot3/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "paho-mqtt>=2.1.0",
+    "requests>=2.31.0",
 ]
 
 [project.urls]

--- a/python/iot3/pyproject.toml
+++ b/python/iot3/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=65.5.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "iot3"
+version = "0.0.1"
+authors = [
+  { name="Yann E. MORIN", email="yann.morin@orange.com" },
+]
+description = "IoT3 SDK"
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Development Status :: 4 - Beta",
+]
+dependencies = [
+]
+
+[project.urls]
+"Homepage" = "https://github.com/Orange-OpenSource/its-client"
+"Bug Tracker" = "https://github.com/Orange-OpenSource/its-client/issues"

--- a/python/iot3/src/iot3/core/__init__.py
+++ b/python/iot3/src/iot3/core/__init__.py
@@ -1,0 +1,211 @@
+# Software Name: iot3
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import time as _time
+from typing import Any as _Any
+from typing import Callable as _Callable
+from typing import Optional as _Optional
+from typing import TypeAlias as _TypeAlias
+from . import mqtt as _mqtt
+from . import otel as _otel
+
+"""
+This module provides a simple API wrapping MQTT and OpenTelemetry.
+
+The simple API consists in a few functions and a type annotation:
+
+* Functions:
+  * start(): start the MQTT and the OpenTelemetry clients
+  * ready(): return whether the MQTT client is ready
+  * wait_for_ready(): endlessly loop until ready() returns True
+  * publish(): send an MQTT message
+  * subscribe(): subscribe to one or more topics
+  * stop(): stop the MQTT and OpenTelemetry clients
+
+* Type annotation:
+  * MsgCallbackType: the type annotation of a function called when an
+                     MQTT message is received; the first argument will
+                     be the value passed to start() as data_callback,
+                     the second argument will be the topic the message
+                     was received on, the third argument will be the
+                     payload of the message; the function shall only
+                     return None (but any returned value is ignored).
+
+The simple API also provides a single object that is a sample of a basic
+configuration, which can be used as a template and adpated to a local
+setup.
+"""
+
+
+sample_config = {
+    "mqtt": {
+        "host": "localhost",
+        "port": 1883,
+        "client-id": "mqtt-client-id",
+        "username": "mqtt-user",
+        "password": "mqtt-secret",
+    },
+    "otel": {
+        "service_name": "my-service",
+        "endpoint": "http://localhost:4318",
+        "auth": "basic",
+        "username": "otel-user",
+        "password": "otel-secret",
+        "batch_period": 5,
+        "max_backlog": 100,
+        "compression": "gzip",
+    },
+}
+
+
+MsgCallbackType: _TypeAlias = _Callable[[_Any, str, bytes], None]
+
+
+def start(
+    *,
+    config: dict,
+    message_callback: _Optional[MsgCallbackType] = None,
+    callback_data: _Any = None,
+) -> None:
+    """Start the IoT3 Core SDK.
+
+    :param config: The SDK configuration.
+    :param message_callback: The function to call when a message is
+                             received; when called, the first argument
+                             will be callback_data, the second will be
+                             the topic the mesage was received on, and
+                             the third and last argument will be the
+                             message payload.
+    :param callback_data: The data to pass as first argument to
+                          message_callback(), above.
+    """
+    global _core
+
+    if _core is not None:
+        raise RuntimeError("IoT3 Core SDK already intialised.")
+
+    o_kwargs = dict()
+
+    for auth in _otel.Auth:
+        if config["otel"]["auth"] == auth.value:
+            o_kwargs["auth"] = auth
+            if auth != otel.Auth.NONE:
+                o_kwargs["username"] = config["otel"]["username"]
+                o_kwargs["password"] = config["otel"]["password"]
+            break
+    else:
+        raise ValueError(f"unknown authentication {config['otel']['auth']}")
+
+    for comp in _otel.Compression:
+        if config["otel"]["compression"] == comp.value:
+            o_kwargs["compression"] = comp
+            break
+    else:
+        raise ValueError(f"unknown compression {config['otel']['compression']}")
+
+    o = _otel.Otel(
+        service_name=config["otel"]["service_name"],
+        endpoint=config["otel"]["endpoint"],
+        batch_period=config["otel"]["batch_period"],
+        max_backlog=config["otel"]["max_backlog"],
+        **o_kwargs,
+    )
+    o.start()
+
+    # Wrap the callback to avoid leaking telemetry into the simple API
+    def _msg_cb(*, data, topic, payload, **_kwargs):
+        message_callback(data, topic, payload)
+
+    m = _mqtt.MqttClient(
+        client_id=config["mqtt"]["client-id"],
+        host=config["mqtt"]["host"],
+        port=config["mqtt"]["port"],
+        username=config["mqtt"]["username"],
+        password=config["mqtt"]["password"],
+        msg_cb=_msg_cb if message_callback else None,
+        msg_cb_data=callback_data,
+        span_ctxmgr_cb=o.span,
+    )
+    m.start()
+
+    _core = dict([("otel", o), ("mqtt", m)])
+
+
+def stop():
+    """Stop the Iot3 Core SDK."""
+    global _core
+
+    if _core is None:
+        raise RuntimeError("IoT3 Core SDK not initialised.")
+
+    _core["mqtt"].stop()
+    _core["otel"].stop()
+    _core = None
+
+
+def is_ready() -> bool:
+    """Checks whether the IoT3 Core SDK is ready.
+
+    The IoT3 Core SDK is ready when the MQTT client is connected to
+    the MQTT broker. Messages sent when the SDK is not ready, are
+    lost without notice.
+    """
+    global _core
+
+    if _core is None:
+        raise RuntimeError("IoT3 Core SDK not initialised.")
+
+    return _core["mqtt"].is_ready()
+
+
+def wait_for_ready():
+    """Wait until the IoT2 Core SDK is ready.
+
+    Beware that this may take an indeterminate amount of time; in
+    case the MQTT client can't connect at all, wait_for_ready()
+    will wait forever and never return.
+    """
+    while True:
+        if is_ready():
+            break
+        _time.sleep(0.1)
+
+
+def publish(
+    topic: str,
+    payload: str | bytes,
+):
+    """Send an MQTT message
+
+    "param topic: The MQTT topic on which to send the message.
+    :param payload: The payload of the MQTT message to send.
+    """
+    global _core
+
+    if _core is None:
+        raise RuntimeError("IoT3 Core SDK not initialised.")
+
+    _core["mqtt"].publish(topic=topic, payload=payload)
+
+
+def subscribe(
+    topics: str | list[str],
+):
+    """Subscribe to a list of MQTT topics.
+
+    If a subscription already existed, it is entirely replaced.
+
+    :param topics: A topic, or a list of topics.
+    """
+    global _core
+
+    if _core is None:
+        raise RuntimeError("IoT3 Core SDK not initialised.")
+
+    topics = topics if isinstance(topics, list) else [topics]
+    _core["mqtt"].subscribe_replace(topics=topics)
+
+
+_core = None

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -1,0 +1,209 @@
+# Software Name: iot3
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import paho.mqtt.client
+import paho.mqtt.enums
+import threading
+import time
+from typing import Any, Callable, Optional, TypeAlias
+
+
+MsgCallbackType: TypeAlias = Callable[[Any, str, bytes], None]
+
+
+class MqttClient:
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        socket_path: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        msg_cb: Optional[MsgCallbackType] = None,
+        msg_cb_data: Any = None,
+    ):
+        """
+        Create an MQTT client
+
+        :param client_id: The MQT client ID to identify as.
+        :param host: The host name (or IP) of the MQTT broker.
+        :param port: The port the MQTT broker listens on.
+        :param socket_path: The path of the UNIX socket.
+        :param username: The username to authenticate against the MQTT broker.
+        :param password: The password to authenticate against the MQTT broker.
+        :param msg_cb: The function to call when a message is received from
+                       the MQTT broker.
+        :param msg_cb_data: Arbitrary data that will be passed back to the
+                            msg_cb function.
+        """
+
+        self.msg_cb = msg_cb
+        self.msg_cb_data = msg_cb_data
+
+        if socket_path is not None:
+            transport = "unix"
+            self.host = socket_path
+            self.port = -1
+            self.name = socket_path
+        else:
+            transport = "tcp"
+            self.host = host
+            self.port = port
+            self.name = f"{host}:{port}"
+
+        self.client = paho.mqtt.client.Client(
+            callback_api_version=paho.mqtt.enums.CallbackAPIVersion.VERSION2,
+            client_id=client_id,
+            protocol=paho.mqtt.client.MQTTv5,
+            transport=transport,
+        )
+        self.client.reconnect_delay_set(min_delay=1, max_delay=2)
+        self.client.username_pw_set(username, password)
+        self.client.on_connect = self.__on_connect
+        self.client.on_message = self.__on_message
+
+        self.subscriptions = set()
+        self.subscriptions_lock = threading.RLock()
+
+    def start(self):
+        """Start the MQTT client"""
+        self.client.connect_async(
+            host=self.host,
+            port=self.port,
+            clean_start=True,
+        )
+        self.client.loop_start()
+
+    def is_ready(self):
+        """Returns whether the MQTT client is ready.
+
+        The client is ready when it is connected to the MQTT broker.
+        """
+        return self.client.is_connected()
+
+    def wait_for_ready(self):
+        """Wait for the client to be ready.
+
+        This can block forever.
+        """
+        while not self.client.is_connected():
+            time.sleep(0.1)
+
+    def stop(self):
+        """Stop the MQTT client"""
+        self.client.disconnect()
+        self.client.loop_stop()
+
+    def publish(self, *, topic: str, payload: bytes | str):
+        """Publish an MQTT message
+
+        :param topic: The MQTT topic to post on.
+        :param payload: The payload to post.
+        """
+        if not self.client.is_connected():
+            return
+        self.client.publish(topic=topic, payload=payload)
+
+    def subscribe(self, *, topics: list[str]):
+        """Subscribe to additional topics.
+
+        :param topics: The list of additional topics to subscribe to. It is OK to
+                       pass topics that were previously subscribed to.
+        """
+        if self.msg_cb is None:
+            raise RuntimeError(
+                f"MQTT client {self.name}: subscribing without a message callback",
+            )
+        topics = set(topics)
+        with self.subscriptions_lock:
+            sub = topics.difference(self.subscriptions)
+            if sub and self.client.is_connected():
+                self.client.subscribe(list(map(lambda t: (t, 0), sub)))
+            self.subscriptions.update(topics)
+
+    def subscribe_replace(self, *, topics: list[str]):
+        """Replace the existing subscriptions with the new list.
+
+        This is equivalent to calling in sequence:
+            unsubscribe_all()
+            subscribe(topics)
+
+        except that subscribe_replace(topics) is atomic.
+
+        :param topics: The list of topics to subscribe to, in replacement to
+                       any previously subscribed topics. It is OK to pass
+                       topics that were previously subscribed to.
+        """
+        if self.msg_cb is None:
+            raise RuntimeError(
+                f"MQTT client {self.name}: subscribing without a message callback",
+            )
+        topics = set(topics)
+        with self.subscriptions_lock:
+            if self.client.is_connected():
+                unsub = self.subscriptions.difference(topics)
+                sub = topics.difference(self.subscriptions)
+                if unsub:
+                    self.client.unsubscribe(list(unsub))
+                if sub:
+                    self.client.subscribe(list(map(lambda t: (t, 0), sub)))
+            self.subscriptions.clear()
+            self.subscriptions.update(topics)
+
+    def unsubscribe(self, *, topics: list[str]):
+        """Unsubscribe from a list of topics.
+
+        :param topics: The list of topics to remove from the current
+                       subscription set. It is OK to pass topics that were
+                       not previously subscribed to.
+        """
+        topics = set(topics)
+        with self.subscriptions_lock:
+            unsub = topics.intersection(self.subscriptions)
+            if unsub and self.client.is_connected():
+                self.client.unsubscribe(list(unsub))
+            self.subscriptions.difference_update(topics)
+
+    def unsubscribe_all(self):
+        """Unsubscribe from all topics"""
+        # We _can_ lock here even if unsubscribe() also locks by itself,
+        # because this is a RLock, i.e. a reentrant lock.
+        # We _must_ lock here, to avoid another thread from changing
+        # self.subscriptions between here and the locking in
+        # unsubscribe().
+        with self.subscriptions_lock:
+            self.unsubscribe(self.subscriptions)
+
+    # In theory, we would not need this method, as we could very well
+    # have set   self.client.on_message = msg_cb   and be done with
+    # that. Having this intermediate __on_message() will help with
+    # telemetry when we add it.
+    def __on_message(
+        self,
+        _client,
+        _userdata,
+        message: paho.mqtt.client.MQTTMessage,
+    ):
+        self.msg_cb(
+            self.msg_cb_data,
+            message.topic,
+            message.payload,
+        )
+
+    def __on_connect(
+        self,
+        _client,
+        _userdata,
+        _connect_flags,
+        _rc,
+        _properties=None,
+    ):
+        with self.subscriptions_lock:
+            if self.subscriptions:
+                self.client.subscribe(
+                    list(map(lambda t: (t, 0), self.subscriptions)),
+                )

--- a/python/iot3/src/iot3/core/otel.py
+++ b/python/iot3/src/iot3/core/otel.py
@@ -1,0 +1,494 @@
+# Software Name: iot3
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+"""This module implements a lightweight, very limited subset of the
+OpenTelemetry protocol. Only Spans (for traces) and the JSON-over-HTTP
+exporter are supported, both with limitations.
+"""
+
+import base64
+import contextlib
+import enum
+import json
+import queue
+import random
+import requests
+import threading
+import time
+import zlib
+from typing import Optional, Self
+
+
+class SpanKind(enum.IntEnum):
+    # We need those values to *exactly* match those defined in the spec,
+    # so we must not use enum.auto(). This is an enum.IntEnum (rather
+    # than just an enum.Enum) because we want them to be comparable to
+    # an actual int() (in case a caller needs to test it against a span
+    # kind from another implementation).
+    INTERNAL = 1
+    SERVER = 2
+    CLIENT = 3
+    PRODUCER = 4
+    CONSUMER = 5
+
+
+class SpanStatus(enum.IntEnum):
+    # We need those values to *exactly* match those defined in the spec,
+    # so we must not use enum.auto(). This is an enum.IntEnum (rather
+    # than just an enum.Enum) because we want them to be comparable to
+    # an actual int() (in case a caller needs to test it against a span
+    # status from another implementation).
+    UNSET = 0
+    OK = 1
+    ERROR = 2
+
+
+class Compression(enum.StrEnum):
+    NONE = enum.auto()
+    GZIP = enum.auto()
+
+
+class Auth(enum.StrEnum):
+    NONE = enum.auto()
+    BASIC = enum.auto()
+    DIGEST = enum.auto()
+
+
+class Otel(threading.Thread):
+    """Lightweight implementation of an OpenTelemetry exporter.
+
+    This is only able to export spans as application/json, to an HTTP
+    OTLP collector.
+    """
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        endpoint: str,
+        auth: Optional[Auth] = Auth.NONE,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        batch_period: Optional[float] = None,
+        max_backlog: Optional[int] = None,
+        compression: Optional[Compression] = Compression.NONE,
+    ):
+        """
+        Simple span exporter
+
+        Exports spans to an OpenTelemetry collector, using JSON over HTTP.
+
+        Either or both of batch_period and max_backlog must be specified to
+        a non-zero value. When only batch_period is non-zero, then spans are
+        only sent periodically, every batch_period seconds. When only
+        max_backlog is non-zero, then spans are only sent when that many have
+        accumulated. When both are non-zero, then spans are sent periodically
+        and as soon as max_backlog spans have accumulated, whichever occurs
+        first. If max_backlog is provided, then this is also the maximum number
+        of spans that are kept if they can't be exported to the collector, for
+        a later export tentative.
+
+        Note: failure to call stop() before terminating, risk losing any
+        pending spans not yet exported.
+
+        :param service_name: The name of the service.
+        :param endpoint: The URL to the OTLP collector (without the trailing
+                         /v1/traces).
+        :param auth: Type of HTTP authentication to employ.
+        :param username: Username to use for authentication to the collector.
+        :param password: Password to use for authentication to the collector.
+        :param batch_period: Send spans every so often, in seconds.
+        :param max_backlog: Send spans as soon as that many have accumulated.
+                            This is also the maximum number of spans that are
+                            kept if they can't be sent to the collector.
+        :param compression: Type of compression, if any, to use to compress
+                            the payload; the default is no compression.
+        """
+
+        self.service_name = service_name
+        self.endpoint = endpoint
+        if self.endpoint.endswith("/"):
+            self.endpoint = self.endpoint[:-1]
+
+        if auth == Auth.NONE:
+            self.auth = None
+        else:
+            if not username and not password:
+                raise ValueError(f"{auth.name} needs both username and password")
+            if auth == Auth.BASIC:
+                self.auth = (username, password)
+            else:
+                self.auth = requests.auth.HTTPDigestAuth(username, password)
+
+        if batch_period or max_backlog:
+            self.batch_period = batch_period
+            self.max_backlog = max_backlog
+        else:
+            raise ValueError(
+                (
+                    "either or both of batch_period and/or max_backlog"
+                    + " must be specified as a non-zero value"
+                )
+            )
+
+        self.compression = compression
+
+        self.spans = list()
+        self.shutdown = False
+        self.queue = queue.SimpleQueue()
+        self.tls = threading.local()
+
+        super().__init__(
+            name="otel-client",
+            target=self._run,
+            daemon=True,
+        )
+
+    def export_span(self, *, span: "Span"):
+        """Enqeue the given span for exporting.
+
+        The span will be exported, subject to batch_period and max_backlog
+        as passed to __init__().
+
+        :param span: The span to export.
+        """
+        # Note: if queued after stop(), span will ultimately be ignored
+        self.queue.put(span)
+
+    @contextlib.contextmanager
+    def span(self, *args, **kwargs) -> "Span":
+        """Context manager that wraps a Span().
+
+        span() has the same signature as Span().
+
+        span() automatically makes the new span a child of the current
+        span, if any, makes the new span the current span, finalises and
+        exports the new span, and then restore the previous current
+        span.
+
+        If the parent_span argument is not specified, span() automatically
+        handles the parent-child relationship of the new span and any
+        current span, if any. If parent_span is specified and is a Span(),
+        this is used as the span to use as a parent.
+        """
+
+        try:
+            current_span = self.tls.spans[-1]
+        except AttributeError:
+            self.tls.spans = list()
+        except IndexError:
+            pass
+        else:
+            if "parent_span" not in kwargs:
+                kwargs["parent_span"] = current_span
+
+        s = Span(*args, **kwargs)
+        try:
+            self.tls.spans.append(s)
+            yield s
+        finally:
+            s.finalise()
+            self.export_span(span=s)
+            self.tls.spans.pop()
+
+    @staticmethod
+    @contextlib.contextmanager
+    def noexport_span(*args, **kwargs) -> "Span":
+        """Context manager that provides a span that is not exported
+
+        This simplifies coding when no telemetry is needed, by providing
+        a way to write the code only once.
+
+        See otel.span() and Span() for signature.
+        """
+        try:
+            yield NoExportSpan(*args, **kwargs)
+        finally:
+            pass
+
+    def stop(self):
+        """Stop the exporter thread; export pending spans, if any."""
+        self.shutdown = True
+        self.queue.put(Otel._Quit())
+        self.join()
+
+    class _Quit:
+        pass
+
+    def _run(self):
+        prev_timeout = self.batch_period
+        while True:
+            try:
+                if self.batch_period:
+                    # This does not provide a perfect next-expiration delay for
+                    # a precise period, but over the long run, that will make
+                    # for slightly jittered expiration delays, all centered
+                    # around the requested period. Which is good enough.
+                    timeout = self.batch_period - (time.time() % self.batch_period)
+                    # Did we miss a period? Then don't wait!
+                    # Note that there is still a corner case, where we did miss
+                    # a period *and* we got resumed after more than a multiple
+                    # of the period has elapsed. This is considered so
+                    # improbable that we simply ignore that (for now).
+                    block = not (timeout > prev_timeout)
+                else:
+                    timeout = None
+                    block = True
+                span = self.queue.get(block=block, timeout=timeout)
+                prev_timeout = timeout or self.batch_period
+            except queue.Empty:
+                # queue.Empty is only raised when we do have a batch_period
+                # in which case it means we timed out, and we're going to start
+                # a new period.
+                prev_timeout = self.batch_period
+                self._send()
+                continue
+            if type(span) is Otel._Quit:
+                self._send()
+                break
+            self.spans.append(span)
+            if self.max_backlog and len(self.spans) >= self.max_backlog:
+                self._send()
+
+    def _send(self):
+        if not self.spans:
+            return
+
+        report = {
+            "resourceSpans": [
+                {
+                    "resource": {
+                        "attributes": [
+                            {
+                                "key": "service.name",
+                                "value": {
+                                    "stringValue": self.service_name,
+                                },
+                            },
+                        ],
+                    },
+                    "scopeSpans": [
+                        {
+                            "scope": {
+                                "name": "report",
+                            },
+                            "spans": [],
+                        }
+                    ],
+                },
+            ],
+        }
+        report["resourceSpans"][0]["scopeSpans"][0]["spans"] = [
+            span.to_dict() for span in self.spans
+        ]
+
+        data = json.dumps(report, separators=(",", ":"))
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self.compression == Compression.GZIP:
+            headers["Content-Encoding"] = self.compression.value
+            # zlib.compress() is faster than gzip.compress();
+            # 31 = 15 + 16: window size is 2^15 + output has a gzip header.
+            # ==> https://docs.python.org/3/library/gzip.html#gzip.compress
+            # ==> https://docs.python.org/3/library/zlib.html#zlib.compress
+            data = zlib.compress(data.encode(), level=9, wbits=31)
+
+        try:
+            r = requests.post(
+                self.endpoint + "/v1/traces",
+                auth=self.auth,
+                headers=headers,
+                data=data,
+            )
+        except:
+            # Failed to send spans, keep them until next try
+            pass
+        else:
+            # if we could send the spans, start afresh
+            if r.ok:
+                self.spans = list()
+        finally:
+            # In any case, only keep a limited backlog
+            if self.max_backlog:
+                self.spans = self.spans[-self.max_backlog :]
+
+
+class Span:
+    """Implements a minimalist span.
+
+    Prefer using the Otel.span() context manager, as it will
+    automatically handle the parent/child relationship, and
+    finalise and export the span.
+    """
+
+    _ATTRIBUTES_MAPPING = {
+        bool: {"type": "boolValue", "encode": lambda x: x},
+        bytes: {
+            "type": "bytesValue",
+            "encode": lambda x: base64.b64encode(x).decode("ascii"),
+        },
+        float: {"type": "doubleValue", "encode": lambda x: x},
+        int: {"type": "intValue", "encode": lambda x: x},
+        str: {"type": "stringValue", "encode": lambda x: x},
+    }
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        kind: Optional[SpanKind] = SpanKind.INTERNAL,
+        parent_span: Optional[Self] = None,
+        span_links: Optional[list[Self | str]] = None,
+    ):
+        """Basic span.
+
+        :param name: Name of the span.
+        :param kind: Kind of span.
+        :param parent_span: Make the new span a child of parent_span.
+        :param span_links: Link the new span to the spans in this list; each
+                           item in the list can be either a Span(), or an str()
+                           representing a traceparent.
+        """
+        self.name = name
+        self.kind = kind
+        self.start_time = time.time()
+        if parent_span:
+            self.trace_id = parent_span.trace_id
+            self.parent_id = parent_span.span_id
+        else:
+            self.trace_id = random.randbytes(16).hex()
+            self.parent_id = None
+        self.span_id = random.randbytes(8).hex()
+        self.attributes = dict()
+        self.links = list()
+        if span_links:
+            for span in span_links:
+                self.add_link(link=span)
+        self.status_code = SpanStatus.UNSET
+        self.status_message = None
+
+    def finalise(self):
+        """Finalise the span (i.e. set end time)."""
+        self.end_time = time.time()
+
+    def set_attribute(self, *, key, value):
+        """Set or add an atribute
+
+        Only bool, int, float, and string values are accepted.
+
+        :param key: The key (aka name) of the attribute.
+        :param value: The value of the attribute.
+        """
+        if type(value) not in Span._ATTRIBUTES_MAPPING:
+            raise ValueError(
+                f"{value!r} is not one of: {', '.join([k.__name__ for k in Span._ATTRIBUTES_MAPPING])}",
+            )
+        self.attributes[key] = value
+
+    def add_link(
+        self,
+        *,
+        link: Self | str,
+    ):
+        """Add a link from this span to the specified traceparent.
+
+        :param link: The Span() or the str() of the traceparent to link to.
+        """
+        if type(link) is Span:
+            trace_id = link.trace_id
+            span_id = link.span_id
+        else:
+            trace_id = link.split("-")[1]
+            span_id = link.split("-")[2]
+        self.links.append(
+            {
+                "trace_id": trace_id,
+                "span_id": span_id,
+            }
+        )
+
+    def set_status(
+        self,
+        *,
+        status_code: SpanStatus,
+        status_message: Optional[str] = None,
+    ):
+        self.status_code = status_code
+        self.status_message = status_message
+
+    def to_dict(self):
+        """Convert the span to a dict with key valid to the OTLP spec."""
+        # The spec at: https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
+        # is ambiguous. It states:
+        #   """
+        #   The keys of JSON objects are field names converted to lowerCamelCase.
+        #   Original field names are not valid to use as keys for JSON objects.
+        #   For example, this is a valid JSON representation of a Resource:
+        #       { "attributes": {...}, "droppedAttributesCount": 123 },
+        #   and this is NOT a valid representation:
+        #       { "attributes": {...}, "dropped_attributes_count": 123 }.
+        #   """
+        # It is not obivous whether that applies when the data is sent as
+        # application/json, or as application/x-protobuf, or both.
+        # However, when tested against the official Docker image (as of 2024-07-12)
+        # otel/opentelemetry-collector:latest, snake_case identifiers are *also*
+        # accepted when sent as application/json.
+        #
+        # The start and end UNIX timestamp are to be expressed as an integral
+        # number os nanoseconds serialized as a string. Again, passing an int()
+        # or a str() both work with the official collector.
+        #
+        # Let's try to match the spec for now, until proven wrong...
+        span = {
+            "name": self.name,
+            "traceId": self.trace_id,
+            "spanId": self.span_id,
+            "kind": self.kind.value,
+            "parentSpanId": self.parent_id,
+            "startTimeUnixNano": str(int(self.start_time * 1_000_000_000)),
+            "endTimeUnixNano": str(int(self.end_time * 1_000_000_000)),
+        }
+        if self.attributes:
+            span["attributes"] = list()
+            for attr in self.attributes:
+                attr_value = self.attributes[attr]
+                attr_map = Span._ATTRIBUTES_MAPPING[type(attr_value)]
+                span["attributes"].append(
+                    {
+                        "key": attr,
+                        "value": {
+                            attr_map["type"]: attr_map["encode"](attr_value),
+                        },
+                    },
+                )
+        if self.links:
+            span["links"] = list()
+            for link in self.links:
+                span["links"].append(
+                    {
+                        "traceId": link["trace_id"],
+                        "spanId": link["span_id"],
+                    },
+                )
+        if self.status_code != SpanStatus.UNSET:
+            span["status"] = {"code": self.status_code.value}
+            if self.status_code == SpanStatus.ERROR and self.status_message:
+                span["status"]["message"] = self.status_message
+        return span
+
+    def to_traceparent(self):
+        """Return a traceparent that refers to the span."""
+        return f"00-{self.trace_id}-{self.span_id}-00"
+
+
+class NoExportSpan(Span):
+    """A fake span when no telemetry is used"""
+
+    def to_dict(self):
+        return None
+
+    def to_traceparent(self):
+        return None

--- a/python/iot3/tests/test-iot3-core
+++ b/python/iot3/tests/test-iot3-core
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import iot3.core
+import time
+
+def recv(data, topic, payload):
+    print(f"{topic[:16]}: {payload[:16]}")
+
+iot3.core.start(
+    config=iot3.core.sample_config,
+    message_callback=recv,
+)
+
+iot3.core.wait_for_ready()
+
+iot3.core.subscribe("#")
+
+iot3.core.publish("foo/bar/dropped", "dropped")
+time.sleep(1)
+
+iot3.core.publish("foo/bar/passed", "passed")
+time.sleep(1)
+
+iot3.core.stop()

--- a/python/iot3/tests/test-iot3-core-all
+++ b/python/iot3/tests/test-iot3-core-all
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import iot3.core.mqtt
+import iot3.core.otel
+import time
+
+def recv(data, topic, payload):
+    print(f"{topic[:16]}: {payload[:16]}")
+
+o = iot3.core.otel.Otel(
+    service_name="test-service",
+    endpoint="http://localhost:4318",
+    batch_period=1,
+)
+o.start()
+
+c = iot3.core.mqtt.MqttClient(
+    client_id="test",
+    host="127.0.0.1",
+    port=1883,
+    span_ctxmgr_cb=o.span,
+    msg_cb=recv,
+)
+c.start()
+
+c.subscribe(topics=["#"])
+
+c.publish(topic='foo/bar/dropped', payload="dropped")
+time.sleep(1)
+
+c.publish(topic='foo/bar/passed', payload="passed")
+time.sleep(1)
+
+c.stop()
+o.stop()

--- a/python/iot3/tests/test-iot3-core-mqtt
+++ b/python/iot3/tests/test-iot3-core-mqtt
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import iot3.core.mqtt
+import time
+
+
+def recv(data, topic, payload):
+    print(f"{topic[:16]}: {payload[:16]}")
+
+
+c = iot3.core.mqtt.MqttClient(
+    client_id="test",
+    host="127.0.0.1",
+    port=1883,
+    msg_cb=recv,
+)
+c.start()
+
+c.subscribe(topics=["#"])
+c.wait_for_ready()
+c.publish(topic='foo/bar', payload="pouet")
+
+time.sleep(1)
+
+c.stop()

--- a/python/iot3/tests/test-iot3-core-otel
+++ b/python/iot3/tests/test-iot3-core-otel
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import iot3.core.otel
+import os
+import sys
+import time
+
+
+o = iot3.core.otel.Otel(
+    service_name="test-service",
+    endpoint="http://localhost:4318",
+    batch_period=15,
+    max_backlog=15,
+)
+o.start()
+
+with o.span(name="Root span") as s0:
+    time.sleep(0.1)
+    with o.span(name="Explicit child span level 1", parent_span=s0) as s1:
+        time.sleep(0.1)
+        with o.span(name="Automatic child span level 2") as s2:
+            time.sleep(0.1)
+        with o.span(name="Explicit child span level 2 missed", parent_span=s0) as s3:
+            time.sleep(0.1)
+    with o.span(name="Automatic child span level 1") as s4:
+        time.sleep(0.1)
+    with o.span(name="Automatic child span level 1 - failed") as s5:
+        s5.set_status(
+            status_code=iot3.core.otel.SpanStatus.ERROR,
+            status_message="Some failure"
+        )
+        time.sleep(0.1)
+    time.sleep(0.1)
+
+with o.span(name="Root span with link", span_links=[s0]) as s10:
+    time.sleep(0.1)
+
+o.stop()


### PR DESCRIPTION
---
**Features**;

* Implement IoT3 Core SDK:
  * MQTT client
  * OpenTelemetry client
  * telemetry sent for MQTT messages

Closes: #123
Closes: #122

---
**How to test**

1. Prepare an OpenTelemetry collector on localhost:
    ```
    $ docker container run \
        --rm \
        -p 16686:16686 \
        -p 4318:4318 \
        jaegertracing/all-in-one:1.58
    ```
    then open a browser on the Jaegger UI:
    ```
    http://localhost:16686/
    ```
2. Prepare an MQTT broker on localhost (adapt based on your distribution):
    ```sh
    $ sudo systemctl start mosquitto.service
    ```
    and then start an MQTT client to dump the messages on the broker:
    ```
    $ mosquitto_sub -V 5 -t '#' -F '%j' |jq .
    ```
3. Test IoT3 Core SDK:
    1. start an environment with python 3.11:
        ```sh
        $ docker container run \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            --entrypoint /bin/bash \
            python:3.11.9-slim-bookworm
        ```
    2. create a /venv/ in a writable location, and activate it:
        ```sh
        (docker) python3 -m venv /tmp/iot3
        (docker) . /tmp/iot3/bin/activate
        ```
    3. install the IoT3 Core SDK (notice the trailing dot `.`):
        ```sh
        (docker) pip3 --disable-pip-version-check install .
        ```
    4. Run the MQTT-only test:
        ```sh
        (docker) ./tests/test-iot3-core-mqtt
        ```
    5. Run the OpenTelemetry-only test:
        ```sh
        (docker) ./tests/test-iot3-core-otel
        ```
        then, in Jaegger, search for the traces for the `test-service`
        service.
    6. Run the MQTT with OpenTelemetry test:
        ```sh
        (docker) ./tests/test-iot3-core-all
        ```
        then, in Jaegger, search for the traces for the `test-service`
        service.
    7. Run the simple API test:
        ```sh
        (docker) ./tests/test-iot3-core
        ```
        then, in Jaegger, search for the traces for the `my-service`
        service.

---
**Expected results:**

1. The Jaegger UI is displayed in your browser
2. The mosquitto server is running
3. The IoT3 Core SDK works;
    1. the docker container runs
    2. the python /venv/ is created and activated
    3. the IoT3 Core SDK is installed
    4. the MQTT message is dumped by /mosquitto_sub/:
        ```json
        {
          "tst": "2024-07-31T13:27:08.106723Z+0200",
          "topic": "foo/bar",
          "qos": 0,
          "retain": 0,
          "payloadlen": 5,
          "payload": "pouet"
        }
        ```
    5. the Jaegger UI finds two traces:
        * one with 6 spans, of which the last one is in error, reporting /Some failure/
        * one with a single span, which has a link to the root span
          of the first trace, above
    6. the MQTT message is dumped by /mosquitto_sub/:
        ```json
        {
          "tst": "2024-07-31T13:42:33.339973Z+0200",
          "topic": "foo/bar/passed",
          "qos": 0,
          "retain": 0,
          "payloadlen": 6,
          "properties": {
            "user-properties": {
              "traceparent": "00-cb2e0b60496eca82dfb9420006759aff-ec4169b906b4a5cd-00"
            }
          },
          "payload": "passed"
        }
        ```
        then Jaegger UI finds three new traces, all with a single span:
        * the first is for the failed publish, and has a span:
            * of kind `producer`
            * with attributes:
                * `test.iot3.core.mqtt.action=publish`
                * `test.iot3.core.mqtt.topic=foo/bar/dropped`
            * with an error status reporting /The client is not currently connected./
        * the second is for the sucessful publish, and has a span:
            * of kind `producer`
            * with attributes:
                * `test.iot3.core.mqtt.action=publish`
                * `test.iot3.core.mqtt.topic=foo/bar/passed`
            * with an unset status
        * the third is for the receive, and has a span:
            * of kind `consumer`
            * with attributes:
                * `test.iot3.core.mqtt.action=receive`
                * `test.iot3.core.mqtt.topic=foo/bar/passed`
            * with an unset status
            * with a link to the span of the second trace, above
    7. the results are similar to those of step 6, above
