### PR TITLE
java/iot3mobility: fix topic root for mobility messages publication

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -44,6 +44,7 @@ public class IoT3Mobility {
     private final RoIManager roIManager;
 
     private final String uuid;
+    private final String context;
     private final int stationId;
 
     /**
@@ -77,6 +78,7 @@ public class IoT3Mobility {
                         String telemetryUsername,
                         String telemetryPassword) {
         this.uuid = uuid;
+        this.context = context;
         // random stationId at the moment, will be an option to set it later on
         this.stationId = Utils.randomBetween(999, 99999999);
 
@@ -291,7 +293,7 @@ public class IoT3Mobility {
         String quadkey = QuadTileHelper.latLngToQuadKey(cam.getBasicContainer().getPosition().getLatitudeDegree(),
                 cam.getBasicContainer().getPosition().getLongitudeDegree(), 22);
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
-        String topic = "SWR/inQueue/v2x/cam/" + uuid + geoExtension;
+        String topic = context + "/inQueue/v2x/cam/" + uuid + geoExtension;
 
         // send the message
         if(ioT3Core != null) ioT3Core.mqttPublish(topic, cam.getJsonCAM().toString());
@@ -358,7 +360,7 @@ public class IoT3Mobility {
                 denm.getManagementContainer().getEventPosition().getLongitudeDegree(),
                 22);
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
-        String topic = "SWR/inQueue/v2x/denm/" + uuid + geoExtension;
+        String topic = context + "/inQueue/v2x/denm/" + uuid + geoExtension;
 
         // send the message
         if(ioT3Core != null) ioT3Core.mqttPublish(topic, denm.getJsonDENM().toString());
@@ -376,7 +378,7 @@ public class IoT3Mobility {
                 cpm.getManagementContainer().getReferencePosition().getLongitudeDegree(),
                 22);
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
-        String topic = "SWR/inQueue/v2x/cpm/" + uuid + geoExtension;
+        String topic = context + "/inQueue/v2x/cpm/" + uuid + geoExtension;
 
         // send the message
         if(ioT3Core != null) ioT3Core.mqttPublish(topic, cpm.getJson().toString());


### PR DESCRIPTION
**Fixes**;

IoT3 Mobility SDK:
Fix topic root for CAM, DENM and CPM publication : it is now correctly set according to the "context" parameter.

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context"; // this will be used as the topic root
// MQTT parameters
private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
private static final int EXAMPLE_MQTT_PORT = 1883;
private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
private static final boolean EXAMPLE_MQTT_USE_TLS = false;
```
_Note: use an MQTT broker paired with an interQueue manager taking care of the inQueue -> outQueue copy._

4. Run ```Iot3MobilityExample``` and check that the mobility messages are published and received with the appropriate topic root (i.e. equal to the "context" parameter).

---
**Expected results:**

1. CAMs should be sent and received at 1 Hz, and visible in the logs.
2. DENMs should be sent and received every 10 seconds, and visible in the logs.
3. CPMs should be sent and received at 1 Hz, and visible in the logs.

You can also use the ITSdroid app (with a project code matching the EXAMPLE_CONTEXT value), to visualise the messages at the UTAC TEQMO.
