### PR TITLE
Rust authority bootstrap

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -81,6 +81,7 @@ features = ["trace", "rt-tokio"]
 
 [dependencies.reqwest]
 version = "0.11"
+features = ["json"]
 
 [dependencies.serde]
 version = "1.0"

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -2,6 +2,14 @@
 id="ora_opensource"
 type="mec_application"
 
+#[bootstrap]
+#host="mydomain.com"
+#port="8080"
+#path="/bootstrap"
+#role="external-app"
+#username="login"
+#password="password"
+
 [mqtt]
 host="test.mosquitto.org"
 port=8886

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,4 +14,5 @@
 /// or to create/store data (e.g. counting pedestrian, vehicles, etc. in a specific area)
 #[cfg(feature = "mobility")]
 pub mod application;
+pub mod bootstrap;
 pub mod configuration;

--- a/rust/src/client/bootstrap.rs
+++ b/rust/src/client/bootstrap.rs
@@ -1,0 +1,447 @@
+/*
+ * Software Name : libits-client
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ */
+
+use crate::client::bootstrap::bootstrap_error::BootstrapError;
+use crate::client::configuration::bootstrap_configuration::BootstrapConfiguration;
+use crate::client::configuration::configuration_error::ConfigurationError;
+#[cfg(feature = "geo_routing")]
+use crate::client::configuration::geo_configuration::GeoConfiguration;
+#[cfg(feature = "telemetry")]
+use crate::client::configuration::telemetry_configuration::TelemetryConfiguration;
+use crate::client::configuration::{get_optional_from_section, Configuration, MqttOptionWrapper};
+#[cfg(feature = "mobility")]
+use {
+    crate::client::configuration::{
+        mobility_configuration::MobilityConfiguration,
+        node_configuration::{NodeConfiguration, NODE_SECTION},
+        pick_mandatory_section,
+    },
+    std::sync::RwLock,
+};
+
+use crate::client::bootstrap::bootstrap_error::BootstrapError::{
+    InvalidResponse, MissingField, NotAString,
+};
+use crate::client::configuration::configuration_error::ConfigurationError::{
+    BootstrapFailure, MissingMandatoryField,
+};
+use ini::{Ini, Properties};
+use log::{debug, error, info, trace, warn};
+use reqwest::Url;
+use rumqttc::v5::MqttOptions;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::ops::Deref;
+
+mod bootstrap_error;
+
+#[derive(Debug)]
+struct Bootstrap {
+    id: String,
+    username: String,
+    password: String,
+    protocols: HashMap<String, String>,
+}
+
+impl TryFrom<Value> for Bootstrap {
+    type Error = BootstrapError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        if let Some(protocols) = value.get("protocols") {
+            if let Some(protocols) = protocols.as_object() {
+                let protocols: Result<_, _> = protocols.iter().map(extract_protocol_pair).collect();
+                let protocols = protocols?;
+
+                Ok(Bootstrap {
+                    id: extract_str("iot3_id", &value)?,
+                    username: extract_str("psk_run_login", &value)?,
+                    password: extract_str("psk_run_password", &value)?,
+                    protocols,
+                })
+            } else {
+                warn!("Failed to convert {:?} as JSON object", protocols);
+                Err(InvalidResponse("'protocols' field is not a JSON object"))
+            }
+        } else {
+            Err(MissingField("protocols"))
+        }
+    }
+}
+
+/// Calls the bootstrap API and builds a Configuration out of bootstrap information
+///
+/// Bootstrap sequence will return the URL and credentials to use to connect to the services
+/// (MQTT, OTLP collector, ...), any of these information already present in the configuration file
+/// would be overridden  
+/// All the other fields that are unrelated to services connection are still read from
+/// the configuration file and set in the Configuration object
+///
+/// Example of the bootstrap configuration section:
+/// ```ini
+/// [bootstrap]
+/// host="mydomain.com"
+/// port=1234
+/// path="/bootstrap"
+/// role="external-app"
+/// username="boot"
+/// password="str4P!"
+/// ```
+pub async fn bootstrap(mut ini: Ini) -> Result<Configuration, ConfigurationError> {
+    info!("Beginning bootstrap...");
+
+    let bootstrap_configuration = BootstrapConfiguration::try_from(&mut ini)?;
+
+    match do_bootstrap(bootstrap_configuration).await {
+        Ok(b) => {
+            info!("Bootstrap call successful !");
+            debug!("{:?}", &b);
+
+            Ok(Configuration {
+                mqtt_options: mqtt_configuration_from_bootstrap(
+                    &b,
+                    ini.delete(Some("mqtt")).unwrap_or_default(),
+                )?,
+                #[cfg(feature = "geo_routing")]
+                geo: GeoConfiguration::try_from(&pick_mandatory_section(
+                    crate::client::configuration::geo_configuration::GEO_SECTION,
+                    &mut ini,
+                )?)?,
+                #[cfg(feature = "telemetry")]
+                telemetry: telemetry_configuration_from_bootstrap(
+                    &b,
+                    ini.delete(Some("telemetry")).unwrap_or_default(),
+                )?,
+                #[cfg(feature = "mobility")]
+                mobility: MobilityConfiguration::try_from(&pick_mandatory_section(
+                    crate::client::configuration::mobility_configuration::STATION_SECTION,
+                    &mut ini,
+                )?)?,
+                #[cfg(feature = "mobility")]
+                node: match ini.section(Some(NODE_SECTION)) {
+                    Some(properties) => Some(RwLock::new(NodeConfiguration::try_from(properties)?)),
+                    None => None,
+                },
+                custom_settings: Some(ini),
+            })
+        }
+        Err(e) => {
+            error!("Failed to proceed to bootstrap: {:?}", e);
+            Err(BootstrapFailure(format!("{}", e)))
+        }
+    }
+}
+
+fn mqtt_configuration_from_bootstrap(
+    bootstrap: &Bootstrap,
+    mut mqtt_section: Properties,
+) -> Result<MqttOptions, ConfigurationError> {
+    let tls = get_optional_from_section("use_tls", &mqtt_section)?.unwrap_or_default();
+    let ws = get_optional_from_section("use_websocket", &mqtt_section)?.unwrap_or_default();
+
+    let uri = match (tls, ws) {
+        (true, true) => bootstrap
+            .protocols
+            .get("mqtt-wss")
+            .ok_or(MissingMandatoryField("mqtt-wss", "protocols")),
+        (false, true) => bootstrap
+            .protocols
+            .get("mqtt-ws")
+            .ok_or(MissingMandatoryField("mqtt-ws", "protocols")),
+        (true, false) => bootstrap
+            .protocols
+            .get("mqtts")
+            .ok_or(MissingMandatoryField("mqtts", "protocols")),
+        (false, false) => bootstrap
+            .protocols
+            .get("mqtt")
+            .ok_or(MissingMandatoryField("mqtt", "protocols")),
+    }?;
+
+    let url: Url = {
+        if let Ok(url) = Url::parse(uri) {
+            Ok(url)
+        } else {
+            Err(BootstrapFailure(format!(
+                "Failed to convert '{}' as Url",
+                uri
+            )))
+        }
+    }?;
+
+    if ws {
+        mqtt_section.insert("host", url.authority());
+    } else {
+        mqtt_section.insert(
+            "host",
+            url.host_str()
+                .ok_or(BootstrapFailure("URL must have a host".to_string()))?,
+        );
+    }
+
+    mqtt_section.insert(
+        "port",
+        url.port()
+            .ok_or(BootstrapFailure("URL must have a port".to_string()))?
+            .to_string(),
+    );
+    mqtt_section.insert("client_id", &bootstrap.id);
+    mqtt_section.insert("username", &bootstrap.username);
+    mqtt_section.insert("password", &bootstrap.password);
+
+    match MqttOptionWrapper::try_from(&mqtt_section) {
+        Ok(wrapper) => Ok(wrapper.deref().clone()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(feature = "telemetry")]
+fn telemetry_configuration_from_bootstrap(
+    bootstrap: &Bootstrap,
+    mut telemetry_section: Properties,
+) -> Result<TelemetryConfiguration, ConfigurationError> {
+    let tls = get_optional_from_section("use_tls", &telemetry_section)?.unwrap_or_default();
+
+    let uri = if tls {
+        bootstrap
+            .protocols
+            .get("otlp-https")
+            .ok_or(MissingMandatoryField("otlp-https", "protocols"))
+    } else {
+        bootstrap
+            .protocols
+            .get("otlp-http")
+            .ok_or(MissingMandatoryField("otlp-http", "protocols"))
+    }?;
+
+    let url = Url::parse(uri).expect("Not an URL");
+
+    // FIXME wouldn't it be more simple to use the endpoint directly...
+    telemetry_section.insert(
+        "host",
+        url.host_str()
+            .ok_or(BootstrapFailure("URL must have a host".to_string()))?,
+    );
+    telemetry_section.insert(
+        "port",
+        url.port()
+            .ok_or(BootstrapFailure("URL must have a port".to_string()))?
+            .to_string(),
+    );
+    telemetry_section.insert("path", url.path());
+    telemetry_section.insert("username", &bootstrap.username);
+    telemetry_section.insert("password", &bootstrap.password);
+
+    TelemetryConfiguration::try_from(&telemetry_section)
+}
+
+async fn do_bootstrap(
+    bootstrap_configuration: BootstrapConfiguration,
+) -> Result<Bootstrap, BootstrapError> {
+    info!(
+        "Calling bootstrap on '{}'...",
+        bootstrap_configuration.endpoint
+    );
+
+    let client = reqwest::ClientBuilder::new()
+        .build()
+        .expect("Failed to create telemetry HTTP client");
+
+    let body = json!({
+        "ue_id": bootstrap_configuration.station_id,
+        "psk_login": bootstrap_configuration.username,
+        "psk_password": bootstrap_configuration.password,
+        "role": bootstrap_configuration.role
+    })
+    .to_string();
+
+    match client
+        .post(bootstrap_configuration.endpoint)
+        .basic_auth(
+            bootstrap_configuration.username,
+            Some(bootstrap_configuration.password),
+        )
+        .body(body)
+        .send()
+        .await
+    {
+        Ok(response) => match response.text().await {
+            Ok(body) => {
+                trace!("Bootstrap body = {:?}", body);
+                match serde_json::from_str::<Value>(body.as_str()) {
+                    Ok(json_value) => Bootstrap::try_from(json_value),
+                    Err(e) => {
+                        warn!("Error: {:?}", e);
+                        Err(InvalidResponse("Failed to parse response as JSON"))
+                    }
+                }
+            }
+            Err(e) => {
+                debug!("Error: {:?}", e);
+                Err(BootstrapError::ContentError(e.to_string()))
+            }
+        },
+        Err(e) => {
+            debug!("Request error: {:?}", e);
+            Err(BootstrapError::NetworkError(e.to_string()))
+        }
+    }
+}
+
+fn extract_str(field: &'static str, json_value: &Value) -> Result<String, BootstrapError> {
+    if let Some(value) = json_value.get(field) {
+        if let Some(as_str) = value.as_str() {
+            Ok(as_str.to_string())
+        } else {
+            Err(NotAString(field.to_string()))
+        }
+    } else {
+        Err(MissingField(field))
+    }
+}
+
+fn extract_protocol_pair(entry: (&String, &Value)) -> Result<(String, String), BootstrapError> {
+    let key = entry.0.to_string();
+    if let Some(value) = entry.1.as_str() {
+        Ok((key, value.to_string()))
+    } else {
+        Err(NotAString(key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::client::bootstrap::Bootstrap;
+    use serde_json::Value;
+
+    #[test]
+    fn try_from_valid_response() {
+        let response = serde_json::from_str::<Value>(
+            r#"
+            {
+                "iot3_id": "cool_id",
+                "psk_run_login": "notadmin",
+                "psk_run_password": "!s3CuR3",
+                "protocols": {
+                    "mqtt": "mqtt://mqtt.domain.com:1884",
+                    "mqtt-ws": "http://domain.com:8000/message",
+                    "otlp-http": "http://domain.com:8000/collector",
+                    "jaeger-http": "http://domain.com:8000/jaeger"
+                }
+            }"#,
+        )
+        .expect("Failed to create JSON from string");
+
+        let result = Bootstrap::try_from(response);
+
+        assert!(result.is_ok());
+    }
+
+    macro_rules! try_from_invalid_response_returns_error {
+        ($test_name:ident, $response:expr) => {
+            #[test]
+            fn $test_name() {
+                let response = serde_json::from_str::<Value>($response)
+                    .expect("Failed to create JSON from string");
+
+                let result = Bootstrap::try_from(response);
+
+                assert!(result.is_err());
+            }
+        };
+    }
+    try_from_invalid_response_returns_error!(
+        iot3_id_is_not_a_string,
+        r#"
+        {
+            "iot3_id": ["cool_id"],
+            "psk_run_login": "notadmin",
+            "psk_run_password": "!s3CuR3",
+            "protocols": {
+                "mqtt": "mqtt://mqtt.domain.com:1884",
+                "mqtt-ws": "http://domain.com:8000/message",
+                "otlp-http": "http://domain.com:8000/collector",
+                "jaeger-http": "http://domain.com:8000/jaeger"
+            }
+        }"#
+    );
+    try_from_invalid_response_returns_error!(
+        psk_login_is_not_a_string,
+        r#"
+        {
+            "iot3_id": "cool_id",
+            "psk_run_login": {"value": "notadmin"},
+            "psk_run_password": "!s3CuR3",
+            "protocols": {
+                "mqtt": "mqtt://mqtt.domain.com:1884",
+                "mqtt-ws": "http://domain.com:8000/message",
+                "otlp-http": "http://domain.com:8000/collector",
+                "jaeger-http": "http://domain.com:8000/jaeger"
+            }
+        }"#
+    );
+    try_from_invalid_response_returns_error!(
+        psk_password_is_not_a_string,
+        r#"
+        {
+            "iot3_id": "cool_id",
+            "psk_run_login": "notadmin",
+            "psk_run_password": {"plain": "!s3CuR3"},
+            "protocols": {
+                "mqtt": "mqtt://mqtt.domain.com:1884",
+                "mqtt-ws": "http://domain.com:8000/message",
+                "otlp-http": "http://domain.com:8000/collector",
+                "jaeger-http": "http://domain.com:8000/jaeger"
+            }
+        }"#
+    );
+    try_from_invalid_response_returns_error!(
+        missing_protocols,
+        r#"
+        {
+            "iot3_id": "cool_id",
+            "psk_run_login": "notadmin",
+            "psk_run_password": "!s3CuR3",
+            "protocol": {
+                "mqtt": "mqtt://mqtt.domain.com:1884",
+                "mqtt-ws": "http://domain.com:8000/message",
+                "otlp-http": "http://domain.com:8000/collector",
+                "jaeger-http": "http://domain.com:8000/jaeger"
+            }
+        }"#
+    );
+    try_from_invalid_response_returns_error!(
+        protocols_is_not_an_object,
+        r#"
+        {
+            "iot3_id": "cool_id",
+            "psk_run_login": "notadmin",
+            "psk_run_password": "!s3CuR3",
+            "protocols": [
+                "mqtt://mqtt.domain.com:1884",
+                "http://domain.com:8000/message",
+                "http://domain.com:8000/collector",
+                "http://domain.com:8000/jaeger"
+            ]
+        }"#
+    );
+    try_from_invalid_response_returns_error!(
+        protocol_value_is_not_a_string,
+        r#"
+        {
+            "iot3_id": "cool_id",
+            "psk_run_login": "notadmin",
+            "psk_run_password": "!s3CuR3",
+            "protocols": {
+                "mqtt": ["mqtt://mqtt.domain.com:1884", "mqtts://mqtt.domain.com:8884"]
+            }
+        }"#
+    );
+}

--- a/rust/src/client/bootstrap/bootstrap_error.rs
+++ b/rust/src/client/bootstrap/bootstrap_error.rs
@@ -1,0 +1,26 @@
+/*
+ * Software Name : libits-client
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ */
+
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub(crate) enum BootstrapError {
+    #[error("Bootstrap response is invalid: {0}")]
+    InvalidResponse(&'static str),
+    #[error("Boostrap response is missing required field '{0}'")]
+    MissingField(&'static str),
+    #[error("Could not convert bootstrap response as string: {0}")]
+    ContentError(String),
+    #[error("Bootstrap request failed: {0}")]
+    NetworkError(String),
+    #[error("Could not parse value of field '{0}' as a string")]
+    NotAString(String),
+}

--- a/rust/src/client/configuration.rs
+++ b/rust/src/client/configuration.rs
@@ -39,6 +39,7 @@ use crate::client::configuration::{
 #[cfg(feature = "geo_routing")]
 use crate::client::configuration::geo_configuration::{GeoConfiguration, GEO_SECTION};
 
+pub(crate) mod bootstrap_configuration;
 pub mod configuration_error;
 #[cfg(feature = "geo_routing")]
 pub mod geo_configuration;

--- a/rust/src/client/configuration/bootstrap_configuration.rs
+++ b/rust/src/client/configuration/bootstrap_configuration.rs
@@ -1,0 +1,38 @@
+use crate::client::configuration::configuration_error::ConfigurationError;
+use crate::client::configuration::{
+    get_mandatory_field, get_mandatory_from_section, pick_mandatory_section,
+};
+use ini::Ini;
+
+#[derive(Debug)]
+pub struct BootstrapConfiguration {
+    pub endpoint: String,
+    pub station_id: String,
+    pub username: String,
+    pub password: String,
+    pub role: String,
+}
+
+impl TryFrom<&mut Ini> for BootstrapConfiguration {
+    type Error = ConfigurationError;
+
+    fn try_from(ini: &mut Ini) -> Result<Self, Self::Error> {
+        let properties = &pick_mandatory_section("bootstrap", ini)?;
+        let section = ("bootstrap", properties);
+
+        let endpoint = format!(
+            "http://{}:{}{}",
+            get_mandatory_from_section::<String>("host", section)?,
+            get_mandatory_from_section::<u16>("port", section)?,
+            get_mandatory_from_section::<String>("path", section)?,
+        );
+
+        Ok(Self {
+            endpoint,
+            station_id: get_mandatory_field::<String>(Some("station"), "id", ini)?,
+            username: get_mandatory_from_section::<String>("username", section)?,
+            password: get_mandatory_from_section::<String>("password", section)?,
+            role: get_mandatory_from_section::<String>("role", section)?,
+        })
+    }
+}

--- a/rust/src/client/configuration/configuration_error.rs
+++ b/rust/src/client/configuration/configuration_error.rs
@@ -13,6 +13,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ConfigurationError {
+    #[error("{0}")]
+    BootstrapFailure(String),
     #[error("Could not found field '{0}'")]
     FieldNotFound(&'static str),
     #[error("Cannot parse '{0}' due to invalid file type")]

--- a/rust/src/client/configuration/geo_configuration.rs
+++ b/rust/src/client/configuration/geo_configuration.rs
@@ -1,5 +1,5 @@
 use crate::client::configuration::configuration_error::ConfigurationError;
-use crate::client::configuration::get_mandatory_field;
+use crate::client::configuration::get_mandatory_from_section;
 use ini::Properties;
 
 pub(crate) const GEO_SECTION: &str = "geo";
@@ -26,8 +26,8 @@ impl TryFrom<&Properties> for GeoConfiguration {
 
     fn try_from(properties: &Properties) -> Result<Self, Self::Error> {
         Ok(Self {
-            prefix: get_mandatory_field::<String>("prefix", ("geo", properties))?,
-            suffix: get_mandatory_field::<String>("suffix", ("geo", properties))?,
+            prefix: get_mandatory_from_section::<String>("prefix", ("geo", properties))?,
+            suffix: get_mandatory_from_section::<String>("suffix", ("geo", properties))?,
         })
     }
 }

--- a/rust/src/client/configuration/mobility_configuration.rs
+++ b/rust/src/client/configuration/mobility_configuration.rs
@@ -12,7 +12,7 @@
 use ini::Properties;
 
 use crate::client::configuration::configuration_error::ConfigurationError;
-use crate::client::configuration::get_mandatory_field;
+use crate::client::configuration::get_mandatory_from_section;
 
 pub(crate) const STATION_SECTION: &str = "station";
 
@@ -29,8 +29,14 @@ impl TryFrom<&Properties> for MobilityConfiguration {
 
     fn try_from(properties: &Properties) -> Result<Self, Self::Error> {
         let s = MobilityConfiguration {
-            station_id: get_mandatory_field(STATION_ID_FIELD, (STATION_SECTION, properties))?,
-            station_type: get_mandatory_field(STATION_TYPE_FIELD, (STATION_SECTION, properties))?,
+            station_id: get_mandatory_from_section(
+                STATION_ID_FIELD,
+                (STATION_SECTION, properties),
+            )?,
+            station_type: get_mandatory_from_section(
+                STATION_TYPE_FIELD,
+                (STATION_SECTION, properties),
+            )?,
         };
 
         Ok(s)

--- a/rust/src/client/configuration/node_configuration.rs
+++ b/rust/src/client/configuration/node_configuration.rs
@@ -10,7 +10,7 @@
  */
 
 use crate::client::configuration::configuration_error::ConfigurationError;
-use crate::client::configuration::{get_mandatory_field, get_optional_from_section};
+use crate::client::configuration::{get_mandatory_from_section, get_optional_from_section};
 use crate::exchange::message::information::Information;
 use crate::mobility::quadtree;
 use crate::mobility::quadtree::quadkey::Quadkey;
@@ -118,7 +118,10 @@ impl TryFrom<&Properties> for NodeConfiguration {
         }
 
         let s = Self {
-            responsibility_enabled: get_mandatory_field::<bool>("responsibility_enabled", section)?,
+            responsibility_enabled: get_mandatory_from_section::<bool>(
+                "responsibility_enabled",
+                section,
+            )?,
             thread_count,
             ..Default::default()
         };

--- a/rust/src/client/configuration/telemetry_configuration.rs
+++ b/rust/src/client/configuration/telemetry_configuration.rs
@@ -4,7 +4,7 @@ use log::warn;
 use std::string::ToString;
 
 use crate::client::configuration::configuration_error::ConfigurationError;
-use crate::client::configuration::{get_mandatory_field, get_optional_from_section};
+use crate::client::configuration::{get_mandatory_from_section, get_optional_from_section};
 
 pub(crate) const TELEMETRY_SECTION: &str = "telemetry";
 pub(crate) const DEFAULT_PATH: &str = "v1/traces";
@@ -76,15 +76,15 @@ impl TryFrom<&Properties> for TelemetryConfiguration {
         let (username, password) =
             match get_optional_from_section::<String>("username", properties)? {
                 Some(username) => {
-                    let password = get_mandatory_field::<String>("password", section)?;
+                    let password = get_mandatory_from_section::<String>("password", section)?;
                     (Some(username), Some(password))
                 }
                 None => (None, None),
             };
 
         let s = TelemetryConfiguration {
-            host: get_mandatory_field::<String>("host", section)?,
-            port: get_mandatory_field::<u16>("port", section)?,
+            host: get_mandatory_from_section::<String>("host", section)?,
+            port: get_mandatory_from_section::<u16>("port", section)?,
             path,
             batch_size,
             username,


### PR DESCRIPTION
What's new
---------------

New function to create a Configuration from bootstrap sequence  
The bootstrap sequence provide services' URL and credentials, any of these information already present in the configuration file
All the other fields that are unrelated to services connection are still read from the configuration file and set in the Configuration object

closes #185 
closes #161 

How to test
---------------

1. Edit `examples/config.ini` and 
    1. Fill the `[bootstrap]` section with the proper endpoint and credentials
    2. Remove the `[mqtt]` section
    3. Remove the ``telemetry]` section
2. Apply the joined [patch][1] to make the `copycat` example using the bootstrap sequence
    ```
    cd rust
    wget https://github.com/user-attachments/files/17728759/copycat_bootstrap.txt
    mv copycat_bootstrap.txt copycat_bootstrap.patch
    git apply copycat_bootstrap.patch
    ```
3. Start the `copycat` example
    ```
    cargo run --example copycat --features geo_routing --features telemetry
    ```
    **=> The example runs and receives messages**

[1]: https://github.com/user-attachments/files/17728759/copycat_bootstrap.txt
