### PR TITLE
Rust sdk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,49 @@ jobs:
         run: |
           cd rust
           cargo build --release --verbose
-      - name: Run tests
+      - name: mobility feature build
+        run: |
+          cd rust
+          cargo build --features mobility --verbose
+      - name: telemetry feature build
+        run: |
+          cd rust
+          cargo build --features telemetry --verbose
+      - name: geo_routing feature build
+        run: |
+          cd rust
+          cargo build --features geo_routing --verbose
+      - name: Build all features
+        run: |
+          cd rust
+          cargo build --all-features --verbose
+      - name: Release build all features
+        run: |
+          cd rust
+          cargo build --all-features --release --verbose
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: No features
         run: |
           cd rust
           cargo test --verbose
+      - name: mobility feature test
+        run: |
+          cd rust
+          cargo test --features mobility --verbose
+      - name: telemetry feature test
+        run: |
+          cd rust
+          cargo test --features telemetry --verbose
+      - name: geo_routing feature test
+        run: |
+          cd rust
+          cargo test --features geo_routing --verbose
+      - name: All feature
+        run: |
+          cd rust
+          cargo test --all-features --verbose

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -115,6 +115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +138,39 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -179,6 +218,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,9 +279,21 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -576,6 +672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,10 +699,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
@@ -649,6 +770,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -820,6 +956,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1036,17 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -891,10 +1057,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -965,6 +1197,12 @@ checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -1040,10 +1278,16 @@ dependencies = [
  "enum_dispatch",
  "flexi_logger",
  "geo",
+ "http 1.1.0",
  "integer-sqrt",
  "lazy_static",
  "log",
  "map_3d",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "reqwest",
  "rumqttc",
  "rust-ini",
  "serde",
@@ -1061,6 +1305,12 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1085,10 +1335,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fc1b6107fbd06c96e5e481fcf3e6575b873eb84f5b68f1f5706cde0fed42c4"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1108,6 +1370,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1167,10 +1446,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -1222,6 +1628,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1658,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
@@ -1280,6 +1712,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1347,7 +1802,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -1378,6 +1833,46 @@ name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "ring"
@@ -1421,10 +1916,10 @@ dependencies = [
  "bytes",
  "flume",
  "futures-util",
- "http",
+ "http 1.1.0",
  "log",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "rustls-webpki",
  "thiserror",
  "tokio",
@@ -1458,6 +1953,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,10 +1986,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1490,7 +2007,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -1510,6 +2027,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -1547,7 +2070,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1613,12 +2136,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1735,6 +2270,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1860,6 +2434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2452,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1880,6 +2474,89 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
 ]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2",
+ "http 0.2.12",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -1913,6 +2590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +2604,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.1.0",
  "httparse",
  "log",
  "rand",
@@ -1990,6 +2673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,6 +2692,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2034,6 +2732,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2233,6 +2943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ws_stream_tungstenite"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,7 +2960,7 @@ checksum = "a198f414f083fb19fcc1bffcb0fa0cf46d33ccfa229adf248cac12c180e91609"
 dependencies = [
  "async-tungstenite",
  "async_io_stream",
- "bitflags",
+ "bitflags 2.5.0",
  "futures-core",
  "futures-io",
  "futures-sink",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -83,3 +83,4 @@ features = ["async", "compress"]
 [[bench]]
 name = "position"
 harness = false
+required-features = ["mobility"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,6 +41,7 @@ required-features = ["geo_routing"]
 crossbeam-channel = "0.5"
 enum_dispatch = "0.3"
 geo = "0.27"
+http = "1.1"
 integer-sqrt = "0.1"
 log = "0.4"
 map_3d = "0.1"
@@ -53,6 +54,24 @@ threadpool = "1.8"
 [dependencies.rumqttc]
 version = "0.24"
 features = ["websocket"]
+
+[dependencies.opentelemetry]
+version = "0.23"
+
+[dependencies.opentelemetry-http]
+version = "0.12"
+features = ["reqwest"]
+
+[dependencies.opentelemetry-otlp]
+version = "0.16"
+features = ["trace", "http-proto"]
+
+[dependencies.opentelemetry_sdk]
+version = "0.23"
+features = ["trace", "rt-tokio"]
+
+[dependencies.reqwest]
+version = "0.11"
 
 [dependencies.serde]
 version = "1.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,10 @@ telemetry = []
 name = "copycat"
 required-features = ["geo_routing"]
 
+[[example]]
+name = "telemetry"
+required-features = ["telemetry"]
+
 [dependencies]
 crossbeam-channel = "0.5"
 enum_dispatch = "0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ crate-type = ["lib"]
 [features]
 mobility = []
 geo_routing = ["mobility"]
+telemetry = []
 
 [[example]]
 name = "copycat"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,7 +30,8 @@ edition = "2021"
 crate-type = ["lib"]
 
 [features]
-geo_routing = []
+mobility = []
+geo_routing = ["mobility"]
 
 [[example]]
 name = "copycat"

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,6 +13,19 @@ Examples
 By default, all example logs into `./log/<example>_rCURRENT.log`
 You can inspect the logs using `tail -F log/its-client_rCURRENT.log`
 
+### json_counter
+
+Subscribes to `test.mosquitto.org` and yields how much messages were received and the number of them that had JSON payload
+
+```
+cargo run --example json_counter
+```
+
+Logs are redirected to a file
+```
+tail -F log/json_counter_rCURRENT.log
+```
+
 ### copycat
 
 Subscribes to ITS CAM and CPM messages, stores them and sends a copy 3 seconds later

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -3,11 +3,11 @@ id="ora_opensource"
 type="mec_application"
 
 [mqtt]
-host="its-platform.com"
-port=11883
-client_id="ora_copycat"
-username="geo"
-password="geo"
+host="test.mosquitto.org"
+port=1884
+client_id="com_orange_example"
+username="rw"
+password="readwrite"
 use_tls=false
 use_websocket=false
 

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -15,6 +15,14 @@ use_websocket=false
 responsibility_enabled=true
 thread_count=4
 
+;[telemetry]
+;host=otlp.domain.ext
+;port=4318
+; Optional, defaults to 'v1/traces'
+;path=custom/v1/traces
+; Optional, defaults to 2048
+;max_batch_size=10
+
 [log]
 level="debug"
 folder="log"

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -5,7 +5,7 @@ type="mec_application"
 [mqtt]
 host="test.mosquitto.org"
 port=1884
-client_id="com_orange_example"
+client_id="com_orange_its-client"
 username="rw"
 password="readwrite"
 use_tls=false

--- a/rust/examples/json_counter.rs
+++ b/rust/examples/json_counter.rs
@@ -1,0 +1,164 @@
+/*
+ * Software Name : libits
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
+ */
+
+use std::any::Any;
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::path::Path;
+use std::str::FromStr;
+
+use clap::{Arg, Command};
+use flexi_logger::{with_thread, Cleanup, Criterion, Logger, Naming, WriteMode};
+use ini::Ini;
+use libits::client::configuration::Configuration;
+use libits::transport::mqtt::mqtt_client::MqttClient;
+use libits::transport::mqtt::mqtt_router::MqttRouter;
+use libits::transport::mqtt::topic::Topic;
+use log::{error, info};
+use rumqttc::v5::mqttbytes::v5::Publish;
+
+#[derive(Clone, Default, Debug, Hash, PartialEq, Eq)]
+struct StrTopic {
+    topic: String,
+}
+impl Display for StrTopic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.topic)
+    }
+}
+impl FromStr for StrTopic {
+    type Err = std::str::Utf8Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StrTopic {
+            topic: String::from(s),
+        })
+    }
+}
+impl Topic for StrTopic {
+    fn as_route(&self) -> String {
+        String::from("no_routing")
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let matches = Command::new("ITS CopyCat client")
+        .version("0.1.0")
+        .author("Nicolas Buffon <nicolas.buffon@orange.com>")
+        .about("MQTT example counting message that contain JSON payload")
+        .arg(
+            Arg::new("config-file-path")
+                .short('c')
+                .long("config")
+                .default_value("examples/config.ini")
+                .value_name("CONFIG_FILE_PATH")
+                .help("Path to the configuration file"),
+        )
+        .get_matches();
+
+    let mut configuration = Configuration::try_from(
+        Ini::load_from_file(Path::new(
+            matches.get_one::<String>("config-file-path").unwrap(),
+        ))
+        .expect("Failed to load config file as Ini"),
+    )
+    .expect("Failed to create Configuration from loaded Ini");
+
+    let log_path = &configuration
+        .get::<String>(Some("log"), "path")
+        .unwrap_or("log".to_string());
+    let log_path = Path::new(log_path);
+    if !log_path.is_dir() {
+        if let Err(error) = fs::create_dir(log_path) {
+            panic!("Unable to create the log directory: {}", error);
+        }
+    }
+    let _logger = match Logger::try_with_env_or_str("info") {
+        Ok(logger) => {
+            match logger
+                .log_to_stdout()
+                .write_mode(WriteMode::Async)
+                .format_for_files(with_thread)
+                .append()
+                .rotate(
+                    Criterion::Size(2_000_000),
+                    Naming::Timestamps,
+                    Cleanup::KeepLogAndCompressedFiles(5, 30),
+                )
+                .print_message()
+                .start()
+            {
+                Ok(logger_handle) => {
+                    info!("logger ready on {}", log_path.to_str().unwrap());
+                    logger_handle
+                }
+                Err(error) => panic!("Logger starting failed with {:?}", error),
+            }
+        }
+        Err(error) => panic!("Logger initialization failed with {:?}", error),
+    };
+
+    configuration
+        .mqtt_options
+        .set_max_packet_size(Some(256_000));
+
+    let (mut client, mut event_loop) = MqttClient::new(&configuration.mqtt_options);
+    let mut router = MqttRouter::default();
+
+    router.add_route(
+        StrTopic::from_str("#").unwrap(),
+        |publish: Publish| -> Option<Box<dyn Any + Send + 'static>> {
+            if let Ok(payload) = std::str::from_utf8(publish.payload.as_ref()) {
+                if serde_json::from_str::<String>(payload).is_ok() {
+                    Some(Box::new(Ok::<(), &'static str>(())))
+                } else {
+                    Some(Box::new(Err::<(), &'static str>(
+                        "Failed to parse payload as JSON",
+                    )))
+                }
+            } else {
+                Some(Box::new(Err::<(), &'static str>(
+                    "Failed to parse payload as UTF-8",
+                )))
+            }
+        },
+    );
+
+    client.subscribe(&["#".to_string()]).await;
+
+    let mut total: u128 = 0;
+    let mut json: u128 = 0;
+
+    loop {
+        match event_loop.poll().await {
+            Ok(event) => {
+                if let Some((_, result)) = router.handle_event::<StrTopic>(event) {
+                    let result = result.downcast::<Result<(), &'static str>>();
+                    if result.is_ok() {
+                        json += 1;
+                    }
+                }
+                total += 1;
+
+                if total % 1000 == 0 {
+                    println!("Received {} messages including {} as JSON", total, json);
+                }
+            }
+            Err(e) => {
+                error!("Connection error received: {:?}", e);
+                info!("Exiting...");
+                break;
+            }
+        }
+    }
+}

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -21,7 +21,7 @@ use ini::Ini;
 use log::{info, warn};
 use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
 use opentelemetry::trace::{mark_span_as_active, TraceContextExt};
-use opentelemetry::Context;
+use opentelemetry::{global, Context};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 
 use libits::client::configuration::Configuration;
@@ -214,4 +214,7 @@ async fn main() {
     if let Err(e) = recv_handle.join() {
         warn!("Listener thread failed to join: {:?}", e)
     }
+
+    // Trace export is batched, shutting down the tracer provider will force the export
+    global::shutdown_tracer_provider();
 }

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -1,0 +1,217 @@
+/*
+ * Software Name : libits
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
+ */
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::path::Path;
+use std::{fs, thread};
+
+use clap::{Arg, Command};
+use flexi_logger::{with_thread, Cleanup, Criterion, FileSpec, Logger, Naming, WriteMode};
+use ini::Ini;
+use log::{info, warn};
+use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
+use opentelemetry::trace::{mark_span_as_active, TraceContextExt};
+use opentelemetry::Context;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+use libits::client::configuration::Configuration;
+use libits::transport::telemetry::{execute_in_span, get_span, init_tracer};
+
+const TRACER_NAME: &str = "telemetry/example";
+
+macro_rules! trace_span_context_info {
+    ($name: expr, $cxt: expr) => {
+        let span = $cxt.span();
+        let span_context = span.span_context();
+        info!(
+            "{: <24} trace_id: {}, span_id: {}",
+            $name,
+            span_context.trace_id(),
+            span_context.span_id()
+        );
+    };
+}
+
+/// Data container that will be used to carry [W3C context][1] to link spans across traces
+///
+/// - See [Injector]
+/// - See [Extractor]
+/// - See [TraceContextPropagator]
+#[derive(Debug, Default)]
+struct Data {
+    dict: HashMap<String, String>,
+}
+impl Injector for Data {
+    fn set(&mut self, key: &str, value: String) {
+        self.dict.set(key, value)
+    }
+}
+impl Extractor for Data {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.dict.get(key).map(|string| string.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.dict.keys().map(|string| string.as_str()).collect()
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let matches = Command::new("Telemetry example")
+        .version("0.1.0")
+        .author("Nicolas Buffon <nicolas.buffon@orange.com>")
+        .about("Sends spans to OTLP collector")
+        .arg(
+            Arg::new("config-file-path")
+                .short('c')
+                .long("config")
+                .default_value("examples/config.ini")
+                .value_name("CONFIG_FILE_PATH")
+                .help("Path to the configuration file"),
+        )
+        .get_matches();
+
+    let configuration = Configuration::try_from(
+        Ini::load_from_file(Path::new(
+            matches.get_one::<String>("config-file-path").unwrap(),
+        ))
+        .expect("Failed to load config file as Ini"),
+    )
+    .expect("Failed to create Configuration from loaded Ini");
+
+    let log_path = &configuration
+        .get::<String>(Some("log"), "path")
+        .unwrap_or("log".to_string());
+    let log_path = Path::new(log_path);
+    if !log_path.is_dir() {
+        if let Err(error) = fs::create_dir(log_path) {
+            panic!("Unable to create the log directory: {}", error);
+        }
+    }
+    let _logger = match Logger::try_with_env_or_str("info") {
+        Ok(logger) => {
+            match logger
+                .log_to_file(FileSpec::default().directory(log_path).suppress_timestamp())
+                .log_to_stdout()
+                .write_mode(WriteMode::Async)
+                .format_for_files(with_thread)
+                .append()
+                .rotate(
+                    Criterion::Size(2_000_000),
+                    Naming::Timestamps,
+                    Cleanup::KeepLogAndCompressedFiles(5, 30),
+                )
+                .print_message()
+                .start()
+            {
+                Ok(logger_handle) => {
+                    info!("logger ready on {}", log_path.to_str().unwrap());
+                    logger_handle
+                }
+                Err(error) => panic!("Logger starting failed with {:?}", error),
+            }
+        }
+        Err(error) => panic!("Logger initialization failed with {:?}", error),
+    };
+
+    init_tracer(&configuration.telemetry, "iot3").expect("Failed to configure telemetry");
+
+    info!("Send a trace with a single span 'ping' root span");
+    let ping_data = execute_in_span(TRACER_NAME, "example/ping", None::<&Data>, || {
+        let context = Context::current();
+        trace_span_context_info!("└─ Ping", context);
+
+        let mut data = Data::default();
+
+        let propagator = TraceContextPropagator::new();
+        propagator.inject(&mut data);
+
+        data
+    });
+
+    info!("Send a trace with a single span 'pong' root span linked with the previous one 'ping'");
+    execute_in_span(TRACER_NAME, "example/pong", Some(&ping_data), || {
+        let context = Context::current();
+        trace_span_context_info!("└─ Pong", context);
+    });
+
+    info!("Send a single trace with two spans");
+    execute_in_span(TRACER_NAME, "example/nested_root", None::<&Data>, || {
+        let context = Context::current();
+        trace_span_context_info!("└─ Root", context);
+
+        execute_in_span(TRACER_NAME, "example/nested_child", None::<&Data>, || {
+            let context = Context::current();
+            trace_span_context_info!("   └─ Child", context);
+        })
+    });
+
+    info!("Send a trace with 3 spans from 3 threads");
+    let root_span = get_span(TRACER_NAME, "main_thread", None::<&Data>);
+    let guard = mark_span_as_active(root_span);
+    let cxt = Context::current();
+    trace_span_context_info!("└─ Main thread", &cxt);
+
+    let (listener_tx, recv_handle) = {
+        let (tx, rx) = crossbeam_channel::unbounded();
+
+        let recv_handle = thread::Builder::new()
+            .name("listener".to_string())
+            .spawn(move || {
+                let cxt: Context = rx.recv().unwrap();
+                let _guard = cxt.attach();
+
+                execute_in_span(TRACER_NAME, "listener_thread", None::<&Data>, || {
+                    let cxt = Context::current();
+                    trace_span_context_info!("   └─ Listener thread", cxt);
+                });
+            })
+            .unwrap();
+
+        (tx, recv_handle)
+    };
+
+    let (send_rx, send_handle) = {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let send_handle = thread::Builder::new()
+            .name("listener".to_string())
+            .spawn(move || {
+                let cxt: Context = rx.recv().unwrap();
+                let _guard = cxt.clone().attach();
+
+                execute_in_span(TRACER_NAME, "sender_thread", None::<&Data>, || {
+                    let inner_cxt = Context::current();
+                    trace_span_context_info!("   ├─ Sender thread", inner_cxt);
+                    listener_tx
+                        .send(cxt)
+                        .expect("Failed to send context through channel");
+                });
+            })
+            .unwrap();
+
+        (tx, send_handle)
+    };
+
+    send_rx
+        .send(cxt)
+        .expect("Failed to send context through channel");
+    drop(guard);
+
+    if let Err(e) = send_handle.join() {
+        warn!("Sender thread failed to join: {:?}", e)
+    }
+    if let Err(e) = recv_handle.join() {
+        warn!("Listener thread failed to join: {:?}", e)
+    }
+}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -10,89 +10,9 @@
  * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
-use crate::client::configuration::Configuration;
-use crate::exchange::etsi::decentralized_environmental_notification_message::{
-    DecentralizedEnvironmentalNotificationMessage, RelevanceDistance, RelevanceTrafficDirection,
-};
-use crate::exchange::etsi::reference_position::ReferencePosition;
-use crate::exchange::etsi::{etsi_now, heading_to_etsi, speed_to_etsi, timestamp_to_etsi};
-use crate::exchange::sequence_number::SequenceNumber;
-use crate::exchange::PathElement;
-use crate::mobility::mobile::Mobile;
-
 /// Structures, functions and traits in this mod are made to create applications that analyze
 /// messages to either send new messages (e.g. creating DENM on odd behaviour from CAMs)
 /// or to create/store data (e.g. counting pedestrian, vehicles, etc. in a specific area)
+#[cfg(feature = "mobility")]
 pub mod application;
 pub mod configuration;
-
-// FIXME use custom errors
-pub fn create_denm(
-    detection_time: u64,
-    configuration: &Configuration,
-    cause: u8,
-    subcause: Option<u8>,
-    sequence_number: &mut SequenceNumber,
-    mobile: &dyn Mobile,
-    path: Vec<PathElement>,
-) -> DecentralizedEnvironmentalNotificationMessage {
-    if let Some(node_configuration) = &configuration.node {
-        let read_lock = node_configuration.read().unwrap();
-        let station_id = read_lock.station_id(None);
-        drop(read_lock);
-
-        let (relevance_distance, relevance_traffic_direction, event_speed, event_heading) =
-            match path.len() {
-                len if len <= 1 => {
-                    let event_speed = mobile.speed().map(speed_to_etsi);
-                    let event_heading = mobile.heading().map(heading_to_etsi);
-
-                    (
-                        Some(RelevanceDistance::LessThan50m.into()),
-                        Some(RelevanceTrafficDirection::UpstreamTraffic.into()),
-                        event_speed,
-                        event_heading,
-                    )
-                }
-                _ => {
-                    // TODO "extrapolate" relevance distance and traffic direction from path
-                    todo!()
-                }
-            };
-
-        DecentralizedEnvironmentalNotificationMessage::new(
-            mobile.id(),
-            station_id,
-            ReferencePosition::from(mobile.position()),
-            sequence_number.get_next() as u16,
-            timestamp_to_etsi(detection_time),
-            cause,
-            subcause,
-            relevance_distance,
-            relevance_traffic_direction,
-            event_speed,
-            event_heading,
-            Some(10),
-            Some(200),
-        )
-    } else {
-        todo!("Ego DENM creation not managed yet")
-    }
-}
-
-/// Creates an updated copy of the provided DENM
-///
-/// FIXME check for appropriation
-pub fn update_denm(
-    detection_time: u64,
-    denm: &DecentralizedEnvironmentalNotificationMessage,
-    mobile: &dyn Mobile,
-) -> DecentralizedEnvironmentalNotificationMessage {
-    let mut copy = denm.clone();
-
-    copy.management_container.detection_time = timestamp_to_etsi(detection_time);
-    copy.management_container.reference_time = etsi_now();
-    copy.management_container.event_position = ReferencePosition::from(mobile.position());
-
-    copy
-}

--- a/rust/src/client/application.rs
+++ b/rust/src/client/application.rs
@@ -10,5 +10,87 @@
  * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
+use crate::client::configuration::Configuration;
+use crate::exchange::etsi::decentralized_environmental_notification_message::{
+    DecentralizedEnvironmentalNotificationMessage, RelevanceDistance, RelevanceTrafficDirection,
+};
+use crate::exchange::etsi::reference_position::ReferencePosition;
+use crate::exchange::etsi::{etsi_now, heading_to_etsi, speed_to_etsi, timestamp_to_etsi};
+use crate::exchange::sequence_number::SequenceNumber;
+use crate::exchange::PathElement;
+use crate::mobility::mobile::Mobile;
+
 pub mod analyzer;
 pub mod pipeline;
+
+// FIXME use custom errors
+#[cfg(feature = "mobility")]
+pub fn create_denm(
+    detection_time: u64,
+    configuration: &Configuration,
+    cause: u8,
+    subcause: Option<u8>,
+    sequence_number: &mut SequenceNumber,
+    mobile: &dyn Mobile,
+    path: Vec<PathElement>,
+) -> DecentralizedEnvironmentalNotificationMessage {
+    if let Some(node_configuration) = &configuration.node {
+        let read_lock = node_configuration.read().unwrap();
+        let station_id = read_lock.station_id(None);
+        drop(read_lock);
+
+        let (relevance_distance, relevance_traffic_direction, event_speed, event_heading) =
+            match path.len() {
+                len if len <= 1 => {
+                    let event_speed = mobile.speed().map(speed_to_etsi);
+                    let event_heading = mobile.heading().map(heading_to_etsi);
+
+                    (
+                        Some(RelevanceDistance::LessThan50m.into()),
+                        Some(RelevanceTrafficDirection::UpstreamTraffic.into()),
+                        event_speed,
+                        event_heading,
+                    )
+                }
+                _ => {
+                    todo!("\"extrapolate\" relevance distance and traffic direction from path")
+                }
+            };
+
+        DecentralizedEnvironmentalNotificationMessage::new(
+            mobile.id(),
+            station_id,
+            ReferencePosition::from(mobile.position()),
+            sequence_number.get_next() as u16,
+            timestamp_to_etsi(detection_time),
+            cause,
+            subcause,
+            relevance_distance,
+            relevance_traffic_direction,
+            event_speed,
+            event_heading,
+            Some(10),
+            Some(200),
+        )
+    } else {
+        todo!("Ego DENM creation not managed yet")
+    }
+}
+
+/// Creates an updated copy of the provided DENM
+///
+/// FIXME check for appropriation
+#[cfg(feature = "mobility")]
+pub fn update_denm(
+    detection_time: u64,
+    denm: &DecentralizedEnvironmentalNotificationMessage,
+    mobile: &dyn Mobile,
+) -> DecentralizedEnvironmentalNotificationMessage {
+    let mut copy = denm.clone();
+
+    copy.management_container.detection_time = timestamp_to_etsi(detection_time);
+    copy.management_container.reference_time = etsi_now();
+    copy.management_container.event_position = ReferencePosition::from(mobile.position());
+
+    copy
+}

--- a/rust/src/client/application/pipeline.rs
+++ b/rust/src/client/application/pipeline.rs
@@ -24,6 +24,7 @@ use crate::transport::packet::Packet;
 use crate::transport::payload::Payload;
 use crossbeam_channel::{unbounded, Receiver};
 use log::{debug, error, info, trace, warn};
+use rumqttc::v5::mqttbytes::v5::PublishProperties;
 use rumqttc::v5::{Event, EventLoop};
 use serde::de::DeserializeOwned;
 use std::any::Any;
@@ -377,6 +378,7 @@ where
                                 let item = Packet {
                                     topic,
                                     payload: *exchange,
+                                    properties: PublishProperties::default(),
                                 };
                                 //assumed clone, we send to 2 channels
                                 match monitoring_sender.send((item.clone(), None)) {
@@ -398,6 +400,7 @@ where
                             match information_sender.send(Packet {
                                 topic,
                                 payload: *information,
+                                properties: PublishProperties::default(),
                             }) {
                                 Ok(()) => trace!("mqtt information sent"),
                                 Err(error) => {

--- a/rust/src/client/configuration/configuration_error.rs
+++ b/rust/src/client/configuration/configuration_error.rs
@@ -26,7 +26,7 @@ pub enum ConfigurationError {
     NoCustomSettings,
     #[error("Could not found section '{0}'")]
     SectionNotFound(&'static str),
-    #[error("Could parse value of field '{0}' as a '{1}'")]
+    #[error("Could not parse value of field '{0}' as a '{1}'")]
     TypeError(&'static str, &'static str),
     #[error("Username provided with no password")]
     NoPassword,

--- a/rust/src/client/configuration/mobility_configuration.rs
+++ b/rust/src/client/configuration/mobility_configuration.rs
@@ -1,0 +1,39 @@
+/*
+ * Software Name : libits
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
+ */
+
+use ini::Properties;
+
+use crate::client::configuration::configuration_error::ConfigurationError;
+use crate::client::configuration::get_mandatory_field;
+
+pub(crate) const STATION_SECTION: &str = "station";
+
+const STATION_ID_FIELD: &str = "id";
+const STATION_TYPE_FIELD: &str = "type";
+
+pub struct MobilityConfiguration {
+    pub station_id: String,
+    pub station_type: String,
+}
+
+impl TryFrom<&Properties> for MobilityConfiguration {
+    type Error = ConfigurationError;
+
+    fn try_from(properties: &Properties) -> Result<Self, Self::Error> {
+        let s = MobilityConfiguration {
+            station_id: get_mandatory_field(STATION_ID_FIELD, (STATION_SECTION, properties))?,
+            station_type: get_mandatory_field(STATION_TYPE_FIELD, (STATION_SECTION, properties))?,
+        };
+
+        Ok(s)
+    }
+}

--- a/rust/src/client/configuration/node_configuration.rs
+++ b/rust/src/client/configuration/node_configuration.rs
@@ -11,7 +11,7 @@
  */
 
 use crate::client::configuration::configuration_error::ConfigurationError;
-use crate::client::configuration::{get_mandatory_field, get_optional_from_section, NODE_SECTION};
+use crate::client::configuration::{get_mandatory_field, get_optional_from_section};
 use crate::exchange::message::information::Information;
 use crate::mobility::quadtree;
 use crate::mobility::quadtree::quadkey::Quadkey;
@@ -19,6 +19,8 @@ use crate::mobility::quadtree::Quadtree;
 use ini::Properties;
 use log::{error, info, warn};
 use std::str::FromStr;
+
+pub(crate) const NODE_SECTION: &str = "node";
 
 /// Configuration of the node the client is hosted on
 ///

--- a/rust/src/client/configuration/telemetry_configuration.rs
+++ b/rust/src/client/configuration/telemetry_configuration.rs
@@ -1,0 +1,119 @@
+use ini::Properties;
+use log::warn;
+use std::string::ToString;
+
+use crate::client::configuration::configuration_error::ConfigurationError;
+use crate::client::configuration::{get_mandatory_field, get_optional_from_section};
+
+pub(crate) const TELEMETRY_SECTION: &str = "telemetry";
+pub(crate) const DEFAULT_PATH: &str = "v1/traces";
+
+/// OpenTelemetry configuration
+///
+/// Ini configuration example:
+/// ```ini
+/// [telemetry]
+/// ; IP or hostname of the OTLP collector
+/// host="otlp.company.com"
+/// ; Port of the OTLP collector
+/// port=14125
+/// ; Optionnal, defaults to v1/traces
+/// path="custom/v1/traces"
+/// ; Optionnal, defaults to 2048
+/// batch_size=1024
+///```
+#[derive(Clone, Debug, Default)]
+pub struct TelemetryConfiguration {
+    pub host: String,
+    pub port: u16,
+    pub path: String,
+    pub batch_size: usize,
+}
+
+impl TryFrom<&Properties> for TelemetryConfiguration {
+    type Error = ConfigurationError;
+
+    fn try_from(properties: &Properties) -> Result<Self, Self::Error> {
+        let section = ("telemetry", properties);
+
+        let path = match get_optional_from_section::<String>("path", properties) {
+            Ok(value) => value.unwrap_or(DEFAULT_PATH.to_string()),
+            Err(e) => {
+                warn!(
+                    "OLTP collector path could not be read from configuration: {}",
+                    e
+                );
+                warn!("Defaulting to '{}'", DEFAULT_PATH);
+                DEFAULT_PATH.to_string()
+            }
+        };
+
+        let batch_size = match get_optional_from_section::<usize>("batch_size", properties) {
+            Ok(value) => value.unwrap_or(2048),
+            Err(e) => {
+                if let ConfigurationError::TypeError(_, _) = e {
+                    panic!("{}", e);
+                }
+                2048
+            }
+        };
+
+        let s = TelemetryConfiguration {
+            host: get_mandatory_field::<String>("host", section)?,
+            port: get_mandatory_field::<u16>("port", section)?,
+            path,
+            batch_size,
+        };
+
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::client::configuration::telemetry_configuration::TelemetryConfiguration;
+    use ini::Ini;
+
+    const EXHAUSTIVE_TELEMETRY_CONF: &str = r#"
+[telemetry]
+host="tel.emetry.com"
+port=1234
+path="unusual/v1/traces"
+batch_size=4096
+"#;
+
+    const MINIMAL_TELEMETRY_CONF: &str = r#"
+[telemetry]
+host="tel.emetry.com"
+port=1234
+"#;
+
+    #[test]
+    fn values_are_read_from_conf() {
+        let ini =
+            Ini::load_from_str(EXHAUSTIVE_TELEMETRY_CONF).expect("Failed to load string as Ini");
+
+        let telemetry_conf =
+            TelemetryConfiguration::try_from(ini.section(Some("telemetry")).unwrap());
+
+        let telemetry_conf =
+            telemetry_conf.expect("Failed to create TelemetryConfiguration from config");
+        assert_eq!("tel.emetry.com", telemetry_conf.host);
+        assert_eq!(1234, telemetry_conf.port);
+        assert_eq!("unusual/v1/traces", telemetry_conf.path);
+        assert_eq!(4096, telemetry_conf.batch_size);
+    }
+
+    #[test]
+    fn default_values() {
+        let ini = Ini::load_from_str(MINIMAL_TELEMETRY_CONF).expect("Failed to load string as Ini");
+
+        let telemetry_conf =
+            TelemetryConfiguration::try_from(ini.section(Some("telemetry")).unwrap());
+
+        let telemetry_conf =
+            telemetry_conf.expect("Failed to create TelemetryConfiguration from config");
+        assert_eq!("v1/traces", telemetry_conf.path);
+        assert_eq!(2048, telemetry_conf.batch_size);
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,8 +13,11 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub mod client;
+#[cfg(feature = "mobility")]
 pub mod exchange;
+#[cfg(feature = "mobility")]
 pub mod mobility;
+#[cfg(feature = "mobility")]
 pub(crate) mod monitor;
 pub mod transport;
 

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -13,4 +13,5 @@
 pub mod mqtt;
 pub mod packet;
 pub mod payload;
+#[cfg(feature = "telemetry")]
 pub mod telemetry;

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -13,3 +13,4 @@
 pub mod mqtt;
 pub mod packet;
 pub mod payload;
+pub mod telemetry;

--- a/rust/src/transport/mqtt.rs
+++ b/rust/src/transport/mqtt.rs
@@ -13,8 +13,8 @@
 use rumqttc::v5::MqttOptions;
 use rumqttc::{TlsConfiguration, Transport};
 
-pub(crate) mod mqtt_client;
-pub(crate) mod mqtt_router;
+pub mod mqtt_client;
+pub mod mqtt_router;
 pub mod topic;
 
 #[cfg(feature = "geo_routing")]

--- a/rust/src/transport/mqtt/geo_topic.rs
+++ b/rust/src/transport/mqtt/geo_topic.rs
@@ -219,17 +219,20 @@ mod tests {
     #[test]
     fn test_cam_topic_from_str() {
         let topic_string = "5GCroCo/outQueue/v2x/cam/car_1/0/1/2/3";
-        let topic_result = GeoTopic::from_str(topic_string);
-        assert!(topic_result.is_ok());
-        let topic = topic_result.unwrap();
-        assert_eq!(topic.project, "5GCroCo".to_string());
-        assert_eq!(topic.queue, Queue::Out);
-        assert_eq!(topic.server, "v2x".to_string());
-        assert_eq!(topic.message_type, MessageType::CAM);
-        assert_eq!(topic.uuid, "car_1".to_string());
-        assert_eq!(topic.geo_extension.tiles.len(), 4);
-        for i in 0..4 {
-            assert_eq!(topic.geo_extension.tiles[i], Tile::from(i as u8));
+
+        match GeoTopic::from_str(topic_string) {
+            Ok(topic) => {
+                assert_eq!(topic.project, "5GCroCo".to_string());
+                assert_eq!(topic.queue, Queue::Out);
+                assert_eq!(topic.server, "v2x".to_string());
+                assert_eq!(topic.message_type, MessageType::CAM);
+                assert_eq!(topic.uuid, "car_1".to_string());
+                assert_eq!(topic.geo_extension.tiles.len(), 4);
+                for i in 0..4 {
+                    assert_eq!(topic.geo_extension.tiles[i], Tile::from(i as u8));
+                }
+            }
+            Err(e) => panic!("Failed to create GeoTopic from string: {}", e),
         }
     }
 
@@ -237,45 +240,54 @@ mod tests {
     fn test_denm_topic_from_str() {
         let topic_string =
             "5GCroCo/outQueue/v2x/denm/wse_app_bcn1/1/2/0/2/2/2/2/3/3/0/0/3/2/0/2/0/1/0/1/0/3/1/";
-        let topic_result = GeoTopic::from_str(topic_string);
-        assert!(topic_result.is_ok());
-        let topic = topic_result.unwrap();
-        assert_eq!(topic.project, "5GCroCo".to_string());
-        assert_eq!(topic.queue, Queue::Out);
-        assert_eq!(topic.server, "v2x".to_string());
-        assert_eq!(topic.message_type, MessageType::DENM);
-        assert_eq!(topic.uuid, "wse_app_bcn1".to_string());
-        assert_eq!(topic.geo_extension.tiles.len(), 22);
+
+        match GeoTopic::from_str(topic_string) {
+            Ok(topic) => {
+                assert_eq!(topic.project, "5GCroCo".to_string());
+                assert_eq!(topic.queue, Queue::Out);
+                assert_eq!(topic.server, "v2x".to_string());
+                assert_eq!(topic.message_type, MessageType::DENM);
+                assert_eq!(topic.uuid, "wse_app_bcn1".to_string());
+                assert_eq!(topic.geo_extension.tiles.len(), 22);
+            }
+            Err(e) => panic!("Failed to create GeoTopic from string: {}", e),
+        }
     }
 
     #[test]
     fn test_info_topic_from_str() {
-        let topic_string = "5GCroCo/outQueue/v2x/info/broker";
-        let topic_result = GeoTopic::from_str(topic_string);
-        assert!(topic_result.is_ok());
-        let topic = topic_result.unwrap();
-        assert_eq!(topic.project, "5GCroCo".to_string());
-        assert_eq!(topic.queue, Queue::Out);
-        assert_eq!(topic.server, "v2x".to_string());
-        assert_eq!(topic.message_type, MessageType::INFO);
-        assert_eq!(topic.uuid, "broker".to_string());
-        assert_eq!(topic.geo_extension.tiles.len(), 0);
+        let topic_string = "5GCroCo/outQueue/info/broker";
+
+        match GeoTopic::from_str(topic_string) {
+            Ok(topic) => {
+                assert_eq!(topic.project, "5GCroCo".to_string());
+                assert_eq!(topic.queue, Queue::Out);
+                assert!(topic.server.is_empty());
+                assert_eq!(topic.message_type, MessageType::INFO);
+                assert_eq!(topic.uuid, "broker".to_string());
+                assert_eq!(topic.geo_extension.tiles.len(), 0);
+            }
+            Err(e) => panic!("Failed to create GeoTopic from string: {}", e),
+        }
     }
 
     #[test]
     fn test_in_queue_cam_topic_from_str() {
         let topic_string = "5GCroCo/inQueue/v2x/cam/car_1/0/1/2/3";
-        let topic_result = GeoTopic::from_str(topic_string);
-        assert!(topic_result.is_ok());
-        let topic = topic_result.unwrap();
-        assert_eq!(topic.project, "5GCroCo".to_string());
-        assert_eq!(topic.queue, Queue::In);
-        assert_eq!(topic.server, "v2x".to_string());
-        assert_eq!(topic.message_type, MessageType::CAM);
-        assert_eq!(topic.uuid, "car_1".to_string());
-        assert_eq!(topic.geo_extension.tiles.len(), 4);
-        for i in 0..4 {
-            assert_eq!(topic.geo_extension.tiles[i], Tile::from(i as u8));
+
+        match GeoTopic::from_str(topic_string) {
+            Ok(topic) => {
+                assert_eq!(topic.project, "5GCroCo".to_string());
+                assert_eq!(topic.queue, Queue::In);
+                assert_eq!(topic.server, "v2x".to_string());
+                assert_eq!(topic.message_type, MessageType::CAM);
+                assert_eq!(topic.uuid, "car_1".to_string());
+                assert_eq!(topic.geo_extension.tiles.len(), 4);
+                for i in 0..4 {
+                    assert_eq!(topic.geo_extension.tiles[i], Tile::from(i as u8));
+                }
+            }
+            Err(e) => panic!("Failed to create GeoTopic from string: {}", e),
         }
     }
 }

--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -20,7 +20,7 @@ use rumqttc::v5::mqttbytes::v5::Filter;
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, Event, EventLoop, MqttOptions};
 
-pub(crate) struct MqttClient {
+pub struct MqttClient {
     client: AsyncClient,
 }
 

--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -49,11 +49,18 @@ impl<'client> MqttClient {
         };
     }
 
-    pub async fn publish<T: Topic, P: Payload>(&self, item: Packet<T, P>) {
-        let payload = serde_json::to_string(&item.payload).unwrap();
+    pub async fn publish<T: Topic, P: Payload>(&self, packet: Packet<T, P>) {
+        let payload = serde_json::to_string(&packet.payload).unwrap();
+
         match self
             .client
-            .publish(item.topic.to_string(), QoS::ExactlyOnce, false, payload)
+            .publish_with_properties(
+                packet.topic.to_string(),
+                QoS::ExactlyOnce,
+                false,
+                payload,
+                packet.properties,
+            )
             .await
         {
             Ok(()) => {
@@ -63,7 +70,7 @@ impl<'client> MqttClient {
                 "Failed to send publish, is the connection close? \nError: {:?}",
                 e
             ),
-        };
+        }
     }
 }
 

--- a/rust/src/transport/mqtt/mqtt_router.rs
+++ b/rust/src/transport/mqtt/mqtt_router.rs
@@ -24,7 +24,8 @@ type BoxedReception = Box<dyn Any + 'static + Send>;
 
 type BoxedCallback = Box<dyn Fn(Publish) -> Option<BoxedReception>>;
 
-pub(crate) struct MqttRouter {
+#[derive(Default)]
+pub struct MqttRouter {
     route_map: HashMap<String, BoxedCallback>,
 }
 
@@ -35,7 +36,7 @@ impl MqttRouter {
         }
     }
 
-    pub(crate) fn add_route<T, C>(&mut self, topic: T, callback: C)
+    pub fn add_route<T, C>(&mut self, topic: T, callback: C)
     where
         T: Topic,
         C: Fn(Publish) -> Option<BoxedReception> + 'static,
@@ -44,7 +45,7 @@ impl MqttRouter {
         info!("Registered route for topic: {}", topic.as_route());
     }
 
-    pub(crate) fn handle_event<T: Topic>(&mut self, event: Event) -> Option<(T, BoxedReception)> {
+    pub fn handle_event<T: Topic>(&mut self, event: Event) -> Option<(T, BoxedReception)> {
         match event {
             Event::Incoming(incoming) => match incoming {
                 Incoming::Publish(publish) => {

--- a/rust/src/transport/packet.rs
+++ b/rust/src/transport/packet.rs
@@ -10,6 +10,8 @@
  * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
+use opentelemetry::propagation::{Extractor, Injector};
+use rumqttc::v5::mqttbytes::v5::PublishProperties;
 use std::fmt::Debug;
 
 use crate::transport::mqtt::topic::Topic;
@@ -23,10 +25,41 @@ where
 {
     pub topic: T,
     pub payload: P,
+    pub properties: PublishProperties,
 }
 
 impl<T: Topic, P: Payload> Packet<T, P> {
     pub fn new(topic: T, payload: P) -> Self {
-        Packet { topic, payload }
+        Self {
+            topic,
+            payload,
+            properties: PublishProperties::default(),
+        }
+    }
+}
+
+impl<T: Topic, P: Payload> Injector for Packet<T, P> {
+    fn set(&mut self, key: &str, value: String) {
+        self.properties
+            .user_properties
+            .push((key.to_string(), value));
+    }
+}
+
+impl<T: Topic, P: Payload> Extractor for Packet<T, P> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.properties
+            .user_properties
+            .iter()
+            .find(|(k, _)| key == k)
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.properties
+            .user_properties
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .collect::<Vec<&str>>()
     }
 }

--- a/rust/src/transport/telemetry.rs
+++ b/rust/src/transport/telemetry.rs
@@ -1,0 +1,99 @@
+/*
+ * Software Name : libits
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
+ */
+
+use opentelemetry::global::BoxedSpan;
+use opentelemetry::propagation::{Extractor, TextMapPropagator};
+use opentelemetry::trace::{Link, TraceContextExt, Tracer};
+use opentelemetry::{global, Context, KeyValue};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{RandomIdGenerator, Sampler, TracerProvider};
+use opentelemetry_sdk::Resource;
+use std::time::Duration;
+
+/// Registers a global TracerProvider with HTTP exporter
+pub fn init_tracer(
+    service_name: &'static str,
+    host: &'static str,
+    port: u16,
+) -> Result<(), opentelemetry::trace::TraceError> {
+    let endpoint = format!("http://{}:{}/v1/traces", host, port);
+
+    let http_exporter = opentelemetry_otlp::new_exporter()
+        .http()
+        .with_http_client(reqwest::Client::new())
+        .with_endpoint(endpoint)
+        .with_timeout(Duration::from_secs(3))
+        .build_span_exporter()?;
+
+    let tracer_provider = TracerProvider::builder()
+        .with_simple_exporter(http_exporter)
+        .with_config(
+            opentelemetry_sdk::trace::config()
+                .with_sampler(Sampler::AlwaysOn)
+                .with_id_generator(RandomIdGenerator::default())
+                .with_max_events_per_span(64)
+                .with_max_attributes_per_span(16)
+                .with_max_events_per_span(16)
+                .with_resource(Resource::new(vec![KeyValue::new(
+                    "service.name",
+                    service_name,
+                )])),
+        )
+        .build();
+
+    let _ = global::set_tracer_provider(tracer_provider);
+
+    Ok(())
+}
+
+pub fn execute_in_span<F, E, R>(
+    tracer_name: &'static str,
+    span_name: &'static str,
+    from: Option<&E>,
+    block: F,
+) -> R
+where
+    F: FnOnce() -> R,
+    E: Extractor,
+{
+    let span = get_span(tracer_name, span_name, from);
+    let cx = Context::current_with_span(span);
+    let _guard = cx.attach();
+
+    block()
+}
+
+pub fn get_span<E>(
+    tracer_name: &'static str,
+    span_name: &'static str,
+    from: Option<&E>,
+) -> BoxedSpan
+where
+    E: Extractor,
+{
+    let tracer = global::tracer(tracer_name);
+
+    let span_builder = if let Some(packet) = from {
+        let propagator = TraceContextPropagator::new();
+        let trace_cx = propagator.extract(packet);
+        let span_cx = trace_cx.span().span_context().clone();
+
+        tracer
+            .span_builder(span_name)
+            .with_links(vec![Link::with_context(span_cx)])
+    } else {
+        tracer.span_builder(span_name)
+    };
+
+    span_builder.start(&tracer)
+}


### PR DESCRIPTION
What's new
----------

- Add `json_counter` example to illustrate how to use mqtt mod
- Use `test.mosquitto.org` as public MQTT broker in the example configuration file
- Allow to add publish properties in MQTT messages

Fixes #125 

### mobility 

- Fix geo_topic failing unit test
- New feature `mobility` for mobility related structs and methods
- Restrict mobility related structs and methods to `mobility` feature

### telemetry

- New feature `telemetry` for telemetry related structs and methods
- Add telemetry methods (OpenTelemetry) (closes #124)
- Add `telemetry` example to illustrate how to use telemetry mod
- Implement [Injector][1] and [Extractor][2] traits for Packet to set [W3C context][3] as MQTT publish property

How to test
-----------

1. Launch json_counter example
    ```
    cargo run --example json_counter
    ```
    **Example runs and yields about the number of JSON messages received among the total**
    > Received 1000 messages including 997 as JSON  
    > Received 2000 messages including 1997 as JSON  
    > Received 3000 messages including 2997 as JSON  
    > ...

2. Configure OTLP collector
    Edit the `example/config.ini` file to set the OTLP collector endpoint config by filling the following section
    ```
    [telemetry]
    host="otlp.domain.ext"
    port=4318
    ; Optionnal, defaults to "v1/traces"
    path="custom/v1/traces"
    ```
3. Launch telemetry example
    ```
    cargo run --example telemetry --features telemetry
    ```
    **Example runs and sends 4 traces**
    ```
    Transport: standard MQTT; TLS disabled
    INFO [telemetry] logger ready on log
    INFO [telemetry] Send a trace with a single span 'ping' root span
    INFO [telemetry] └─ Ping                  trace_id: 4d9183d7274f4b8c850d46887f35141a, span_id: bd458664e66f860e
    DEBUG [reqwest::connect] starting new connection: http://90.84.47.115:18000/
    INFO [telemetry] Send a trace with a single span 'pong' root span linked with the previous one 'ping'
    INFO [telemetry] └─ Pong                  trace_id: 8479671f21bf9b0fd166b8ead1ff2761, span_id: 3c153c5e70a8a2a2
    INFO [telemetry] Send a single trace with two spans
    INFO [telemetry] └─ Root                  trace_id: cd4a1ee42952fcafc5eaf61f1881eca2, span_id: 7580f10ca1595e5b
    INFO [telemetry]    └─ Child              trace_id: cd4a1ee42952fcafc5eaf61f1881eca2, span_id: d570aff4e9889e95
    INFO [telemetry] Send a trace with 3 spans from 3 threads
    INFO [telemetry] └─ Main thread           trace_id: 6b1fe1d4b7aa574bbbe4b987053bcfd2, span_id: e5050064d17d0527
    INFO [telemetry]    ├─ Sender thread      trace_id: 6b1fe1d4b7aa574bbbe4b987053bcfd2, span_id: 9f449076f02efdd6
    INFO [telemetry]    └─ Listener thread    trace_id: 6b1fe1d4b7aa574bbbe4b987053bcfd2, span_id: d1bb7d93ec83207e
    ```
    

4. Launch copycat example
    ```
    cargo run --example copycat --features geo_routing
    ```
    **=> The example correctly runs**

[1]: https://docs.rs/opentelemetry/latest/opentelemetry/propagation/trait.Injector.html
[2]: https://docs.rs/opentelemetry/latest/opentelemetry/propagation/trait.Extractor.html
[3]: https://www.w3.org/TR/trace-context/