### PR TITLE
python: fix issues 198 & 203

### DIFF
--- a/python/its-status/its_status/collector.cellular.py
+++ b/python/its-status/its_status/collector.cellular.py
@@ -30,7 +30,11 @@ class Status:
                     "code": m_j["modem"]["3gpp"]["operator-code"],
                     "name": m_j["modem"]["3gpp"]["operator-name"],
                 }
-                tech = m_j["modem"]["generic"]["access-technologies"][0]
+                try:
+                    # We might not yet know what technology is used...
+                    tech = m_j["modem"]["generic"]["access-technologies"][0]
+                except KeyError:
+                    tech = None
                 item["connection"] = {
                     "technology": tech,
                     "signal": [],

--- a/python/its-vehicle/its_vehicle/client.py
+++ b/python/its-vehicle/its_vehicle/client.py
@@ -193,7 +193,7 @@ class ITSClient:
                 payload_d.get("source_uuid", None) != self.cfg["instance-id"]
                 or self.cfg["mirror-self"]
             ):
-                self.mqtt_mirror.publish(topic, payload)
+                self.mqtt_mirror.publish(topic=topic, payload=payload)
         except:
             # Payload does not have expected fields, or is not a dict;
             # ignore this invalid message


### PR DESCRIPTION
**Changes:**

* Fixes: #198 
* Fixes: #203 

---
**How to test:**

1. The fix for #198 is hard to validate, as the condition seldom occurs in practice...
2. Test the fix for #203: 
    1. install _its-vehicle_ and its dependencies
    2. configure _its-vehicle_ with both a remote and a local MQTT broker
    3. run _its-vehicle_
    4. observe the quadkeys in the topic of messages received by the remote broker
    5. send a message to the remote broker, on a topic which quadkeys is _close_ to the messages above

---
**Expected results:**

1. _its-status_ does not crash anymore
2. the message sent in step _v._ is received on the local broker