### PR TITLE
Java/iot3core: secure message exchanges for user equipment

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -198,6 +198,14 @@ public class IoT3Core {
     }
 
     /**
+     * Check that the MQTT connection is secured with TLS
+     */
+    public boolean isMqttConnectionSecured() {
+        if(mqttClient != null) return mqttClient.isConnected() && mqttClient.isConnectionSecured();
+        else return false;
+    }
+
+    /**
      * Build an instance of IoT3Core.
      */
     public static class IoT3CoreBuilder {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -31,51 +31,24 @@ public class IoT3Core {
      * Instantiate the IoT3.0 Core SDK.
      *
      * @param mqttHost MQTT broker address
+     * @param mqttPort port of the MQTT broker
      * @param mqttUsername MQTT username
      * @param mqttPassword MQTT password
      * @param mqttClientId unique MQTT client ID
-     * @param ioT3CoreCallback interface to retrieve the different clients outputs
-     * @param telemetryHost Open Telemetry server address
-     */
-    public IoT3Core(String mqttHost,
-                    String mqttUsername,
-                    String mqttPassword,
-                    String mqttClientId,
-                    IoT3CoreCallback ioT3CoreCallback,
-                    String telemetryHost) {
-        this(mqttHost,
-                1883,
-                8883,
-                mqttUsername,
-                mqttPassword,
-                mqttClientId,
-                ioT3CoreCallback,
-                telemetryHost,
-                -1,
-                "/telemetry",
-                "default",
-                "default");
-    }
-
-    /**
-     * Instantiate the IoT3.0 Core SDK.
-     *
-     * @param mqttHost MQTT broker address
-     * @param mqttPortTcp TCP port of the MQTT broker
-     * @param mqttPortTls TLS port of the MQTT broker
-     * @param mqttUsername MQTT username
-     * @param mqttPassword MQTT password
-     * @param mqttClientId unique MQTT client ID
+     * @param mqttUseTls use TLS for a secure connection with the MQTT broker
      * @param ioT3CoreCallback interface to retrieve the different clients outputs
      * @param telemetryHost Open Telemetry server address
      * @param telemetryPort port of the Open Telemetry server
+     * @param telemetryEndpoint endpoint of the Open Telemetry server URL
+     * @param telemetryUsername Open Telemetry username
+     * @param telemetryPassword Open Telemetry password
      */
-    public IoT3Core(String mqttHost,
-                    int mqttPortTcp,
-                    int mqttPortTls,
+    private IoT3Core(String mqttHost,
+                    int mqttPort,
                     String mqttUsername,
                     String mqttPassword,
                     String mqttClientId,
+                    boolean mqttUseTls,
                     IoT3CoreCallback ioT3CoreCallback,
                     String telemetryHost,
                     int telemetryPort,
@@ -95,12 +68,11 @@ public class IoT3Core {
         // instantiate the MQTT client
         this.mqttClient = new MqttClient(
                 mqttHost,
-                mqttPortTcp,
-                mqttPortTls,
+                mqttPort,
                 mqttUsername,
                 mqttPassword,
                 mqttClientId,
-                null,
+                mqttUseTls,
                 new MqttCallback() {
                     @Override
                     public void connectionLost(Throwable cause) {
@@ -230,11 +202,11 @@ public class IoT3Core {
      */
     public static class IoT3CoreBuilder {
         private String mqttHost;
-        private int mqttPortTcp;
-        private int mqttPortTls;
+        private int mqttPort;
         private String mqttUsername;
         private String mqttPassword;
         private String mqttClientId;
+        private boolean mqttUseTls;
         private IoT3CoreCallback ioT3CoreCallback;
         private String telemetryHost;
         private int telemetryPort;
@@ -251,24 +223,24 @@ public class IoT3Core {
          * Set the MQTT parameters of your IoT3Core instance.
          *
          * @param mqttHost the host or IP address of the MQTT broker
-         * @param mqttPortTcp the TCP port of the MQTT broker
-         * @param mqttPortTls the TLS port of the MQTT broker
+         * @param mqttPort the port of the MQTT broker
          * @param mqttUsername the username for authentication with the MQTT broker
          * @param mqttPassword the password for authentication with the MQTT broker
          * @param mqttClientId your client ID
+         * @param mqttUseTls use TLS for a secure connection with the MQTT broker
          */
         public IoT3CoreBuilder mqttParams(String mqttHost,
-                                          int mqttPortTcp,
-                                          int mqttPortTls,
+                                          int mqttPort,
                                           String mqttUsername,
                                           String mqttPassword,
-                                          String mqttClientId) {
+                                          String mqttClientId,
+                                          boolean mqttUseTls) {
             this.mqttHost = mqttHost;
-            this.mqttPortTcp = mqttPortTcp;
-            this.mqttPortTls = mqttPortTls;
+            this.mqttPort = mqttPort;
             this.mqttUsername = mqttUsername;
             this.mqttPassword = mqttPassword;
             this.mqttClientId = mqttClientId;
+            this.mqttUseTls = mqttUseTls;
             return this;
         }
 
@@ -313,11 +285,11 @@ public class IoT3Core {
         public IoT3Core build() {
             return new IoT3Core(
                     mqttHost,
-                    mqttPortTcp,
-                    mqttPortTls,
+                    mqttPort,
                     mqttUsername,
                     mqttPassword,
                     mqttClientId,
+                    mqttUseTls,
                     ioT3CoreCallback,
                     telemetryHost,
                     telemetryPort,

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -38,7 +38,7 @@ public class MqttClient {
     private final MqttCallback callback;
     private final OpenTelemetryClient openTelemetryClient;
 
-    private boolean tlsConnection = false;
+    private final boolean useTls;
 
     public MqttClient(String serverHost,
                       int serverPort,
@@ -50,6 +50,7 @@ public class MqttClient {
                       OpenTelemetryClient openTelemetryClient) {
         this.callback = callback;
         this.openTelemetryClient = openTelemetryClient;
+        this.useTls = useTls;
 
         Mqtt5ClientBuilder mqttClientBuilder = com.hivemq.client.mqtt.MqttClient.builder()
                 .useMqttVersion5()
@@ -94,7 +95,6 @@ public class MqttClient {
                 }
             });
         }
-        tlsConnection = false;
     }
 
     public void connect() {
@@ -265,7 +265,7 @@ public class MqttClient {
     }
 
     public boolean isConnectionSecured() {
-        return isConnected() && tlsConnection;
+        return isConnected() && useTls;
     }
 
     public boolean isValidMqttPubTopic(String topic) {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -7,7 +7,6 @@
  */
 package com.orange.iot3core.clients;
 
-import com.hivemq.client.mqtt.MqttClientSslConfig;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
@@ -42,12 +41,11 @@ public class MqttClient {
     private boolean tlsConnection = false;
 
     public MqttClient(String serverHost,
-                      int tcpPort,
-                      int tlsPort,
+                      int serverPort,
                       String username,
                       String password,
                       String clientId,
-                      MqttClientSslConfig sslConfig,
+                      boolean useTls,
                       MqttCallback callback,
                       OpenTelemetryClient openTelemetryClient) {
         this.callback = callback;
@@ -57,6 +55,7 @@ public class MqttClient {
                 .useMqttVersion5()
                 .identifier(clientId)
                 .serverHost(serverHost)
+                .serverPort(serverPort)
                 .addDisconnectedListener(context1 -> {
                     LOGGER.log(Level.INFO, "Disconnected from MQTT broker " + serverHost);
                     callback.connectionLost(context1.getCause());
@@ -73,14 +72,10 @@ public class MqttClient {
                     .applySimpleAuth();
         }
 
-        if(sslConfig == null) {
-            mqttClient = mqttClientBuilder.serverPort(tcpPort)
-                    .buildAsync();
+        if(useTls) {
+            mqttClient = mqttClientBuilder.sslWithDefaultConfig().buildAsync();
         } else {
-            mqttClient = mqttClientBuilder.serverPort(tlsPort)
-                    .sslConfig(sslConfig)
-                    .buildAsync();
-            tlsConnection = true;
+            mqttClient = mqttClientBuilder.buildAsync();
         }
 
         // single callback for processing messages received on subscribed topics
@@ -93,7 +88,7 @@ public class MqttClient {
         if(mqttClient != null) {
             mqttClient.disconnect().whenComplete((mqtt5DisconnectResult, throwable) -> {
                 if(throwable != null) {
-                    LOGGER.log(Level.WARNING, "Error during disconnection");
+                    LOGGER.log(Level.WARNING, "Error during disconnection: " + throwable.getMessage());
                 } else {
                     LOGGER.log(Level.INFO, "Disconnected");
                 }
@@ -108,7 +103,7 @@ public class MqttClient {
                 .send()
                 .whenComplete((connAck, throwable) -> {
                     if(throwable != null) {
-                        LOGGER.log(Level.INFO, "Error during connection to the server");
+                        LOGGER.log(Level.INFO, "Error during connection to the server: " + throwable.getMessage());
                     } else {
                         LOGGER.log(Level.INFO, "Success connecting to the server");
                     }
@@ -123,7 +118,7 @@ public class MqttClient {
                     .send()
                     .whenComplete((subAck, throwable) -> {
                         if (throwable != null) {
-                            LOGGER.log(Level.WARNING, "Subscribed fail!");
+                            LOGGER.log(Level.WARNING, "Subscription failed: " + throwable.getMessage());
                         } else {
                             LOGGER.log(Level.FINE, "Subscribed!");
                         }
@@ -142,7 +137,7 @@ public class MqttClient {
                     .send()
                     .whenComplete((subAck, throwable) -> {
                         if (throwable != null) {
-                            LOGGER.log(Level.WARNING, "Unsubscribed fail!");
+                            LOGGER.log(Level.WARNING, "Unsubscription failed: " + throwable.getMessage());
                         } else {
                             LOGGER.log(Level.INFO, "Unsubscribed!");
                         }

--- a/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
@@ -78,6 +78,9 @@ public class Iot3CoreExample {
     }
 
     private static void onConnectionComplete() {
+        // Check if MQTT connection is secured
+        if(ioT3Core.isMqttConnectionSecured()) System.out.println("MQTT connection is SECURED");
+        else System.out.println("MQTT connection is NOT SECURED");
         // subscribe to the root test topic and to all iot3 topics using the wildcard #
         ioT3Core.mqttSubscribe("test");
         ioT3Core.mqttSubscribe("test/iot3/#");

--- a/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
@@ -11,11 +11,11 @@ public class Iot3CoreExample {
 
     // MQTT parameters
     private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
-    private static final int EXAMPLE_MQTT_PORT_TCP = 1883;
-    private static final int EXAMPLE_MQTT_PORT_TLS = 8883;
+    private static final int EXAMPLE_MQTT_PORT = 1883;
     private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
     private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
     private static final String EXAMPLE_MQTT_CLIENT_ID = "mqtt_client_id";
+    private static final boolean EXAMPLE_MQTT_USE_TLS = true;
     // OpenTelemetry parameters
     private static final String EXAMPLE_OTL_HOST = "telemetry_host";
     private static final int EXAMPLE_OTL_PORT = 4318;
@@ -29,11 +29,11 @@ public class Iot3CoreExample {
         // instantiate IoT3Core and its callback
         ioT3Core = new IoT3Core.IoT3CoreBuilder()
                 .mqttParams(EXAMPLE_MQTT_HOST,
-                        EXAMPLE_MQTT_PORT_TCP,
-                        EXAMPLE_MQTT_PORT_TLS,
+                        EXAMPLE_MQTT_PORT,
                         EXAMPLE_MQTT_USERNAME,
                         EXAMPLE_MQTT_PASSWORD,
-                        EXAMPLE_MQTT_CLIENT_ID)
+                        EXAMPLE_MQTT_CLIENT_ID,
+                        EXAMPLE_MQTT_USE_TLS)
                 .telemetryParams(EXAMPLE_OTL_HOST,
                         EXAMPLE_OTL_PORT,
                         EXAMPLE_OTL_ENDPOINT,

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
@@ -30,24 +30,37 @@ import java.util.concurrent.TimeUnit;
 
 public class Iot3MobilityExample {
 
-    private static final String EXAMPLE_HOST = "host";
-    private static final String EXAMPLE_USERNAME = "username";
-    private static final String EXAMPLE_PASSWORD = "password";
     private static final String EXAMPLE_UUID = "uuid";
     private static final String EXAMPLE_CONTEXT = "context";
-    private static final String EXAMPLE_TELEMETRY_HOST = "telemetry_host";
+    // MQTT parameters
+    private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
+    private static final int EXAMPLE_MQTT_PORT = 1883;
+    private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
+    private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
+    private static final boolean EXAMPLE_MQTT_USE_TLS = false;
+    // OpenTelemetry parameters
+    private static final String EXAMPLE_OTL_HOST = "telemetry_host";
+    private static final int EXAMPLE_OTL_PORT = 4318;
+    private static final String EXAMPLE_OTL_ENDPOINT = "/telemetry/endpoint";
+    private static final String EXAMPLE_OTL_USERNAME = "telemetry_username";
+    private static final String EXAMPLE_OTL_PASSWORD = "telemetry_password";
 
     private static IoT3Mobility ioT3Mobility;
 
     public static void main(String[] args) {
         // instantiate IoT3Mobility and its callback
-        ioT3Mobility = new IoT3Mobility(
-                EXAMPLE_HOST,
-                EXAMPLE_USERNAME,
-                EXAMPLE_PASSWORD,
-                EXAMPLE_UUID, // serves to identify the road user, app or infrastructure
-                EXAMPLE_CONTEXT, // serves as the root of the MQTT mobility topics
-                new IoT3MobilityCallback() {
+        ioT3Mobility = new IoT3Mobility.IoT3MobilityBuilder(EXAMPLE_UUID, EXAMPLE_CONTEXT)
+                .mqttParams(EXAMPLE_MQTT_HOST,
+                        EXAMPLE_MQTT_PORT,
+                        EXAMPLE_MQTT_USERNAME,
+                        EXAMPLE_MQTT_PASSWORD,
+                        EXAMPLE_MQTT_USE_TLS)
+                .telemetryParams(EXAMPLE_OTL_HOST,
+                        EXAMPLE_OTL_PORT,
+                        EXAMPLE_OTL_ENDPOINT,
+                        EXAMPLE_OTL_USERNAME,
+                        EXAMPLE_OTL_PASSWORD)
+                .callback(new IoT3MobilityCallback() {
                     @Override
                     public void connectionLost(Throwable cause) {
                         System.out.println("MQTT Connection lost...");
@@ -57,8 +70,8 @@ public class Iot3MobilityExample {
                     public void connectComplete(boolean reconnect, String serverURI) {
                         System.out.println("MQTT connection complete: " + serverURI);
                     }
-                },
-                EXAMPLE_TELEMETRY_HOST);
+                })
+                .build();
 
         // set the RoadHazardCallback to be informed of road hazards in the corresponding Region of Interest (RoI)
         ioT3Mobility.setRoadHazardCallback(new IoT3RoadHazardCallback() {
@@ -90,13 +103,13 @@ public class Iot3MobilityExample {
                 // RoadUser is a simple object provided by IoT3Mobility
                 System.out.println("New Road User: " + roadUser.getUuid());
                 LatLng position = roadUser.getPosition();
-                System.out.println("Road User position: " + position.toString());
+                System.out.println("Road User position: " + position);
                 // the CAM on which this object is based can still be accessed
                 CAM originalCam = roadUser.getCam();
                 double latitude = originalCam.getBasicContainer().getPosition().getLatitudeDegree();
                 double longitude = originalCam.getBasicContainer().getPosition().getLongitudeDegree();
                 LatLng camPosition = new LatLng(latitude, longitude);
-                System.out.println("CAM position: " + camPosition.toString());
+                System.out.println("CAM position: " + camPosition);
             }
 
             @Override


### PR DESCRIPTION
**Features**;

IoT3 Core SDK:
TLS is now operational to secure the connection with an MQTT broker (server certificate only, using system trust store to verify it).

Closes: #139 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3CoreExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
// MQTT parameters
private static final String EXAMPLE_MQTT_HOST = "test.mosquitto.org";
private static final int EXAMPLE_MQTT_PORT = 8886;
private static final String EXAMPLE_MQTT_USERNAME = "";
private static final String EXAMPLE_MQTT_PASSWORD = "";
private static final String EXAMPLE_MQTT_CLIENT_ID = "mqtt_tls_test";
private static final boolean EXAMPLE_MQTT_USE_TLS = false;
```
4. Run ```Iot3CoreExample```.
5. Observe results, then change : 
```
private static final boolean EXAMPLE_MQTT_USE_TLS = true;
```
6. Run ```Iot3CoreExample``` again.

---
**Expected results:**

1. On the console, you should see that the connection to the broker fails on port 8886 when TLS is set to `false`. This is expected because on port 8886, the broker only accepts TLS connections (see [https://test.mosquitto.org/](https://test.mosquitto.org/)).
2. On the console, you should see that the connection to the broker succeeds on port 8886 when TLS is set to `true`, with a log message `MQTT connection is SECURED` and some messages exchanges happening before the client disconnects.