### PR TITLE
Send messages to telemetry service for MQTT exchanges

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -30,11 +30,12 @@ public class IoT3Core {
     /**
      * Instantiate the IoT3.0 Core SDK.
      *
-     * @param mqttHost MQTT broker address, provided by Orange
-     * @param mqttUsername MQTT username, provided by Orange
-     * @param mqttPassword MQTT password, provided by Orange
+     * @param mqttHost MQTT broker address
+     * @param mqttUsername MQTT username
+     * @param mqttPassword MQTT password
      * @param mqttClientId unique MQTT client ID
      * @param ioT3CoreCallback interface to retrieve the different clients outputs
+     * @param telemetryHost Open Telemetry server address
      */
     public IoT3Core(String mqttHost,
                     String mqttUsername,
@@ -42,13 +43,54 @@ public class IoT3Core {
                     String mqttClientId,
                     IoT3CoreCallback ioT3CoreCallback,
                     String telemetryHost) {
+        this(mqttHost,
+                1883,
+                8883,
+                mqttUsername,
+                mqttPassword,
+                mqttClientId,
+                ioT3CoreCallback,
+                telemetryHost,
+                -1,
+                "/telemetry/default/v1/traces");
+    }
+
+    /**
+     * Instantiate the IoT3.0 Core SDK.
+     *
+     * @param mqttHost MQTT broker address
+     * @param mqttPortTcp TCP port of the MQTT broker
+     * @param mqttPortTls TLS port of the MQTT broker
+     * @param mqttUsername MQTT username
+     * @param mqttPassword MQTT password
+     * @param mqttClientId unique MQTT client ID
+     * @param ioT3CoreCallback interface to retrieve the different clients outputs
+     * @param telemetryHost Open Telemetry server address
+     * @param telemetryPort port of the Open Telemetry server
+     */
+    public IoT3Core(String mqttHost,
+                    int mqttPortTcp,
+                    int mqttPortTls,
+                    String mqttUsername,
+                    String mqttPassword,
+                    String mqttClientId,
+                    IoT3CoreCallback ioT3CoreCallback,
+                    String telemetryHost,
+                    int telemetryPort,
+                    String telemetryEndpoint) {
         // instantiate the OpenTelemetry client
+        OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.Scheme.HTTP;
+        scheme.setCustomPort(telemetryPort);
         this.openTelemetryClient = new OpenTelemetryClient(
-                OpenTelemetryClient.Scheme.HTTP,
-                telemetryHost);
+                scheme,
+                telemetryHost,
+                telemetryEndpoint,
+                mqttClientId);
         // instantiate the MQTT client
         this.mqttClient = new MqttClient(
                 mqttHost,
+                mqttPortTcp,
+                mqttPortTls,
                 mqttUsername,
                 mqttPassword,
                 mqttClientId,

--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -52,7 +52,9 @@ public class IoT3Core {
                 ioT3CoreCallback,
                 telemetryHost,
                 -1,
-                "/telemetry/default/v1/traces");
+                "/telemetry",
+                "default",
+                "default");
     }
 
     /**
@@ -77,7 +79,9 @@ public class IoT3Core {
                     IoT3CoreCallback ioT3CoreCallback,
                     String telemetryHost,
                     int telemetryPort,
-                    String telemetryEndpoint) {
+                    String telemetryEndpoint,
+                    String telemetryUsername,
+                    String telemetryPassword) {
         // instantiate the OpenTelemetry client
         OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.Scheme.HTTP;
         scheme.setCustomPort(telemetryPort);
@@ -85,7 +89,9 @@ public class IoT3Core {
                 scheme,
                 telemetryHost,
                 telemetryEndpoint,
-                mqttClientId);
+                mqttClientId,
+                telemetryUsername,
+                telemetryPassword);
         // instantiate the MQTT client
         this.mqttClient = new MqttClient(
                 mqttHost,
@@ -218,4 +224,107 @@ public class IoT3Core {
     public void mqttPublish(String topic, String message, boolean retain) {
         if(mqttClient != null) mqttClient.publishMessage(topic, message, retain);
     }
+
+    /**
+     * Build an instance of IoT3Core.
+     */
+    public static class IoT3CoreBuilder {
+        private String mqttHost;
+        private int mqttPortTcp;
+        private int mqttPortTls;
+        private String mqttUsername;
+        private String mqttPassword;
+        private String mqttClientId;
+        private IoT3CoreCallback ioT3CoreCallback;
+        private String telemetryHost;
+        private int telemetryPort;
+        private String telemetryEndpoint;
+        private String telemetryUsername;
+        private String telemetryPassword;
+
+        /**
+         * Start building an instance of IoT3Core.
+         */
+        public IoT3CoreBuilder() {}
+
+        /**
+         * Set the MQTT parameters of your IoT3Core instance.
+         *
+         * @param mqttHost the host or IP address of the MQTT broker
+         * @param mqttPortTcp the TCP port of the MQTT broker
+         * @param mqttPortTls the TLS port of the MQTT broker
+         * @param mqttUsername the username for authentication with the MQTT broker
+         * @param mqttPassword the password for authentication with the MQTT broker
+         * @param mqttClientId your client ID
+         */
+        public IoT3CoreBuilder mqttParams(String mqttHost,
+                                          int mqttPortTcp,
+                                          int mqttPortTls,
+                                          String mqttUsername,
+                                          String mqttPassword,
+                                          String mqttClientId) {
+            this.mqttHost = mqttHost;
+            this.mqttPortTcp = mqttPortTcp;
+            this.mqttPortTls = mqttPortTls;
+            this.mqttUsername = mqttUsername;
+            this.mqttPassword = mqttPassword;
+            this.mqttClientId = mqttClientId;
+            return this;
+        }
+
+        /**
+         * Set the OpenTelemetry parameters of your IoT3Core instance.
+         *
+         * @param telemetryHost the host or IP address of the OpenTelemetry server
+         * @param telemetryPort the port of the OpenTelemetry server
+         * @param telemetryEndpoint the endpoint of the OpenTelemetry server (e.g. /endpoint/example)
+         * @param telemetryUsername the username for authentication with the OpenTelemetry server
+         * @param telemetryPassword the password for authentication with the OpenTelemetry server
+         */
+        public IoT3CoreBuilder telemetryParams(String telemetryHost,
+                                               int telemetryPort,
+                                               String telemetryEndpoint,
+                                               String telemetryUsername,
+                                               String telemetryPassword) {
+            this.telemetryHost = telemetryHost;
+            this.telemetryPort = telemetryPort;
+            this.telemetryEndpoint = telemetryEndpoint;
+            this.telemetryUsername = telemetryUsername;
+            this.telemetryPassword = telemetryPassword;
+            return this;
+        }
+
+        /**
+         * Set the callback of your IoT3Core instance.
+         *
+         * @param ioT3CoreCallback callback to be notified of mainly MQTT-related events, e.g. message reception
+         *                         or connection status
+         */
+        public IoT3CoreBuilder callback(IoT3CoreCallback ioT3CoreCallback) {
+            this.ioT3CoreCallback = ioT3CoreCallback;
+            return this;
+        }
+
+        /**
+         * Build the IoT3Core instance.
+         *
+         * @return Iot3Core instance
+         */
+        public IoT3Core build() {
+            return new IoT3Core(
+                    mqttHost,
+                    mqttPortTcp,
+                    mqttPortTls,
+                    mqttUsername,
+                    mqttPassword,
+                    mqttClientId,
+                    ioT3CoreCallback,
+                    telemetryHost,
+                    telemetryPort,
+                    telemetryEndpoint,
+                    telemetryUsername,
+                    telemetryPassword);
+        }
+    }
+
 }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -18,6 +18,8 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 
@@ -39,6 +41,8 @@ public class MqttClient {
     private boolean tlsConnection = false;
 
     public MqttClient(String serverHost,
+                      int tcpPort,
+                      int tlsPort,
                       String username,
                       String password,
                       String clientId,
@@ -69,10 +73,10 @@ public class MqttClient {
         }
 
         if(sslConfig == null) {
-            mqttClient = mqttClientBuilder.serverPort(11883)
+            mqttClient = mqttClientBuilder.serverPort(tcpPort)
                     .buildAsync();
         } else {
-            mqttClient = mqttClientBuilder.serverPort(18883)
+            mqttClient = mqttClientBuilder.serverPort(tlsPort)
                     .sslConfig(sslConfig)
                     .buildAsync();
             tlsConnection = true;
@@ -82,14 +86,11 @@ public class MqttClient {
     }
 
     public void disconnect() {
-        Span span = openTelemetryClient.startSpan("MQTT Disconnect");
         if(mqttClient != null) {
             mqttClient.disconnect().whenComplete((mqtt5DisconnectResult, throwable) -> {
                 if(throwable != null) {
-                    openTelemetryClient.endSpan(span, false, "Failed to disconnect from MQTT broker");
                     LOGGER.log(Level.WARNING, "Error during disconnection");
                 } else {
-                    openTelemetryClient.endSpan(span, true, "Disconnected from MQTT broker");
                     LOGGER.log(Level.INFO, "Disconnected");
                 }
             });
@@ -98,23 +99,19 @@ public class MqttClient {
     }
 
     public void connect() {
-        Span span = openTelemetryClient.startSpan("MQTT Connect");
         mqttClient.connectWith()
                 .cleanStart(true)
                 .send()
                 .whenComplete((connAck, throwable) -> {
                     if(throwable != null) {
-                        openTelemetryClient.endSpan(span, false, "Failed to connect to MQTT broker");
                         LOGGER.log(Level.INFO, "Error during connection to the server");
                     } else {
-                        openTelemetryClient.endSpan(span, true, "Connected to MQTT broker");
                         LOGGER.log(Level.INFO, "Success connecting to the server");
                     }
                 });
     }
 
     public void subscribeToTopic(String topic) {
-        Span span = openTelemetryClient.startSpan("MQTT Subscribe");
         LOGGER.log(Level.INFO, "Subscribing to topic: " + topic);
         if(mqttClient != null) {
             mqttClient.subscribeWith()
@@ -123,12 +120,8 @@ public class MqttClient {
                     .send()
                     .whenComplete((subAck, throwable) -> {
                         if (throwable != null) {
-                            openTelemetryClient.endSpan(span, false,
-                                    "Failed to subscribe to MQTT topic: " + topic);
                             LOGGER.log(Level.WARNING, "Subscribed fail!");
                         } else {
-                            openTelemetryClient.endSpan(span, true,
-                                    "Subscribed to MQTT topic: " + topic);
                             LOGGER.log(Level.FINE, "Subscribed!");
                         }
                         callback.subscriptionComplete(throwable);
@@ -139,7 +132,6 @@ public class MqttClient {
     }
 
     public void unsubscribeFromTopic(String topic) {
-        Span span = openTelemetryClient.startSpan("MQTT Unsubscribe");
         LOGGER.log(Level.INFO, "Unsubscribing from topic: " + topic);
         if(mqttClient != null) {
             mqttClient.unsubscribeWith()
@@ -147,12 +139,8 @@ public class MqttClient {
                     .send()
                     .whenComplete((subAck, throwable) -> {
                         if (throwable != null) {
-                            openTelemetryClient.endSpan(span, false,
-                                    "Failed to unsubscribe from MQTT topic: " + topic);
                             LOGGER.log(Level.WARNING, "Unsubscribed fail!");
                         } else {
-                            openTelemetryClient.endSpan(span, true,
-                                    "Unsubscribed from MQTT topic: " + topic);
                             LOGGER.log(Level.INFO, "Unsubscribed!");
                         }
                         callback.unsubscriptionComplete(throwable);
@@ -165,11 +153,11 @@ public class MqttClient {
     public void publishMessage(String topic, String message, boolean retained, int qos) {
         LOGGER.log(Level.INFO, "Sending message: " + topic + " | "+ message);
         if(isValidMqttPubTopic(topic)) {
-            Span span = openTelemetryClient.startSpan("MQTT Send Message");
-            span.setAttribute(AttributeKey.stringKey("messaging.destination"), topic);
-            span.setAttribute(AttributeKey.stringKey("messaging.message_payload_size_bytes"),
+            Span span = openTelemetryClient.startSpan("IoT3 Core MQTT Message", SpanKind.PRODUCER);
+            span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"), topic);
+            span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
                     String.valueOf(message.length()));
-            openTelemetryClient.addEvent(span, "Sending MQTT message");
+            span.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
 
             // Inject the trace context into a map
             Map<String, String> contextMap = new HashMap<>();
@@ -199,10 +187,11 @@ public class MqttClient {
                         .send()
                         .whenComplete((mqtt3Publish, throwable) -> {
                             if (throwable != null) {
-                                openTelemetryClient.endSpan(span, false, "MQTT message could not be sent");
+                                span.setStatus(StatusCode.ERROR);
+                                span.end();
                                 LOGGER.log(Level.WARNING, "Failed publishing message...");
                             } else {
-                                openTelemetryClient.endSpan(span, true, "MQTT message sent");
+                                span.end();
                                 LOGGER.log(Level.INFO, "Success publishing message ["
                                         + (System.currentTimeMillis() - pubTimestamp) + " ms]");
                             }
@@ -256,18 +245,20 @@ public class MqttClient {
         SpanContext receivedSpanContext = Span.fromContext(extractedContext).getSpanContext();
 
         // Create a new span with a link to the received span context
-        Span receivedSpan = openTelemetryClient.startSpanWithLink("MQTT Receive Message",
-                receivedSpanContext.getTraceId(), receivedSpanContext.getSpanId());
-        receivedSpan.setAttribute(AttributeKey.stringKey("messaging.destination"),
+        Span receivedSpan = openTelemetryClient.startSpanWithLink(
+                "IoT3 Core MQTT Message",
+                SpanKind.CONSUMER,
+                receivedSpanContext.getTraceId(),
+                receivedSpanContext.getSpanId());
+        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"),
                 publish.getTopic().toString());
-        receivedSpan.setAttribute(AttributeKey.stringKey("messaging.message_payload_size_bytes"),
+        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
                 String.valueOf(message.length()));
-        openTelemetryClient.addEvent(receivedSpan, "Received MQTT message");
+        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
+        receivedSpan.end();
 
         LOGGER.log(Level.INFO, "MQTT message arrived on: " + publish.getTopic() + " | " + message);
         callback.messageArrived(publish.getTopic().toString(), message);
-        openTelemetryClient.endSpan(receivedSpan, true,
-                "Processed received MQTT message");
     }
 
     public boolean isConnected() {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -8,6 +8,7 @@
 package com.orange.iot3core.clients;
 
 import com.hivemq.client.mqtt.MqttClientSslConfig;
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
@@ -82,6 +83,9 @@ public class MqttClient {
             tlsConnection = true;
         }
 
+        // single callback for processing messages received on subscribed topics
+        mqttClient.publishes(MqttGlobalPublishFilter.SUBSCRIBED, this::processPublish);
+
         connect();
     }
 
@@ -116,7 +120,6 @@ public class MqttClient {
         if(mqttClient != null) {
             mqttClient.subscribeWith()
                     .topicFilter(topic)
-                    .callback(this::processPublish)
                     .send()
                     .whenComplete((subAck, throwable) -> {
                         if (throwable != null) {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -187,9 +187,10 @@ public class MqttClient {
                         .send()
                         .whenComplete((mqtt3Publish, throwable) -> {
                             if (throwable != null) {
-                                span.setStatus(StatusCode.ERROR);
+                                span.setStatus(StatusCode.ERROR, throwable.getMessage());
                                 span.end();
-                                LOGGER.log(Level.WARNING, "Failed publishing message...");
+                                LOGGER.log(Level.WARNING, "Failed publishing message... "
+                                        + throwable.getMessage());
                             } else {
                                 span.end();
                                 LOGGER.log(Level.INFO, "Success publishing message ["

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
@@ -11,7 +11,6 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.*;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
-import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -23,22 +22,25 @@ import java.time.Duration;
 
 public class OpenTelemetryClient {
 
-    private static final String INSTRUMENTATION_NAME = "com.orange.iot3core";
+    private final String serviceName;
     private Tracer tracer;
     private SdkTracerProvider tracerProvider;
     private final Scheme scheme;
     private final String host;
+    private final String endpoint;
 
-    public OpenTelemetryClient(Scheme scheme, String host) {
+    public OpenTelemetryClient(Scheme scheme, String host, String endpoint, String serviceName) {
         this.scheme = scheme;
         this.host = host;
+        this.endpoint = endpoint;
+        this.serviceName = serviceName;
         initialize();
     }
 
     private void initialize() {
-        String endpoint = scheme.getScheme() + "://" + host + ":" + scheme.getDefaultPort() + "/v1/traces";
-        OpenTelemetry openTelemetry = initOpenTelemetry(endpoint);
-        this.tracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
+        String url = scheme.getScheme() + "://" + host + ":" + scheme.getPort() + endpoint;
+        OpenTelemetry openTelemetry = initOpenTelemetry(url);
+        this.tracer = openTelemetry.getTracer(serviceName);
     }
 
     private OpenTelemetry initOpenTelemetry(String endpoint) {
@@ -52,7 +54,7 @@ public class OpenTelemetryClient {
                 .build();
 
         Resource resource = Resource.builder()
-                .put("service.name", INSTRUMENTATION_NAME)
+                .put("service.name", serviceName)
                 .build();
 
         SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
@@ -72,36 +74,19 @@ public class OpenTelemetryClient {
         return openTelemetry;
     }
 
-    public Span startSpan(String spanName) {
-        return tracer.spanBuilder(spanName).startSpan();
+    public Span startSpan(String spanName, SpanKind spanKind) {
+        return tracer.spanBuilder(spanName).setSpanKind(spanKind).startSpan();
     }
 
-    public Span startSpanWithLink(String spanName, Span linkedSpan) {
-        return startSpanWithLink(spanName, getTraceId(linkedSpan), getSpanId(linkedSpan));
+    public Span startSpanWithLink(String spanName, SpanKind spanKind, Span linkedSpan) {
+        return startSpanWithLink(spanName, spanKind, getTraceId(linkedSpan), getSpanId(linkedSpan));
     }
 
-    public Span startSpanWithLink(String spanName, String linkedTraceId, String linkedSpanId) {
+    public Span startSpanWithLink(String spanName, SpanKind spanKind, String linkedTraceId, String linkedSpanId) {
         SpanContext spanContext = SpanContext.createFromRemoteParent(
                 linkedTraceId, linkedSpanId, TraceFlags.getDefault(), TraceState.getDefault()
         );
-        return tracer.spanBuilder(spanName).addLink(spanContext).startSpan();
-    }
-
-    public void endSpan(Span span, boolean success, String event) {
-        try (Scope scope = span.makeCurrent()) {
-            span.addEvent(event);
-            if (!success) {
-                span.addEvent("Operation failed");
-            }
-        } catch (Exception e) {
-            span.recordException(e);
-        } finally {
-            span.end();
-        }
-    }
-
-    public void addEvent(Span span, String event) {
-        span.addEvent(event);
+        return tracer.spanBuilder(spanName).setSpanKind(spanKind).addLink(spanContext).startSpan();
     }
 
     public String getSpanId(Span span) {
@@ -121,24 +106,31 @@ public class OpenTelemetryClient {
     }
 
     public enum Scheme {
-        HTTP("http", "4318"),
-        HTTPS("https", "4318"),
-        GRPC("grpc", "4317");
+        HTTP("http", 4318),
+        HTTPS("https", 4318),
+        GRPC("grpc", 4317);
 
         private final String scheme;
-        private final String defaultPort;
+        private final int defaultPort;
+        private int customPort;
 
-        Scheme(String scheme, String defaultPort) {
+        Scheme(String scheme, int defaultPort) {
             this.scheme = scheme;
             this.defaultPort = defaultPort;
+            this.customPort = -1;
         }
 
         public String getScheme() {
             return scheme;
         }
 
-        public String getDefaultPort() {
-            return defaultPort;
+        public int getPort() {
+            if(customPort < 0) return defaultPort;
+            else return customPort;
+        }
+
+        public void setCustomPort(int customPort) {
+            this.customPort = customPort;
         }
     }
 

--- a/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
@@ -10,10 +10,14 @@ import java.util.concurrent.TimeUnit;
 public class Iot3CoreExample {
 
     private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
-    private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
-    private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
-    private static final String EXAMPLE_MQTT_CLIENT_ID = "mqtt_client_id";
+    private static final int EXAMPLE_MQTT_PORT_TCP = 1883;
+    private static final int EXAMPLE_MQTT_PORT_TLS = 8883;
+    private static final String EXAMPLE_MQTT_USERNAME = "username";
+    private static final String EXAMPLE_MQTT_PASSWORD = "password";
+    private static final String EXAMPLE_MQTT_CLIENT_ID = "client_id";
     private static final String EXAMPLE_OTL_HOST = "open_telemetry_host";
+    private static final int EXAMPLE_OTL_PORT = 4318;
+    private static final String EXAMPLE_OTL_ENDPOINT = "/otl/endpoint";
 
     private static IoT3Core ioT3Core;
 
@@ -21,6 +25,8 @@ public class Iot3CoreExample {
         // instantiate IoT3Core and its callback
         ioT3Core = new IoT3Core(
                 EXAMPLE_MQTT_HOST,
+                EXAMPLE_MQTT_PORT_TCP,
+                EXAMPLE_MQTT_PORT_TLS,
                 EXAMPLE_MQTT_USERNAME,
                 EXAMPLE_MQTT_PASSWORD,
                 EXAMPLE_MQTT_CLIENT_ID,
@@ -59,27 +65,28 @@ public class Iot3CoreExample {
                         else System.out.println("MQTT unsubscription failed");
                     }
                 },
-                EXAMPLE_OTL_HOST);
+                EXAMPLE_OTL_HOST,
+                EXAMPLE_OTL_PORT,
+                EXAMPLE_OTL_ENDPOINT);
     }
 
     private static void onConnectionComplete() {
         // subscribe to some topics
-        ioT3Core.mqttSubscribe("test/world");
-        ioT3Core.mqttSubscribe("test/world/#");
+        ioT3Core.mqttSubscribe("test/iot3");
+        ioT3Core.mqttSubscribe("test/iot3/core");
 
-        try {
-            final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        try (ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor()) {
             // publish a message on a topic that we have not subscribed to
             executorService.schedule(() -> publishMessage("test",
-                            "Message 1 should not come back"),
+                            "This is a test message, it should not come back"),
                     2, TimeUnit.SECONDS);
             // publish a message on a topic that we have subscribed to
-            executorService.schedule(() -> publishMessage("test/world",
-                            "Message 2 should come back"),
+            executorService.schedule(() -> publishMessage("test/iot3",
+                            "This is an iot3 message, it should come back"),
                     4, TimeUnit.SECONDS);
             // publish a message on a topic that we have subscribed to with the wildcard #
-            executorService.schedule(() -> publishMessage("test/world/anything",
-                            "Message 3 should come back"),
+            executorService.schedule(() -> publishMessage("test/iot3/#",
+                            "This is an iot3 core message, it should also come back"),
                     6, TimeUnit.SECONDS);
             // disconnect the clients of IoT3Core
             executorService.schedule(ioT3Core::disconnectAll, 8, TimeUnit.SECONDS);


### PR DESCRIPTION
**Features**;

IoT3 Core SDK:
Telemetry is now operational when publishing and receiving MQTT messages, using the OpenTelemetry client: `service_name`, `span.status`, `span.name`, `span.kind`, `attributes` and `links` are all set according to the specification (see #128).

Closes: #128 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3CoreExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
// MQTT parameters
private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
private static final int EXAMPLE_MQTT_PORT_TCP = 1883;
private static final int EXAMPLE_MQTT_PORT_TLS = 8883;
private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
private static final String EXAMPLE_MQTT_CLIENT_ID = "mqtt_client_id";
// OpenTelemetry parameters
private static final String EXAMPLE_OTL_HOST = "telemetry_host";
private static final int EXAMPLE_OTL_PORT = 4318;
private static final String EXAMPLE_OTL_ENDPOINT = "/telemetry/endpoint";
private static final String EXAMPLE_OTL_USERNAME = "telemetry_username";
private static final String EXAMPLE_OTL_PASSWORD = "telemetry_password";
```
4. Run ```Iot3CoreExample```.

---
**Expected results:**

1. On the console, you should see 3 messages being published at 2 seconds interval, on 3 different topics:
The first and third messages should be received back, while the second should not be.
2. In Jaeger, you should be able to find the logs of the 3 published messages, and of the 2 received messages with links to the respective published ones.