### PR TITLE
python/iot3: implement TLS and Websockets

### DIFF
--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -34,7 +34,7 @@ class MqttClient:
         """
         Create an MQTT client
 
-        :param client_id: The MQT client ID to identify as.
+        :param client_id: The MQTT client ID to identify as.
         :param host: The host name (or IP) of the MQTT broker.
         :param port: The port the MQTT broker listens on.
         :param socket_path: The path of the UNIX socket.

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -46,6 +46,32 @@ class MqttClient:
                             msg_cb function.
         :param span_ctx_cb: The function to obtain a context manager for an
                             OpenTelemetry span.
+
+        There are two ways to connect to the MQTT broker:
+         * via TCP: both host and port must be specified;
+         * via UNIX socket (only for local broker): socket_path must
+           be specified.
+
+        If socket_path is specified, then a connection through the UNIX
+        socket is used, otherwise a TCP connection is used.
+
+        Specifying a message callback as msg_cb allows subscribing to,
+        and thus receiving messages from specific topics. If no msg_cb
+        is provided, it is not possible to subscribe, and only emitting
+        is permitted. msg_cb must be a callable that accepts at least
+        those keyword arguments: data, topic, payload. Ideally, to be
+        future-proof, it should be declared with:
+            def my_cb(
+                *_args,
+                *,
+                data: Any,
+                topic: str,
+                payload: bytes,
+                **_kwargs,
+            ) -> None
+
+        If msg_cb_data is specified, it is passed as the data keyword
+        argument of msg_cb, otherwise None is passed.
         """
 
         self.msg_cb = msg_cb

--- a/python/iot3/tests/test-iot3-core
+++ b/python/iot3/tests/test-iot3-core
@@ -3,8 +3,10 @@
 import iot3.core
 import time
 
+
 def recv(data, topic, payload):
     print(f"{topic[:16]}: {payload[:16]}")
+
 
 iot3.core.start(
     config=iot3.core.sample_config,

--- a/python/iot3/tests/test-iot3-core
+++ b/python/iot3/tests/test-iot3-core
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import iot3.core
+import random
 import time
 
 
@@ -8,19 +9,28 @@ def recv(data, topic, payload):
     print(f"{topic[:16]}: {payload[:16]}")
 
 
+config = iot3.core.sample_config
+config["mqtt"] = {
+    "host": "test.mosquitto.org",
+    "port": 1883,
+    "client-id": random.randbytes(16).hex(),
+    "username": None,
+    "password": None,
+}
+
+topic = "test/" + random.randbytes(16).hex() + "/iot3"
+
 iot3.core.start(
-    config=iot3.core.sample_config,
+    config=config,
     message_callback=recv,
 )
 
-iot3.core.wait_for_ready()
+iot3.core.subscribe(f"{topic}/+")
 
-iot3.core.subscribe("#")
-
-iot3.core.publish("foo/bar/dropped", "dropped")
+iot3.core.publish(f"{topic}/dropped", "dropped")
 time.sleep(1)
 
-iot3.core.publish("foo/bar/passed", "passed")
+iot3.core.publish(f"{topic}/passed", "passed")
 time.sleep(1)
 
 iot3.core.stop()

--- a/python/iot3/tests/test-iot3-core-all
+++ b/python/iot3/tests/test-iot3-core-all
@@ -4,8 +4,10 @@ import iot3.core.mqtt
 import iot3.core.otel
 import time
 
+
 def recv(data, topic, payload):
     print(f"{topic[:16]}: {payload[:16]}")
+
 
 o = iot3.core.otel.Otel(
     service_name="test-service",

--- a/python/iot3/tests/test-iot3-core-all
+++ b/python/iot3/tests/test-iot3-core-all
@@ -2,12 +2,16 @@
 
 import iot3.core.mqtt
 import iot3.core.otel
+import random
 import time
 
 
 def recv(data, topic, payload):
-    print(f"{topic[:16]}: {payload[:16]}")
+    print(f"{data}: {topic[:16]}: {payload[:16]}")
 
+
+client_id = random.randbytes(16).hex()
+topic = "test/" + random.randbytes(16).hex() + "/iot3"
 
 o = iot3.core.otel.Otel(
     service_name="test-service",
@@ -17,20 +21,20 @@ o = iot3.core.otel.Otel(
 o.start()
 
 c = iot3.core.mqtt.MqttClient(
-    client_id="test",
-    host="127.0.0.1",
+    client_id=client_id,
+    host="test.mosquitto.org",
     port=1883,
     span_ctxmgr_cb=o.span,
     msg_cb=recv,
 )
 c.start()
 
-c.subscribe(topics=["#"])
+c.subscribe(topics=[f"{topic}/+"])
 
-c.publish(topic='foo/bar/dropped', payload="dropped")
+c.publish(topic=f'{topic}/dropped', payload="dropped")
 time.sleep(1)
 
-c.publish(topic='foo/bar/passed', payload="passed")
+c.publish(topic=f'{topic}/passed', payload="passed")
 time.sleep(1)
 
 c.stop()

--- a/python/iot3/tests/test-iot3-core-mqtt
+++ b/python/iot3/tests/test-iot3-core-mqtt
@@ -28,3 +28,20 @@ c.publish(topic=topic, payload="clear message")
 time.sleep(1)
 
 c.stop()
+
+c = iot3.core.mqtt.MqttClient(
+    client_id=client_id,
+    host="test.mosquitto.org",
+    port=8886,
+    msg_cb=recv,
+    msg_cb_data="tls",
+)
+c.start()
+
+c.subscribe(topics=[topic])
+c.wait_for_ready()
+c.publish(topic=topic, payload="3ИСЯЧРТЕD ПЕЅЅД̈GЕ")
+
+time.sleep(1)
+
+c.stop()

--- a/python/iot3/tests/test-iot3-core-mqtt
+++ b/python/iot3/tests/test-iot3-core-mqtt
@@ -1,24 +1,29 @@
 #!/usr/bin/env python3
 
 import iot3.core.mqtt
+import random
 import time
 
 
 def recv(data, topic, payload):
-    print(f"{topic[:16]}: {payload[:16]}")
+    print(f"{data}: {topic[:16]}: {payload.decode()[:32]}")
 
+
+client_id = random.randbytes(16).hex()
+topic = "test/" + random.randbytes(16).hex() + "/iot3"
 
 c = iot3.core.mqtt.MqttClient(
-    client_id="test",
-    host="127.0.0.1",
+    client_id=client_id,
+    host="test.mosquitto.org",
     port=1883,
     msg_cb=recv,
+    msg_cb_data="clear",
 )
 c.start()
 
-c.subscribe(topics=["#"])
+c.subscribe(topics=[topic])
 c.wait_for_ready()
-c.publish(topic='foo/bar', payload="pouet")
+c.publish(topic=topic, payload="clear message")
 
 time.sleep(1)
 

--- a/python/iot3/tests/test-iot3-core-mqtt
+++ b/python/iot3/tests/test-iot3-core-mqtt
@@ -45,3 +45,40 @@ c.publish(topic=topic, payload="3ИСЯЧРТЕD ПЕЅЅД̈GЕ")
 time.sleep(1)
 
 c.stop()
+
+c = iot3.core.mqtt.MqttClient(
+    client_id=client_id,
+    host="test.mosquitto.org",
+    port=8080,
+    websocket_path="/mqtt",
+    tls=False,
+    msg_cb=recv,
+    msg_cb_data="ws",
+)
+c.start()
+
+c.subscribe(topics=[topic])
+c.wait_for_ready()
+c.publish(topic=topic, payload="clear message")
+
+time.sleep(1)
+
+c.stop()
+
+c = iot3.core.mqtt.MqttClient(
+    client_id=client_id,
+    host="test.mosquitto.org",
+    port=8081,
+    websocket_path="/mqtt",
+    msg_cb=recv,
+    msg_cb_data="wss",
+)
+c.start()
+
+c.subscribe(topics=[topic])
+c.wait_for_ready()
+c.publish(topic=topic, payload="3ИСЯЧРТЕD ПЕЅЅД̈GЕ")
+
+time.sleep(1)
+
+c.stop()

--- a/python/iot3/tests/test-iot3-core-otel
+++ b/python/iot3/tests/test-iot3-core-otel
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import iot3.core.otel
-import os
-import sys
 import time
 
 
@@ -27,7 +25,7 @@ with o.span(name="Root span") as s0:
     with o.span(name="Automatic child span level 1 - failed") as s5:
         s5.set_status(
             status_code=iot3.core.otel.SpanStatus.ERROR,
-            status_message="Some failure"
+            status_message="Some failure",
         )
         time.sleep(0.1)
     time.sleep(0.1)

--- a/python/its-info/its-info.cfg
+++ b/python/its-info/its-info.cfg
@@ -28,11 +28,8 @@ instance_id = ID
 # MQTT topic to post info message on; default: info
 # topic = TOPIC
 
-# hostname or IP address of the broker to connect to; default: 127.0.0.1
-# host = HOST
-
-# Port the MQTT broker listens on; default: 1883
-# port = PORT
+# Path to the UNIX socket the broker listens on
+# socket-path = PATH
 
 # Username to authenticate to the MQTT broker; default: unset, no authentication
 # username = USERNAME

--- a/python/its-info/its_info/main.py
+++ b/python/its-info/its_info/main.py
@@ -36,8 +36,7 @@ class MQTTInfoClient:
             "interface": None,
         },
         "mqtt": {
-            "host": "127.0.0.1",
-            "port": 1883,
+            "socket-path": "/run/mosquitto/mqtt.socket",
             "username": None,
             "password": None,
             "topic": "info",
@@ -114,7 +113,10 @@ class MQTTInfoClient:
         self.timer = linuxfd.timerfd(closeOnExec=True)
 
         logging.debug("creating MQTT client")
-        self.client = paho.mqtt.client.Client(client_id=self.cfg["mqtt"]["client_id"])
+        self.client = paho.mqtt.client.Client(
+            client_id=self.cfg["mqtt"]["client_id"],
+            transport="unix",
+        )
         self.client.reconnect_delay_set(
             min_delay=1,
             max_delay=self.cfg["mqtt"]["retry"],
@@ -126,10 +128,7 @@ class MQTTInfoClient:
         self.client.on_connect = self.on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_socket_close = self.on_socket_close
-        self.client.connect_async(
-            host=self.cfg["mqtt"]["host"],
-            port=int(self.cfg["mqtt"]["port"]),
-        )
+        self.client.connect_async(host=self.cfg["mqtt"]["socket-path"])
 
         logging.debug("finished instanciating info object")
 

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -46,6 +46,8 @@ path = /etc/its/neighbours.cfg
 #host = 1.2.3.4
 # - TCP port the MQTT broker listens on (non-TLS)
 #port = 1883
+# - path of the websocket; if unset, do not use WebSockets; default: unset
+#websocket_path = /mqtt
 # - whether to connect with TLS; default False if port == 1883, True otherwise.
 #tls=BOOL
 # - MQTT username and password to authenticate with against the broker,

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -14,16 +14,8 @@ endpoint = http://opentelemetry.example.com:1234
 #password = secret
 
 [local]
-# There are two ways to connect to the local broker, and either,
-# not both, is required:
-# - establish a TCP/IP connection to host:port
-# - establish a TCP-like connection over the UNIX socket socket-path
-# Hostname or IP of the local broker
-host = 127.0.0.1
-# TCP port the local broker listens on (non-TLS)
-port = 1883
-# Path to the UNIX socket to connect to
-#socket-path = /run/mqtt-broker/socket
+# Path to the UNIX socket to connect to the broker
+socket-path = /run/mosquitto/mqtt.socket
 # Username and password to authenticate with against the local broker,
 # empty or unset username for no authentication; default: unset
 #username = user

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -35,7 +35,6 @@ port = 1883
 
 [authority]
 # Type of central authority, one of: file, http, mqtt
-# for now, mqtt is not implemented
 type = file
 
 # Period in seconds at which to reload the file; mandatory;

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -46,6 +46,8 @@ path = /etc/its/neighbours.cfg
 #host = 1.2.3.4
 # - TCP port the MQTT broker listens on (non-TLS)
 #port = 1883
+# - whether to connect with TLS; default False if port == 1883, True otherwise.
+#tls=BOOL
 # - MQTT username and password to authenticate with against the broker,
 #   empty or unset username for no authentication; default: unset
 #username = user

--- a/python/its-interqueuemanager/its_iqm/authority/http.py
+++ b/python/its-interqueuemanager/its_iqm/authority/http.py
@@ -58,6 +58,7 @@ class Authority:
             # Can't download -> don't change the current state;
             # just keep using the neighbours we have, if any.
             logging.debug("failed to download the list of neighbours; changing nothing")
-        # .sections() does not contain the "DEFAULT" section
-        logging.debug(f"loaded {len(loaded_nghbs.sections())} neighbour(s)")
-        self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})
+        else:
+            # .sections() does not contain the "DEFAULT" section
+            logging.debug(f"loaded {len(loaded_nghbs.sections())} neighbour(s)")
+            self.update_cb({s: dict(loaded_nghbs[s]) for s in loaded_nghbs.sections()})

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -28,8 +28,8 @@ class Authority:
             client_id=client_id,
             host=self.cfg["host"],
             port=int(self.cfg["port"]),
-            username=self.cfg["username"] or None,
-            password=self.cfg["password"] or None,
+            username=self.cfg.get("username"),
+            password=self.cfg.get("password"),
             msg_cb=self.msg_cb,
         )
         self.authority_client.subscribe(topics=[self.cfg["topic"]])

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -28,6 +28,7 @@ class Authority:
             client_id=client_id,
             host=self.cfg["host"],
             port=int(self.cfg["port"]),
+            tls=self.cfg.get("tls"),
             username=self.cfg.get("username"),
             password=self.cfg.get("password"),
             msg_cb=self.msg_cb,

--- a/python/its-interqueuemanager/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/its_iqm/authority/mqtt.py
@@ -28,6 +28,7 @@ class Authority:
             client_id=client_id,
             host=self.cfg["host"],
             port=int(self.cfg["port"]),
+            websocket_path=self.cfg.get("websocket_path"),
             tls=self.cfg.get("tls"),
             username=self.cfg.get("username"),
             password=self.cfg.get("password"),

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -59,12 +59,6 @@ class IQM:
             self.span_cb = iot3.core.otel.Otel.noexport_span
 
         logging.info("create local qm")
-        conn = dict()
-        try:
-            conn["host"] = cfg["local"]["host"]
-            conn["port"] = int(cfg["local"]["port"])
-        except TypeError:
-            conn["socket_path"] = cfg["local"]["socket-path"]
 
         qm_data = {
             "copy_qm": None,
@@ -74,9 +68,9 @@ class IQM:
 
         self.local_qm = iot3.core.mqtt.MqttClient(
             client_id=cfg["local"]["client_id"],
+            socket_path=cfg["local"]["socket-path"],
             username=cfg["local"]["username"],
             password=cfg["local"]["password"],
-            **conn,
             msg_cb=self.qm_copy_cb,
             msg_cb_data=qm_data,
             span_ctxmgr_cb=self.span_cb,

--- a/python/its-interqueuemanager/its_iqm/main.py
+++ b/python/its-interqueuemanager/its_iqm/main.py
@@ -21,9 +21,6 @@ DEFAULTS = {
         "password": None,
     },
     "local": {
-        "host": None,
-        "port": None,
-        "socket-path": None,
         "username": None,
         "password": None,
         "client_id": "iqm",

--- a/python/its-status/its-status.cfg
+++ b/python/its-status/its-status.cfg
@@ -14,10 +14,8 @@ enabled = true
 [mqtt]
 # Whether to send satus messages to an MQTT broker; false or true, the default
 enabled = false
-# hostname or IP of the MQTT broker to connect to; default: 127.0.0.1
-host = HOSTNAME
-# port of the MQTT broker; default: 1883
-port = 1234
+# Path of the UNIX socket to connect to
+socket_path = PATH
 # Username with which to authenticate to the MQTT broker; if not provided, or empty (the default), do not authenticate
 username = USERNAME
 # Password with which to authenticate to the MQTT broker; maybe empty to not use a password

--- a/python/its-status/its_status/emitter.mqtt.py
+++ b/python/its-status/its_status/emitter.mqtt.py
@@ -14,8 +14,11 @@ class Status:
             self.topic = cfg.get("mqtt", "topic", fallback="status/system")
             self.client = iot3.core.mqtt.MqttClient(
                 client_id=cfg.get("mqtt", "client_id", fallback="its-status"),
-                host=cfg.get("mqtt", "host", fallback="127.0.0.1"),
-                port=cfg.getint("mqtt", "port", fallback=1883),
+                socket_path=cfg.get(
+                    "mqtt",
+                    "socket_path",
+                    fallback="/run/mosquitto/mqtt.socket",
+                ),
                 username=cfg.get("mqtt", "username", fallback=None),
                 password=cfg.get("mqtt", "password", fallback=None),
             )

--- a/python/its-vehicle/its-vehicle.cfg
+++ b/python/its-vehicle/its-vehicle.cfg
@@ -85,9 +85,7 @@ host = HOSTNAME
 
 [broker.mirror]
 # See broker.main, above, for descriptions
-# If neither host nor socket-path are set, no mirroring is done
-# host = HOST
-# port = PORT
+# If socket-path is not set, no mirroring is done
 # socket-path = PATH
 # username = USERNAME
 # password = PASSWORD

--- a/python/its-vehicle/its-vehicle.cfg
+++ b/python/its-vehicle/its-vehicle.cfg
@@ -71,6 +71,8 @@ endpoint = http://opentelemetry.example.com:1234
 host = HOSTNAME
 # Port of the MQTT broker; default: 1883
 # port = PORT
+# Whether to do TLS
+# tls = BOOL
 # Path of the UNIX socket
 # socket-path = PATH
 

--- a/python/its-vehicle/its-vehicle.cfg
+++ b/python/its-vehicle/its-vehicle.cfg
@@ -71,6 +71,8 @@ endpoint = http://opentelemetry.example.com:1234
 host = HOSTNAME
 # Port of the MQTT broker; default: 1883
 # port = PORT
+# Path of the WebSocket; default: unset, do not use WebSockets
+# websocket-path = PATH
 # Whether to do TLS
 # tls = BOOL
 # Path of the UNIX socket

--- a/python/its-vehicle/its_vehicle/main.py
+++ b/python/its-vehicle/its_vehicle/main.py
@@ -33,7 +33,6 @@ DEFAULTS = {
         "password": None,
     },
     "broker.mirror": {
-        "port": 1883,
         "username": None,
         "password": None,
     },
@@ -133,21 +132,12 @@ def main():
         msg_cb=_msg_cb,
     )
 
-    if "host" in cfg["broker.mirror"] or "socket-path" in cfg["broker.mirror"]:
-        if "host" in cfg["broker.mirror"]:
-            conn_opts = {
-                "host": cfg["broker.mirror"]["host"],
-                "port": int(cfg["broker.mirror"]["port"]),
-            }
-        else:
-            conn_opts = {
-                "socket_path": cfg["broker.mirror"]["socket-path"],
-            }
+    if "socket-path" in cfg["broker.mirror"]:
         mqtt_mirror = iot3.core.mqtt.MqttClient(
             client_id=cfg["broker.mirror"]["client-id"],
+            socket_path=cfg["broker.mirror"]["socket-path"],
             username=cfg["broker.mirror"]["username"],
             password=cfg["broker.mirror"]["password"],
-            **conn_opts,
         )
     else:
         mqtt_mirror = None

--- a/python/its-vehicle/its_vehicle/main.py
+++ b/python/its-vehicle/its_vehicle/main.py
@@ -132,6 +132,7 @@ def main():
             "host": cfg["broker.main"]["host"],
             "port": int(cfg["broker.main"]["port"]),
             "tls": cfg["broker.main"]["tls"],
+            "websocket_path": cfg["broker.main"].get("websocket-path"),
         }
     else:
         conn_opts = {

--- a/python/its-vehicle/its_vehicle/roi.py
+++ b/python/its-vehicle/its_vehicle/roi.py
@@ -24,10 +24,15 @@ class RegionOfInterest:
         msg_type: str,
     ):
         depth = self.depths[msg_type]
-        for s in self.speeds:
-            if speed < s or depth == 1:
-                break
-            depth -= 1
+        if speed is not None:
+            for s in self.speeds:
+                if speed < s or depth == 1:
+                    break
+                depth -= 1
+        else:
+            # We don't know our speed, so let's be conservative
+            # and assume the highest speed, so the largest RoI.
+            depth -= len(self.speeds)
 
         # Note: this finds the quadkeys around the current one; at the
         # equator, that gives roughly a square. However, the further


### PR DESCRIPTION
---
**Features**;

* IoT3 Core SDK:
    * Implement MQTT over TLS
    * Implement MQTT over websockets

Closes: #138

---
**How to test**

1. start an environment with python 3.11 in the IoT3 Core SDK directory:
    ```sh
    $ cd python/iot3/
    $ docker container run \
        --rm \
        -ti \
        --network host \
        -e http_proxy \
        -e https_proxy \
        -e no_proxy \
        --user $(id -u):$(id -u) \
        --mount type=bind,source=$(pwd),destination=$(pwd) \
        --workdir $(pwd) \
        --entrypoint /bin/bash \
        python:3.11.9-slim-bookworm
    ```
2. create a /venv/ in a writable location, and activate it:
    ```sh
    (docker) python3 -m venv /tmp/iot3
    (docker) . /tmp/iot3/bin/activate
    ```
3. install the IoT3 Core SDK (notice the trailing dot `.`):
    ```sh
    (docker) pip3 --disable-pip-version-check install .
    ```
4. Start an MQTT client:
    ```sh
    mosquitto_sub \
        -h test.mosquitto.org -p 1883 \
        -t 'test/+/iot3/#' -t 'test/+/iot3/#' \
        -F '%t: %j'
    ```
5. Run the MQTT-only test:
    ```sh
    (docker) ./tests/test-iot3-core-mqtt
    ```

---
**Expected results:**

1. the docker container runs
2. the python /venv/ is created and activated
3. the IoT3 Core SDK is installed
4. 
5. the MQTT messages are reported (the random 16-hexdigit hash
   is the topic where the message was posted):
    ```
    clear: 65c8f6a3a004823e: clear message
    tls: 65c8f6a3a004823e: 3ИСЯЧРТЕD ПЕЅЅД̈GЕ
    ws: 65c8f6a3a004823e: clear message
    wss: 65c8f6a3a004823e: 3ИСЯЧРТЕD ПЕЅЅД̈GЕ
    ```
    * _clear_: native MQTT protocol in clear (no TLS)
    * _tls_: native MQTT protocol over TLS
    * _ws_: MQTT over WebSockets in clear (no TLS)
    * _wss_: MQTT over WebSockets over TLS
