### PR TITLE
python/its-quadkeys: fix neighbouring for nothern and southern borders

### DIFF
--- a/python/its-quadkeys/its_quadkeys/quadkeys.py
+++ b/python/its-quadkeys/its_quadkeys/quadkeys.py
@@ -114,38 +114,58 @@ class QuadKey(str):
 
         Returns None if this QuadKey is the Northern-most QuadKey.
         """
-        return QuadKey(QuadKey.__north_of_s(self.quadkey))
+        qk = QuadKey.__north_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def south_of(self):
         """Returns the QuadKey South of, and at the same depth as this QuadKey.
 
         Returns None if this QuadKey is the Southern-most QuadKey.
         """
-        return QuadKey(QuadKey.__south_of_s(self.quadkey))
+        qk = QuadKey.__south_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def east_of(self):
         """Returns the QuadKey East of, and at the same depth as this QuadKey."""
+        # There is always a QuadKey to the east.
         return QuadKey(QuadKey.__east_of_s(self.quadkey))
 
     def west_of(self):
         """Returns the QuadKey West of, and at the same depth as this QuadKey."""
+        # There is always a QuadKey to the west.
         return QuadKey(QuadKey.__west_of_s(self.quadkey))
 
     def north_west_of(self):
-        """Returns the QuadKey North-West of, and at the same depth as this QuadKey."""
-        return QuadKey(QuadKey.__north_west_of_s(self.quadkey))
+        """Returns the QuadKey North-West of, and at the same depth as this QuadKey.
+
+        Returns None if this QuadKey is the Northern-most QuadKey.
+        """
+        qk = QuadKey.__north_west_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def north_east_of(self):
-        """Returns the QuadKey North-East of, and at the same depth as this QuadKey."""
-        return QuadKey(QuadKey.__north_east_of_s(self.quadkey))
+        """Returns the QuadKey North-East of, and at the same depth as this QuadKey.
+
+        Returns None if this QuadKey is the Northern-most QuadKey.
+        """
+        qk = QuadKey.__north_east_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def south_west_of(self):
-        """Returns the QuadKey South-West of, and at the same depth as this QuadKey."""
-        return QuadKey(QuadKey.__south_west_of_s(self.quadkey))
+        """Returns the QuadKey South-West of, and at the same depth as this QuadKey.
+
+        Returns None if this QuadKey is the Southern-most QuadKey.
+        """
+        qk = QuadKey.__south_west_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def south_east_of(self):
-        """Returns the QuadKey South-East of, and at the same depth as this QuadKey."""
-        return QuadKey(QuadKey.__south_east_of_s(self.quadkey))
+        """Returns the QuadKey South-East of, and at the same depth as this QuadKey.
+
+        Returns None if this QuadKey is the Southern-most QuadKey.
+        """
+        qk = QuadKey.__south_east_of_s(self.quadkey)
+        return QuadKey(qk) if qk else None
 
     def neighbours(self, *, as_zone: bool = False):
         """Return the QuadKeys neighbouring this QuadKey

--- a/python/its-quadkeys/its_quadkeys/quadkeys.py
+++ b/python/its-quadkeys/its_quadkeys/quadkeys.py
@@ -454,16 +454,19 @@ class QuadZone:
                 # its neighbours to the requested depth. If they are
                 # already the correct depth, expanding will do nothing.
                 for q in nghbs:
-                    all_nghbs.add(q.make_shallower(depth))
+                    if q is not None:
+                        all_nghbs.add(q.make_shallower(depth))
             else:
                 # If the QuadKey is shallower than the requested depth,
                 # we need to split it down to the correct depth, and
                 # keep only the border-most QuadKeys, for each type of
                 # borders.
                 for card in nghbs._asdict():
-                    root = getattr(nghbs, card).to_str()
-                    for tail in _mk_tail_s(card, depth=depth - quadkey.depth()):
-                        all_nghbs.add(QuadKey(root + tail))
+                    q = getattr(nghbs, card)
+                    if q is not None:
+                        root = q.to_str()
+                        for tail in _mk_tail_s(card, depth=depth - quadkey.depth()):
+                            all_nghbs.add(QuadKey(root + tail))
 
         final_nghbs = QuadZone()
         for quadkey in all_nghbs:

--- a/python/its-quadkeys/quadkeys-test
+++ b/python/its-quadkeys/quadkeys-test
@@ -33,6 +33,17 @@ def test_quadkey():
         "S": "12030231",
         "SE": "12030320",
     }
+    expected_nghbs_0 = {
+        # Neighbours for QuadKey "0"
+        "NW": None,
+        "N": None,
+        "NE": None,
+        "W": "1",
+        "E": "1",
+        "SW": "3",
+        "S": "2",
+        "SE": "3",
+    }
     """
     this is the split QuadKey
     """
@@ -128,6 +139,14 @@ def test_quadkey():
     if nghbs._asdict() != expected_nghbs:
         raise FailedError(
             f"{ {k:(str(getattr(nghbs,k)),expected_nghbs[k]) for k in nghbs._asdict() if getattr(nghbs,k) != expected_nghbs[k]} }"
+        )
+    print("OK")
+
+    print("QuadKey partial neighbours: ", end="", flush=True)
+    nghbs = its_quadkeys.QuadKey('0').neighbours()
+    if nghbs._asdict() != expected_nghbs_0:
+        raise FailedError(
+            f"{ {k:(str(getattr(nghbs,k)),expected_nghbs_0[k]) for k in nghbs._asdict() if getattr(nghbs,k) != expected_nghbs_0[k]} }"
         )
     print("OK")
 

--- a/python/its-quadkeys/quadkeys-test
+++ b/python/its-quadkeys/quadkeys-test
@@ -420,13 +420,15 @@ def test_quadzone():
 
 
 def check_zone(some, expected):
-    some_l = list(some)
-    expected_l = list(expected)
+    some_l = list([str(qk) for qk in some])
+    expected_l = list([str(qk) for qk in expected])
     z_miss = sorted([qk for qk in expected_l if qk not in some_l])
-    z_extra = sorted([str(qk) for qk in some_l if qk not in expected_l])
+    z_extra = sorted([qk for qk in some_l if qk not in expected_l])
     if z_miss or z_extra:
-        raise FailedError(
-            f"{len(z_miss)} missing: {z_miss}, {len(z_extra)} extra: {z_extra}"
+        raise FailedError((
+            f"{len(z_miss)} missing: {z_miss}, {len(z_extra)} extra: {z_extra}",
+            f"Got {some_l}",
+            f"Expected {expected_l}")
         )
 
 
@@ -435,5 +437,7 @@ if __name__ == "__main__":
         test_quadkey()
         test_quadzone()
     except FailedError as e:
-        print(f"KO: {e.args[0]}")
+        print(f"KO:")
+        for arg in e.args[0]:
+            print(arg)
         sys.exit(1)

--- a/python/its-quadkeys/quadkeys-test
+++ b/python/its-quadkeys/quadkeys-test
@@ -103,7 +103,7 @@ def test_quadkey():
     print(f"QuadKey split (extra_depth): ", end="", flush=True)
     qk_split_z = qk.split(extra_depth=2)
     check_zone(qk_split_z, expected_split_z_2)
-    print(f"OK")
+    print("OK")
 
     print(f"QuadKey shallower: ", end="", flush=True)
     for depth, expected in expected_shallowers:
@@ -112,7 +112,7 @@ def test_quadkey():
             raise FailedError(
                 f"with QuadKey '{qk}' for depth {depth}, expecting '{expected}', got '{qk_shallow}'"
             )
-    print(f"OK")
+    print("OK")
 
     print(f"QuadKey root: ", end="", flush=True)
     for qk_s, expected in expected_roots:
@@ -129,7 +129,7 @@ def test_quadkey():
         raise FailedError(
             f"{ {k:(str(getattr(nghbs,k)),expected_nghbs[k]) for k in nghbs._asdict() if getattr(nghbs,k) != expected_nghbs[k]} }"
         )
-    print(f"OK")
+    print("OK")
 
     print(f"QuadKey from lat/lon/depth: ", end="", flush=True)
     qk = its_quadkeys.QuadKey((43.63516355648167, 1.3744570239910097, 22))
@@ -137,7 +137,7 @@ def test_quadkey():
         raise FailedError(
             f"[43.63516355648167, 1.3744570239910097, 22] => '{qk.to_str('')}'"
         )
-    print(f"OK")
+    print("OK")
 
 
 def test_quadzone():

--- a/python/its-quadkeys/quadkeys-test
+++ b/python/its-quadkeys/quadkeys-test
@@ -437,6 +437,11 @@ def test_quadzone():
     check_zone(earth2, earth)
     print("OK")
 
+    print("Quadzone Whole-Earth neighbours: ", end="", flush=True)
+    earth_nghbs = earth.neighbours(depth=1)
+    check_zone(earth_nghbs, its_quadkeys.QuadZone())
+    print("OK")
+
 
 def check_zone(some, expected):
     some_l = list([str(qk) for qk in some])


### PR DESCRIPTION
**Bug fix:**

Fixes: #147 

---
**How to test:**

1. Install the requirements (you may do so in a _venv_):
    ```sh
    $ cd python/its-quadkeys
    $ pip3 install -r requirements.txt
    ```
2. Run the regression test suite (in the same _venv_ as step 1 if you used one):
    ```sh
    $ ./quadkeys-test
    ```

---
**Expected results:**

1. The requirements are installed.
2. There is no failure in the test suite.