### PR TITLE
rust: telemetry basic auth + MQTT trust store TLS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1271,6 +1271,7 @@ name = "libits-client"
 version = "2.0.0"
 dependencies = [
  "async-channel",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "criterion",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["lib"]
 [features]
 mobility = []
 geo_routing = ["mobility"]
-telemetry = []
+telemetry = ["dep:base64"]
 
 [[example]]
 name = "copycat"
@@ -55,6 +55,10 @@ serde_json = "1.0"
 serde_repr = "0.1"
 thiserror = "1.0"
 threadpool = "1.8"
+
+[dependencies.base64]
+version = "0.22"
+optional = true
 
 [dependencies.rumqttc]
 version = "0.24"

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -22,6 +22,10 @@ thread_count=4
 ;path=custom/v1/traces
 ; Optional, defaults to 2048
 ;max_batch_size=10
+; Optional, for basic auth
+; username=admin
+; Optional, for basic auth
+; password=admin
 
 [log]
 level="debug"

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -4,11 +4,9 @@ type="mec_application"
 
 [mqtt]
 host="test.mosquitto.org"
-port=1884
+port=8886
 client_id="com_orange_its-client"
-username="rw"
-password="readwrite"
-use_tls=false
+use_tls=true
 use_websocket=false
 
 [node]

--- a/rust/src/client/configuration.rs
+++ b/rust/src/client/configuration.rs
@@ -23,7 +23,7 @@ use crate::client::configuration::configuration_error::ConfigurationError::{
     FieldNotFound, MissingMandatoryField, MissingMandatorySection, NoCustomSettings, NoPassword,
     TypeError,
 };
-use crate::transport::mqtt::{configure_tls, configure_transport};
+use crate::transport::mqtt::configure_transport;
 
 #[cfg(feature = "telemetry")]
 use crate::client::configuration::telemetry_configuration::{
@@ -142,16 +142,7 @@ impl TryFrom<&Properties> for MqttOptionWrapper {
             .unwrap_or_default()
             .unwrap_or_default();
 
-        // FIXME manage ALPN, and authentication
-        let tls_configuration = if use_tls {
-            let ca_path = get_mandatory_field::<String>("tls_certificate", ("mqtt", properties))
-                .expect("TLS enabled but no certificate path provided");
-            Some(configure_tls(&ca_path, None, None))
-        } else {
-            None
-        };
-
-        configure_transport(tls_configuration, use_websocket, &mut mqtt_options);
+        configure_transport(use_tls, use_websocket, &mut mqtt_options);
 
         Ok(MqttOptionWrapper(mqtt_options))
     }

--- a/rust/src/transport/mqtt.rs
+++ b/rust/src/transport/mqtt.rs
@@ -20,48 +20,23 @@ pub mod topic;
 pub mod geo_topic;
 
 pub(crate) fn configure_transport(
-    tls_configuration: Option<TlsConfiguration>,
+    use_tls: bool,
     use_websocket: bool,
     mqtt_options: &mut MqttOptions,
 ) {
-    match (tls_configuration, use_websocket) {
-        (Some(tls), true) => {
+    match (use_tls, use_websocket) {
+        (true, true) => {
             println!("Transport: MQTT over WebSocket; TLS enabled");
-            mqtt_options.set_transport(Transport::Wss(tls));
+            mqtt_options.set_transport(Transport::Wss(TlsConfiguration::default()));
         }
-        (Some(tls), false) => {
+        (true, false) => {
             println!("Transport: standard MQTT; TLS enabled");
-            mqtt_options.set_transport(Transport::Tls(tls));
+            mqtt_options.set_transport(Transport::Tls(TlsConfiguration::default()));
         }
-        (None, true) => {
+        (false, true) => {
             println!("Transport: MQTT over WebSocket; TLS disabled");
             mqtt_options.set_transport(Transport::Ws);
         }
-        (None, false) => println!("Transport: standard MQTT; TLS disabled"),
-    }
-}
-
-pub(crate) fn configure_tls(
-    ca_path: &str,
-    alpn: Option<Vec<Vec<u8>>>,
-    client_auth: Option<(Vec<u8>, Vec<u8>)>,
-) -> TlsConfiguration {
-    let ca: Vec<u8> = std::fs::read(ca_path).expect("Failed to read TLS certificate");
-
-    TlsConfiguration::Simple {
-        ca,
-        alpn,
-        client_auth,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::transport::mqtt::configure_tls;
-
-    #[test]
-    #[should_panic]
-    fn configure_tls_with_invalid_path_should_return_error() {
-        let _ = configure_tls("unextisting/path", None, None);
+        (false, false) => println!("Transport: standard MQTT; TLS disabled"),
     }
 }


### PR DESCRIPTION
What's new
---------------

- Manage basic auth for telemetry
- No longer require a certificate for MQTTS, the server certificate has to be signed by a trusted authority ( closes #140 )

How to test
---------------

1. Setup the `[telemetry]` section in config.ini to point to an OTLP collector requiring basic auth
2. Start the telemetry example
    ```
    cargo run --example telemetry --features telemetry
    ```
    **=> Logs yields about traces being sent and no connection error is raised**
3. Check on jaeger that you correctly see the traces
    **=> The four sent traces are present**
4. Run the `json_counter` example
    ```
    RUST_LOG=debug cargo run --example json_counter
    ```
    **=> You must see TLS handshake debug logs**
    > DEBUG [rustls::client::hs] No cached session for DnsName("test.mosquitto.org")  
    > DEBUG [rustls::client::hs] Not resuming any session  
    > DEBUG [rustls::client::hs] Using ciphersuite TLS13_AES_256_GCM_SHA384  
    > DEBUG [rustls::client::tls13] Not resuming  
    > DEBUG [rustls::client::tls13] TLS1.3 encrypted extensions: [ServerNameAck]  
    > DEBUG [rustls::client::hs] ALPN protocol is None  

    **=> The client successfully connects and receive messages**
    > DEBUG [rumqttc::v5::state] Subscribe. Topics = [Filter { path: "#", qos: AtMostOnce, nolocal: false, preserve_retain: false, retain_forward_rule: OnEverySubscribe }], Pkid = 1  
    > DEBUG [rumqttc::v5::state] SubAck Pkid = 1, QoS = AtMostOnce  
    > Received 1000 messages including 997 as JSON  
    Received 2000 messages including 1997 as JSON  