### PR TITLE
Rust file header fix

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,6 @@
 # see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
 #
 # Authors: see CONTRIBUTORS.md
-# Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
 
 [package]
 name = "libits-client"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,11 +1,12 @@
-# Software Name: its-client
-# SPDX-FileCopyrightText: Copyright (c) 2016-2023 Orange
-# SPDX-License-Identifier: MIT License
+# Software Name : libits-client
+# SPDX-FileCopyrightText: Copyright (c) Orange SA
+# SPDX-License-Identifier: MIT
 #
-# This software is distributed under the MIT license, see LICENSE.txt file for more details.
+# This software is distributed under the MIT license,
+# see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
 #
-# Author: Nicolas Buffon <nicolas.buffon@orange.com> et al.
-# Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) client based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
+# Authors: see CONTRIBUTORS.md
+# Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
 
 [package]
 name = "libits-client"

--- a/rust/benches/position.rs
+++ b/rust/benches/position.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/rust/benches/position.rs
+++ b/rust/benches/position.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/examples/copycat.rs
+++ b/rust/examples/copycat.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/examples/copycat.rs
+++ b/rust/examples/copycat.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::fs;

--- a/rust/examples/json_counter.rs
+++ b/rust/examples/json_counter.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::any::Any;

--- a/rust/examples/json_counter.rs
+++ b/rust/examples/json_counter.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/examples/telemetry.rs
+++ b/rust/examples/telemetry.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::collections::HashMap;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 /// Structures, functions and traits in this mod are made to create applications that analyze

--- a/rust/src/client/application.rs
+++ b/rust/src/client/application.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/application.rs
+++ b/rust/src/client/application.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::Configuration;

--- a/rust/src/client/application/analyzer.rs
+++ b/rust/src/client/application/analyzer.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/application/analyzer.rs
+++ b/rust/src/client/application/analyzer.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::Configuration;

--- a/rust/src/client/application/pipeline.rs
+++ b/rust/src/client/application/pipeline.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/application/pipeline.rs
+++ b/rust/src/client/application/pipeline.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::application::analyzer::Analyzer;

--- a/rust/src/client/configuration.rs
+++ b/rust/src/client/configuration.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::configuration_error::ConfigurationError;

--- a/rust/src/client/configuration.rs
+++ b/rust/src/client/configuration.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/configuration/configuration_error.rs
+++ b/rust/src/client/configuration/configuration_error.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use thiserror::Error;

--- a/rust/src/client/configuration/configuration_error.rs
+++ b/rust/src/client/configuration/configuration_error.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/configuration/mobility_configuration.rs
+++ b/rust/src/client/configuration/mobility_configuration.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/client/configuration/mobility_configuration.rs
+++ b/rust/src/client/configuration/mobility_configuration.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use ini::Properties;

--- a/rust/src/client/configuration/node_configuration.rs
+++ b/rust/src/client/configuration/node_configuration.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::configuration_error::ConfigurationError;

--- a/rust/src/client/configuration/node_configuration.rs
+++ b/rust/src/client/configuration/node_configuration.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange.rs
+++ b/rust/src/exchange.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 pub(crate) mod cause;

--- a/rust/src/exchange.rs
+++ b/rust/src/exchange.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/cause.rs
+++ b/rust/src/exchange/cause.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/cause.rs
+++ b/rust/src/exchange/cause.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::exchange::message::Message;

--- a/rust/src/exchange/etsi.rs
+++ b/rust/src/exchange/etsi.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi.rs
+++ b/rust/src/exchange/etsi.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::now;

--- a/rust/src/exchange/etsi/collective_perception_message.rs
+++ b/rust/src/exchange/etsi/collective_perception_message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/collective_perception_message.rs
+++ b/rust/src/exchange/etsi/collective_perception_message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::Configuration;

--- a/rust/src/exchange/etsi/cooperative_awareness_message.rs
+++ b/rust/src/exchange/etsi/cooperative_awareness_message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::exchange::etsi::reference_position::ReferencePosition;

--- a/rust/src/exchange/etsi/cooperative_awareness_message.rs
+++ b/rust/src/exchange/etsi/cooperative_awareness_message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/decentralized_environmental_notification_message.rs
+++ b/rust/src/exchange/etsi/decentralized_environmental_notification_message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/decentralized_environmental_notification_message.rs
+++ b/rust/src/exchange/etsi/decentralized_environmental_notification_message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::hash;

--- a/rust/src/exchange/etsi/map_extended_message.rs
+++ b/rust/src/exchange/etsi/map_extended_message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/map_extended_message.rs
+++ b/rust/src/exchange/etsi/map_extended_message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use log::warn;

--- a/rust/src/exchange/etsi/mobile_perceived_object.rs
+++ b/rust/src/exchange/etsi/mobile_perceived_object.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/mobile_perceived_object.rs
+++ b/rust/src/exchange/etsi/mobile_perceived_object.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 extern crate integer_sqrt;

--- a/rust/src/exchange/etsi/perceived_object.rs
+++ b/rust/src/exchange/etsi/perceived_object.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/perceived_object.rs
+++ b/rust/src/exchange/etsi/perceived_object.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use serde::{Deserialize, Serialize};

--- a/rust/src/exchange/etsi/reference_position.rs
+++ b/rust/src/exchange/etsi/reference_position.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/reference_position.rs
+++ b/rust/src/exchange/etsi/reference_position.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use core::fmt;

--- a/rust/src/exchange/etsi/signal_phase_and_timing_extended_message.rs
+++ b/rust/src/exchange/etsi/signal_phase_and_timing_extended_message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/etsi/signal_phase_and_timing_extended_message.rs
+++ b/rust/src/exchange/etsi/signal_phase_and_timing_extended_message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::Configuration;

--- a/rust/src/exchange/message.rs
+++ b/rust/src/exchange/message.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/message.rs
+++ b/rust/src/exchange/message.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 pub mod content;

--- a/rust/src/exchange/message/content.rs
+++ b/rust/src/exchange/message/content.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/message/content.rs
+++ b/rust/src/exchange/message/content.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::client::configuration::Configuration;

--- a/rust/src/exchange/message/content_error.rs
+++ b/rust/src/exchange/message/content_error.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use thiserror::Error;

--- a/rust/src/exchange/message/content_error.rs
+++ b/rust/src/exchange/message/content_error.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/message/information.rs
+++ b/rust/src/exchange/message/information.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/message/information.rs
+++ b/rust/src/exchange/message/information.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::exchange::message::content::Content;

--- a/rust/src/exchange/mortal.rs
+++ b/rust/src/exchange/mortal.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/exchange/mortal.rs
+++ b/rust/src/exchange/mortal.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::now;

--- a/rust/src/exchange/sequence_number.rs
+++ b/rust/src/exchange/sequence_number.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::fmt::Formatter;

--- a/rust/src/exchange/sequence_number.rs
+++ b/rust/src/exchange/sequence_number.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/rust/src/mobility.rs
+++ b/rust/src/mobility.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 pub mod mobile;

--- a/rust/src/mobility.rs
+++ b/rust/src/mobility.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/mobile.rs
+++ b/rust/src/mobility/mobile.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::mobility::position::Position;

--- a/rust/src/mobility/mobile.rs
+++ b/rust/src/mobility/mobile.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/position.rs
+++ b/rust/src/mobility/position.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use geo::EuclideanDistance;

--- a/rust/src/mobility/position.rs
+++ b/rust/src/mobility/position.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/quadtree.rs
+++ b/rust/src/mobility/quadtree.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/quadtree.rs
+++ b/rust/src/mobility/quadtree.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::mobility::quadtree::quadkey::Quadkey;

--- a/rust/src/mobility/quadtree/parse_error.rs
+++ b/rust/src/mobility/quadtree/parse_error.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use thiserror::Error;

--- a/rust/src/mobility/quadtree/parse_error.rs
+++ b/rust/src/mobility/quadtree/parse_error.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/quadtree/quadkey.rs
+++ b/rust/src/mobility/quadtree/quadkey.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::mobility::position::Position;

--- a/rust/src/mobility/quadtree/quadkey.rs
+++ b/rust/src/mobility/quadtree/quadkey.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/quadtree/tile.rs
+++ b/rust/src/mobility/quadtree/tile.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/mobility/quadtree/tile.rs
+++ b/rust/src/mobility/quadtree/tile.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::mobility::quadtree::parse_error::ParseError;

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/monitor.rs
+++ b/rust/src/monitor.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::exchange::cause::Cause;

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 pub mod mqtt;

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt.rs
+++ b/rust/src/transport/mqtt.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt.rs
+++ b/rust/src/transport/mqtt.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use rumqttc::v5::MqttOptions;

--- a/rust/src/transport/mqtt/geo_topic.rs
+++ b/rust/src/transport/mqtt/geo_topic.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/geo_topic.rs
+++ b/rust/src/transport/mqtt/geo_topic.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::mobility::quadtree::quadkey::Quadkey;

--- a/rust/src/transport/mqtt/geo_topic/message_type.rs
+++ b/rust/src/transport/mqtt/geo_topic/message_type.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::transport::mqtt::geo_topic::GeoTopicError;

--- a/rust/src/transport/mqtt/geo_topic/message_type.rs
+++ b/rust/src/transport/mqtt/geo_topic/message_type.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/geo_topic/queue.rs
+++ b/rust/src/transport/mqtt/geo_topic/queue.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::transport::mqtt::geo_topic::GeoTopicError;

--- a/rust/src/transport/mqtt/geo_topic/queue.rs
+++ b/rust/src/transport/mqtt/geo_topic/queue.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use crate::transport::mqtt::topic::Topic;

--- a/rust/src/transport/mqtt/mqtt_router.rs
+++ b/rust/src/transport/mqtt/mqtt_router.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/mqtt_router.rs
+++ b/rust/src/transport/mqtt/mqtt_router.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::collections::HashMap;

--- a/rust/src/transport/mqtt/topic.rs
+++ b/rust/src/transport/mqtt/topic.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/mqtt/topic.rs
+++ b/rust/src/transport/mqtt/topic.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::fmt::{Debug, Display};

--- a/rust/src/transport/packet.rs
+++ b/rust/src/transport/packet.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/packet.rs
+++ b/rust/src/transport/packet.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use opentelemetry::propagation::{Extractor, Injector};

--- a/rust/src/transport/payload.rs
+++ b/rust/src/transport/payload.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use serde::Serialize;

--- a/rust/src/transport/payload.rs
+++ b/rust/src/transport/payload.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *

--- a/rust/src/transport/telemetry.rs
+++ b/rust/src/transport/telemetry.rs
@@ -7,7 +7,6 @@
  * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
  *
  * Authors: see CONTRIBUTORS.md
- * Software description: This Intelligent Transportation Systems (ITS) [MQTT](https://mqtt.org/) library based on the [JSon](https://www.json.org) [ETSI](https://www.etsi.org/committee/its) specification transcription provides a ready to connect project for the mobility (connected and autonomous vehicles, road side units, vulnerable road users,...).
  */
 
 use std::time::Duration;

--- a/rust/src/transport/telemetry.rs
+++ b/rust/src/transport/telemetry.rs
@@ -1,5 +1,5 @@
 /*
- * Software Name : libits
+ * Software Name : libits-client
  * SPDX-FileCopyrightText: Copyright (c) Orange SA
  * SPDX-License-Identifier: MIT
  *


### PR DESCRIPTION
What's new
---------------

### Rust

- Remove software description from files header
- Fix software name to fit the delivered library crate
- Fix `Cargo.toml` header as it still had the old version

Fixes #160 