### PR TITLE
python/vehicle: hot-fix for OpenTelemetry authentication

### DIFF
--- a/python/its-vehicle/its_vehicle/main.py
+++ b/python/its-vehicle/its_vehicle/main.py
@@ -114,6 +114,7 @@ def main():
         otel = iot3.core.otel.Otel(
             service_name="its-vehicle",
             endpoint=cfg["telemetry"]["endpoint"],
+            auth=iot3.core.otel.Auth.BASIC,
             username=cfg["telemetry"]["username"],
             password=cfg["telemetry"]["password"],
             batch_period=5.0,


### PR DESCRIPTION
**Bug-fix:**

* Workaround authentication in its-vehicle

---
***How to test:*

1. Start an OpenTelemetry collector with Basic Auth.
2. Install its-vehicle
3. Enable telemetry in its-vehicle:
    ```cfg
    [telemetry]
    endpoint = http://your-otlp-collector:4318
    username = USER
    password = PASSWD
    ```
4. Look at the traces in your OTLP collector

---
**Expected results:**

The its-vehicle traces appear in the OTLP collector.