### PR TITLE
python/iot3: extend OpenTelemetry attributes

### DIFF
--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -183,6 +183,7 @@ class MqttClient:
         ) as span:
             new_traceparent = span.to_traceparent()
             span.set_attribute(key="iot3.core.mqtt.topic", value=topic)
+            span.set_attribute(key="iot3.core.mqtt.payload_size", value=len(payload))
             properties = paho.mqtt.properties.Properties(
                 paho.mqtt.packettypes.PacketTypes.PUBLISH,
             )
@@ -292,6 +293,10 @@ class MqttClient:
         with self.span_ctxmgr_cb(**span_kwargs) as span:
             new_traceparent = span.to_traceparent()
             span.set_attribute(key="iot3.core.mqtt.topic", value=message.topic)
+            span.set_attribute(
+                key="iot3.core.mqtt.payload_size",
+                value=len(message.payload),
+            )
             self.msg_cb(
                 data=self.msg_cb_data,
                 topic=message.topic,

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -182,7 +182,7 @@ class MqttClient:
             kind=otel.SpanKind.PRODUCER,
         ) as span:
             new_traceparent = span.to_traceparent()
-            span.set_attribute(key="test.iot3.core.mqtt.topic", value=topic)
+            span.set_attribute(key="iot3.core.mqtt.topic", value=topic)
             properties = paho.mqtt.properties.Properties(
                 paho.mqtt.packettypes.PacketTypes.PUBLISH,
             )
@@ -291,7 +291,7 @@ class MqttClient:
             pass
         with self.span_ctxmgr_cb(**span_kwargs) as span:
             new_traceparent = span.to_traceparent()
-            span.set_attribute(key="test.iot3.core.mqtt.topic", value=message.topic)
+            span.set_attribute(key="iot3.core.mqtt.topic", value=message.topic)
             self.msg_cb(
                 data=self.msg_cb_data,
                 topic=message.topic,

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -178,7 +178,7 @@ class MqttClient:
         :param payload: The payload to post.
         """
         with self.span_ctxmgr_cb(
-            name="IoT3 Core MQTT message",
+            name="IoT3 Core MQTT Message",
             kind=otel.SpanKind.PRODUCER,
         ) as span:
             new_traceparent = span.to_traceparent()
@@ -281,7 +281,7 @@ class MqttClient:
         message: paho.mqtt.client.MQTTMessage,
     ):
         span_kwargs = {
-            "name": "IoT3 Core MQTT message",
+            "name": "IoT3 Core MQTT Message",
             "kind": otel.SpanKind.CONSUMER,
         }
         try:

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -182,7 +182,6 @@ class MqttClient:
             kind=otel.SpanKind.PRODUCER,
         ) as span:
             new_traceparent = span.to_traceparent()
-            span.set_attribute(key="test.iot3.core.mqtt.action", value="publish")
             span.set_attribute(key="test.iot3.core.mqtt.topic", value=topic)
             properties = paho.mqtt.properties.Properties(
                 paho.mqtt.packettypes.PacketTypes.PUBLISH,
@@ -292,7 +291,6 @@ class MqttClient:
             pass
         with self.span_ctxmgr_cb(**span_kwargs) as span:
             new_traceparent = span.to_traceparent()
-            span.set_attribute(key="test.iot3.core.mqtt.action", value="receive")
             span.set_attribute(key="test.iot3.core.mqtt.topic", value=message.topic)
             self.msg_cb(
                 data=self.msg_cb_data,

--- a/python/iot3/src/iot3/core/otel.py
+++ b/python/iot3/src/iot3/core/otel.py
@@ -368,6 +368,7 @@ class Span:
             for span in span_links:
                 self.add_link(link=span)
         self.status_code = SpanStatus.UNSET
+        self.set_attribute(key="iot3.core.sdk_language", value="python")
         self.status_message = None
 
     def finalise(self):


### PR DESCRIPTION
**Features**;

* Extend OpenTelemetry attributes
    * common, generic attribute `iot3.core.sdk_language`
    * MQTT attributes `iot3.core.mqtt.payload_size` and `iot3.core.mqtt.topic`

---
**How to test**

1. Prepare an OpenTelemetry collector on localhost:
    ```
    $ docker container run \
        --rm \
        -p 16686:16686 \
        -p 4318:4318 \
        jaegertracing/all-in-one:1.58
    ```
    then open a browser on the Jaegger UI:
    ```
    http://localhost:16686/
    ```
2. Start an MQTT client:
    ```
    $ mosquitto_sub \
        -h test.mosquitto.org -p 1883 \
        -t 'test/+/iot3/#' \
        -F '%j' \
    | jq -C .
    ```
3. Test IoT3 Core SDK:
    1. start an environment with python 3.11:
        ```sh
        $ docker container run \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            --entrypoint /bin/bash \
            python:3.11.9-slim-bookworm
        ```
    2. create a /venv/ in a writable location, and activate it:
        ```sh
        (docker) python3 -m venv /tmp/iot3
        (docker) . /tmp/iot3/bin/activate
        ```
    3. install the IoT3 Core SDK (notice the trailing dot `.`):
        ```sh
        (docker) cd python/iot3/
        (docker) pip3 --disable-pip-version-check install .
        ```
    4. Run the OpenTelemetry-only test:
        ```sh
        (docker) ./tests/test-iot3-core-otel
        ```
        then, in Jaegger, search for the traces for the `test-service` service.
    4. Run the MQTT with OpenTelemetry test:
        ```sh
        (docker) ./tests/test-iot3-core-all
        ```
        then, in Jaegger, search for the traces for the `test-service` service.
    7. Run the simple API test:
        ```sh
        (docker) ./tests/test-iot3-core
        ```
        then, in Jaegger, search for the traces for the `my-service` service.

---
**Expected results:**

1. The Jaegger UI is displayed in your browser
2. The mosquitto lient is running
3. The IoT3 Core SDK works;
    1. the docker container runs
    2. the python /venv/ is created and activated
    3. the IoT3 Core SDK is installed
    4. the Jaegger UI finds two traces:
        * one with 6 spans, of which the last one is in error, reporting /Some failure/
        * one with a single span, which has a link to the root span of the first trace, above
        * all spans have an attribute:
            * `iot3.core.sdk_language=python`
    5. the MQTT message is dumped by /mosquitto_sub/:
        ```json
        {
          "tst": "2024-10-21T08:58:15.206188Z+0200",
          "topic": "test/5c2a8ef897cf0abb1941cea0fd184b7e/iot3/passed",
          "qos": 0,
          "retain": 0,
          "payloadlen": 6,
          "properties": {
            "user-properties": {
              "traceparent": "00-9c39cc87f7098ec82542cdf38617cef9-f8b69d89c0029e03-00"
            }
          },
          "payload": "passed"
        }
        ```
        then Jaegger UI finds three new traces, all with a single span:
        * the first is for the failed publish, and has a span:
            * of kind `producer`
            * with attributes:
                * `iot3.core.sdk_language=python`
                * `iot3.core.mqtt.payload_size=7`
                * `iot3.core.mqtt.topic=foo/bar/dropped`
            * with an error status reporting /The client is not currently connected./
        * the second is for the sucessful publish, and has a span:
            * of kind `producer`
            * with attributes:
                * `iot3.core.sdk_language=python`
                * `iot3.core.mqtt.payload_size=6`
                * `iot3.core.mqtt.topic=foo/bar/passed`
            * with an unset status
        * the third is for the receive, and has a span:
            * of kind `consumer`
            * with attributes:
                * `iot3.core.sdk_language=python`
                * `iot3.core.mqtt.payload_size=6`
                * `iot3.core.mqtt.topic=foo/bar/passed`
            * with an unset status
            * with a link to the span of the second trace, above
    6. the results are similar to those of step 5, above