### PR TITLE
python/iot3: implement mobility SDK

### DIFF
--- a/python/iot3/pyproject.toml
+++ b/python/iot3/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "paho-mqtt>=2.1.0",
     "requests>=2.31.0",
+    "its-quadkeys @ git+https://github.com/Orange-OpenSource/its-client@2eb528a6497411b807ea62f08dc0dc8306e3cbb0#subdirectory=python/its-quadkeys"
 ]
 
 [project.urls]

--- a/python/iot3/src/iot3/mobility/__init__.py
+++ b/python/iot3/src/iot3/mobility/__init__.py
@@ -6,6 +6,7 @@
 import json
 
 from . import etsi
+from .cam import CAM
 from .gnss import GNSSReport
 
 
@@ -14,7 +15,9 @@ def message_from_json(
     msg_json: str,
 ) -> etsi.Message:
     """Create a new ITS message from a json sentence"""
-    _MSG_TYPE_CLASS = dict()
+    _MSG_TYPE_CLASS = {
+        "cam": CAM,
+    }
     # We should validate msg_json here before loading it,
     # but we need to know the type of message first
     try:

--- a/python/iot3/src/iot3/mobility/__init__.py
+++ b/python/iot3/src/iot3/mobility/__init__.py
@@ -7,6 +7,7 @@ import json
 
 from . import etsi
 from .cam import CAM
+from .denm import DENM
 from .gnss import GNSSReport
 
 
@@ -17,6 +18,7 @@ def message_from_json(
     """Create a new ITS message from a json sentence"""
     _MSG_TYPE_CLASS = {
         "cam": CAM,
+        "denm": DENM,
     }
     # We should validate msg_json here before loading it,
     # but we need to know the type of message first

--- a/python/iot3/src/iot3/mobility/__init__.py
+++ b/python/iot3/src/iot3/mobility/__init__.py
@@ -3,12 +3,306 @@
 # SPDX-License-Identifier: MIT
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
+import copy
+import its_quadkeys
 import json
+import time
+
+from typing import Any, Callable, Optional, Protocol, TypeAlias
+
+from .. import core
 
 from . import etsi
 from .cam import CAM
 from .denm import DENM
 from .gnss import GNSSReport
+
+
+"""
+This module provides a high-level IoT3 Mobility client with a very simple API.
+
+This simple API consists in a few functions and a type annotation:
+
+* Functions:
+  * start(): start the IoT3 Mobility client
+  * send_position():
+  * send_alert(): send an alert
+  * stop(): stop the IoT3 Mobility client
+
+* Type annotations:
+  * AlertCallbackType: the type annotation of a function called when a
+    message is received; parameters will be passed as keyword arguments;
+    to be future proof, such a function should be declared as:
+        def my_alert_callback(
+            *_args,
+            data: typing.Any,
+            location: iot3.mobility.gnss.GNSSReport,
+            cause: iot3.mobility.denm.DENM.Cause,
+            **_kwargs,
+        ) -> None:
+            ...
+"""
+
+
+sample_config = dict(core.sample_config)
+sample_config.update(
+    {
+        "uuid": "1234",
+        "station_type": etsi.Message.StationType.unknown,
+        "namespace": "default",
+        "report_depth": 22,
+        "roi_depth": 15,
+    }
+)
+
+# Simple type annotation for now, as doing a proper type annotation for
+# a callable with *args and **kwargs is non trivial, and even though
+# python 3.13 will make that slightly easier. it's not there yet...
+AlertCallbackType: TypeAlias = Callable[..., None]
+
+
+def start(
+    *,
+    config: dict,
+    alert_callback: Optional[AlertCallbackType] = None,
+    cb_data: Any = None,
+):
+    """Start the IoT3 Mobility SDK
+
+    :param config: The SDK configuration
+    :param alert_callback: The function to call upon reception of a message;
+                           when called, keyword argument (kwarg) data will
+                           be set to msg_cb_data, kwarg location will be set
+                           to an iot3.mobility.gnss.GNSSReport containing the
+                           location of the alert, and kwarg cause will be set
+                           to an iot3.mobility.denm.DENM.Cause; to be future
+                           proof, such a function should be declared as:
+                            def my_alert_callback(
+                                *_args,
+                                data: typing.Any,
+                                location: iot3.mobility.gnss.GNSSReport,
+                                cause: iot3.mobility.denm.DENM.Cause,
+                                **_kwargs,
+                            ) -> None:
+                                ...
+    :param cb_data: The data to use when calling alert_callback(), above.
+    """
+    global _mobility
+
+    if _mobility is not None:
+        raise RuntimeError("IoT3 Mobility SDK already initialised.")
+
+    _mobility = copy.deepcopy(config)
+    _mobility[
+        "topic_template_send"
+    ] = f"{config['namespace']}/inQueue/v2x/{{msg_type}}/{{source_uuid}}/{{quadkey}}"
+    _mobility[
+        "topic_template_recv"
+    ] = f"{config['namespace']}/outQueue/v2x/{{msg_type}}/{{source_uuid}}/{{quadkey}}"
+
+    def _msg_cb(data, topic, payload):
+        try:
+            msg = message_from_json(msg_json=payload)
+        except Exception as e:
+            # Can't make it a known message, ignore
+            print(f"Bummer {e}")
+            return
+        if msg.msg_type == "denm":
+            alert_callback(
+                data=data,
+                location=GNSSReport(
+                    latitude=msg.latitude,
+                    longitude=msg.longitude,
+                    altitude=msg.altitude,
+                ),
+                cause=msg.cause,
+            )
+
+    core.start(
+        config=config,
+        message_callback=_msg_cb if alert_callback else None,
+        callback_data=cb_data,
+    )
+
+
+def stop():
+    """Stop the IoT3 Mobility SDK."""
+    global _mobility
+
+    if _mobility is None:
+        raise RuntimeError("IoT3 mobility SDK not initialised.")
+
+    core.stop()
+
+    _mobility = None
+
+
+def send_position(
+    *,
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    altitude: Optional[float] = None,
+    heading: Optional[float] = None,
+    speed: Optional[float] = None,
+    acceleration: Optional[float] = None,
+    measurement_time: Optional[float] = None,
+    gnss_report: Optional[GNSSReport] = None,
+):
+    """Send the current position.
+
+    :param latitude: latitude, in degrees; positive is North
+    :param longitude: longitude, in degrees; positive is East
+    :param altitude: altitude, in meters
+    :param heading: heading from true North (geographic North), in
+                    degrees; 0.0 is toward North, 90.0 is toward
+                    East, 180.0 is toward South, 270.0 (or -90.0)
+                    is toward West
+    :param speed: speed over ground (horizontal speed), in m/s
+    :param acceleration: longitudinal acceleration (horizontal), in
+                         m/s²
+    :param measurement_time: UNIX timestamp the GNSS leasurement were
+                             made (see below).
+    :param gnss_report: an iot3.mobility.gnss.GNSSReport object that
+                        encapsulates the other parameters (see below).
+
+    All parameters are optional, but latitude and longitude are
+    required, either as discrete parameters, or encapsulated in
+    gnss_report.
+
+    Heading is toward the true North, aka the geographical North, not
+    toward the magnetic North.
+
+    Measurement time is the timestamp at which the GNSS measurement was
+    done, not when calling this function; usually, measurement_time is
+    provided by the GNSS device.
+
+    Location data can be passed either as individual parameters, or as
+    gnss_report, an aggregated object of type iot3.mobility.gnss.GNSSReport;
+    if gnss_report is passed, all other location parameters are ignored.
+
+    The following three examples are equivalent:
+
+        send_position(latitude=43.635, longitude=-1.375)
+        send_position(iot3.mobility.gnss.GNSSReport(
+            latitude=43.635,
+            longitude=-1.375,
+        ))
+        send_position(iot3.mobility.gnss.GNSSReport(
+            latitude_r=0.7616,
+            longitude_r=-0.024,
+        ))
+    """
+    global _mobility
+
+    if _mobility is None:
+        raise RuntimeError("IoT3 mobility SDK not initialised.")
+
+    now = time.time()
+
+    if gnss_report is None:
+        gnss_report = GNSSReport(
+            time=measurement_time,
+            latitude=latitude,
+            longitude=longitude,
+            altitude=altitude,
+            true_heading=heading,
+            speed=speed,
+            acceleration=acceleration,
+        )
+
+    if gnss_report.latitude is None:
+        raise RuntimeError("No valid latitude provided")
+    if gnss_report.longitude is None:
+        raise RuntimeError("No valid longitude provided")
+
+    # Create the CAM early, to get better timestamping
+    cam = CAM(
+        uuid=_mobility["uuid"],
+        station_type=_mobility["station_type"],
+        gnss_report=gnss_report,
+    )
+
+    # Before reporting current location, update RoI, to not miss any message
+    quadkey = its_quadkeys.QuadKey(
+        (
+            latitude,
+            longitude,
+            _mobility["roi_depth"],
+        ),
+    )
+    roi = quadkey.neighbours(as_zone=True)
+    roi.add(quadkey)
+    core.subscribe(
+        topics=list(
+            map(
+                lambda qk: (
+                    _mobility["topic_template_recv"].format(
+                        msg_type="denm",
+                        source_uuid="+",
+                        quadkey=qk.to_str(separator="/"),
+                    )
+                    + "/#"
+                ),
+                roi,
+            )
+        )
+    )
+
+    core.publish(
+        topic=cam.topic(template=_mobility["topic_template_send"]),
+        payload=cam.to_json(),
+    )
+
+
+def send_alert(
+    *,
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    altitude: Optional[float] = None,
+    gnss_report: Optional[GNSSReport] = None,
+    cause: Optional[DENM.Cause] = DENM.Cause.dangerousSituation,
+):
+    """Send an alert.
+
+    :param latitude: latitude, in degrees; positive is North
+    :param longitude: longitude, in degrees; positive is East
+    :param altitude: altitude, in meters
+
+    All parameters are optional, but latitude and longitude are
+    required, either as discrete parameters, or encapsulated in
+    gnss_report.
+
+    Location data can be passed either as individual parameters, or as
+    gnss_report, an aggregated object of type iot3.mobility.gnss.GNSSReport;
+    if gnss_report is passed, all other location parameters are ignored.
+    """
+    global _mobility
+
+    if _mobility is None:
+        raise RuntimeError("IoT3 mobility SDK not initialised.")
+
+    if gnss_report is None:
+        gnss_report = GNSSReport(
+            latitude=latitude,
+            longitude=longitude,
+            altitude=altitude,
+        )
+
+    if gnss_report.latitude is None:
+        raise RuntimeError("No valid latitude provided")
+    if gnss_report.longitude is None:
+        raise RuntimeError("No valid longitude provided")
+
+    denm = DENM(
+        uuid=_mobility["uuid"],
+        gnss_report=gnss_report,
+        cause=cause,
+    )
+
+    core.publish(
+        topic=denm.topic(template=_mobility["topic_template_send"]),
+        payload=denm.to_json(),
+    )
 
 
 def message_from_json(
@@ -37,3 +331,6 @@ def message_from_json(
     msg._message = msg_py_obj
 
     return msg
+
+
+_mobility = None

--- a/python/iot3/src/iot3/mobility/__init__.py
+++ b/python/iot3/src/iot3/mobility/__init__.py
@@ -2,3 +2,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Orange
 # SPDX-License-Identifier: MIT
 # Author: Yann E. MORIN <yann.morin@orange.com>
+
+import json
+
+from . import etsi
+from .gnss import GNSSReport
+
+
+def message_from_json(
+    *,
+    msg_json: str,
+) -> etsi.Message:
+    """Create a new ITS message from a json sentence"""
+    _MSG_TYPE_CLASS = dict()
+    # We should validate msg_json here before loading it,
+    # but we need to know the type of message first
+    try:
+        msg_py_obj = json.loads(msg_json)
+    except json.decoder.JSONDecodeError:
+        raise RuntimeError("Not a known ITS message")
+    try:
+        cls = _MSG_TYPE_CLASS[msg_py_obj["type"]]
+        source_uuid = msg_py_obj["source_uuid"]
+    except (KeyError, TypeError):
+        raise RuntimeError("Not a known ITS message")
+    # Create a raw ITS mesage
+    msg = cls(uuid=source_uuid, gnss_report=GNSSReport())
+    # And now just use the origianl message content
+    msg._message = msg_py_obj
+
+    return msg

--- a/python/iot3/src/iot3/mobility/__init__.py
+++ b/python/iot3/src/iot3/mobility/__init__.py
@@ -1,0 +1,4 @@
+# Software Name: IoT3 Mobility
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>

--- a/python/iot3/src/iot3/mobility/cam.py
+++ b/python/iot3/src/iot3/mobility/cam.py
@@ -1,0 +1,186 @@
+# Software Name: IoT3 Mobility
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import enum
+import hashlib
+import json
+import time
+
+from typing import Optional
+
+from . import etsi
+from .gnss import GNSSReport
+
+
+class CooperativeAwarenessMessage(etsi.Message):
+    msg_type = "cam"
+
+    def __init__(
+        self,
+        *,
+        uuid: str,
+        station_type: Optional[
+            etsi.Message.StationType
+        ] = etsi.Message.StationType.unknown,
+        gnss_report: GNSSReport,
+    ):
+        """Create a basic Cooperative Awareness Message
+
+        :param uuid: the UUID of this station
+        :param station_type: The type of this station
+        :param gnss_report: a GNSS report, coming from a GNSS device
+        """
+        self._gnss_report = gnss_report
+
+        self._message = dict(
+            {
+                "type": "cam",
+                "origin": "self",
+                "version": "1.1.3",
+                "source_uuid": uuid,
+                "timestamp": (
+                    etsi.ETSI.si2etsi(
+                        time.time(),
+                        etsi.ETSI.MILLI_SECOND,
+                        0,
+                    )
+                ),
+                "message": {
+                    "protocol_version": 1,
+                    "station_id": self.station_id(uuid),
+                    "generation_delta_time": (
+                        etsi.ETSI.generation_delta_time(gnss_report.timestamp)
+                    ),
+                    "basic_container": {
+                        "station_type": station_type,
+                        "reference_position": {
+                            "latitude": etsi.ETSI.si2etsi(
+                                gnss_report.latitude,
+                                etsi.ETSI.DECI_MICRO_DEGREE,
+                                900000001,
+                            ),
+                            "longitude": etsi.ETSI.si2etsi(
+                                gnss_report.longitude,
+                                etsi.ETSI.DECI_MICRO_DEGREE,
+                                1800000001,
+                            ),
+                            "altitude": etsi.ETSI.si2etsi(
+                                gnss_report.altitude,
+                                etsi.ETSI.CENTI_METER,
+                                800001,
+                            ),
+                        },
+                        "confidence": {
+                            "position_confidence_ellipse": {
+                                # We treat the 2D error as a circle, so semi-major
+                                # and semi-minor are eqal, and thus the orientation
+                                # of the elipse does not matter.
+                                "semi_major_confidence": etsi.ETSI.si2etsi(
+                                    gnss_report.horizontal_error,
+                                    etsi.ETSI.CENTI_METER,
+                                    4095,
+                                    {"min": 0, "max": 4093},
+                                    4094,
+                                ),
+                                "semi_minor_confidence": etsi.ETSI.si2etsi(
+                                    gnss_report.horizontal_error,
+                                    etsi.ETSI.CENTI_METER,
+                                    4095,
+                                    {"min": 0, "max": 4093},
+                                    4094,
+                                ),
+                                # Any orientation is valid for a circle, just use 0.
+                                "semi_major_orientation": etsi.ETSI.si2etsi(
+                                    0,
+                                    etsi.ETSI.DECI_DEGREE,
+                                    3601,
+                                ),
+                            },
+                        },
+                    },
+                    "high_frequency_container": {
+                        "heading": etsi.ETSI.si2etsi(
+                            gnss_report.track,
+                            etsi.ETSI.DECI_DEGREE,
+                            3601,
+                        ),
+                        "speed": etsi.ETSI.si2etsi(
+                            gnss_report.speed,
+                            etsi.ETSI.CENTI_METER_PER_SECOND,
+                            16383,
+                        ),
+                        "longitudinal_acceleration": etsi.ETSI.si2etsi(
+                            gnss_report.acceleration,
+                            etsi.ETSI.DECI_METER_PER_SECOND_SECOND,
+                            161,
+                        ),
+                    },
+                },
+            },
+        )
+
+    @property
+    def latitude(self):
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["basic_container"]["reference_position"][
+                "latitude"
+            ],
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            900000001,
+        )
+
+    @latitude.setter
+    def latitude(self, latitude):
+        self._message["message"]["basic_container"]["reference_position"][
+            "latitude"
+        ] = etsi.ETSI.si2etsi(
+            latitude,
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            900000001,
+        )
+
+    @property
+    def longitude(self):
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["basic_container"]["reference_position"][
+                "longitude"
+            ],
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            1800000001,
+        )
+
+    @longitude.setter
+    def longitude(self, longitude):
+        self._message["message"]["basic_container"]["reference_position"][
+            "longitude"
+        ] = etsi.ETSI.si2etsi(
+            longitude,
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            1800000001,
+        )
+
+    @property
+    def altitude(self):
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["basic_container"]["reference_position"][
+                "altitude"
+            ],
+            etsi.ETSI.CENTI_METER,
+            800001,
+        )
+
+    @altitude.setter
+    def altitude(self, altitude):
+        self._message["message"]["basic_container"]["reference_position"][
+            "altitude"
+        ] = etsi.ETSI.si2etsi(
+            altitude,
+            etsi.ETSI.CENTI_METER,
+            800001,
+        )
+
+
+# Shorthand
+CAM = CooperativeAwarenessMessage

--- a/python/iot3/src/iot3/mobility/denm.py
+++ b/python/iot3/src/iot3/mobility/denm.py
@@ -1,0 +1,254 @@
+# Software Name: IoT3 Mobility
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import enum
+import hashlib
+import json
+import time
+
+from typing import Optional
+
+from . import etsi
+from .gnss import GNSSReport
+
+
+class DecentralizedEnvironmentalNotificationMessage(etsi.Message):
+    msg_type = "denm"
+
+    class TerminationType(enum.IntEnum):
+        # We need those values to *exactly* match those defined in the spec
+        isCancellation = 0
+        isNegation = 1
+
+    class Cause(enum.IntEnum):
+        # We need those values to *exactly* match those defined in the spec
+        reserved = 0
+        trafficCondition = 1
+        accident = 2
+        roadworks = 3
+        adverseWeatherCondition_Adhesion = 6
+        hazardousLocation_SurfaceCondition = 9
+        hazardousLocation_ObstacleOnTheRoad = 10
+        hazardousLocation_AnimalOnTheRoad = 11
+        humanPresenceOnTheRoad = 12
+        wrongWayDriving = 14
+        rescueAndRecoveryWorkInProgress = 15
+        adverseWeatherCondition_ExtremeWeatherCondition = 17
+        adverseWeatherCondition_Visibility = 18
+        adverseWeatherCondition_Precipitation = 19
+        slowVehicle = 26
+        dangerousEndOfQueue = 27
+        vehicleBreakdown = 91
+        postCrash = 92
+        humanProblem = 93
+        stationaryVehicle = 94
+        emergencyVehicleApproaching = 95
+        hazardousLocation_DangerousCurve = 96
+        collisionRisk = 97
+        signalViolation = 98
+        dangerousSituation = 99
+
+    _seq_nums = dict()
+
+    def __init__(
+        self,
+        *,
+        uuid: str,
+        gnss_report: GNSSReport,
+        detection_time: Optional[float] = None,
+        cause: Cause = Cause.dangerousSituation,
+        validity_duration: Optional[int | float] = None,
+        termination: Optional[TerminationType] = None,
+        sequence_number: Optional[int] = None,
+    ):
+        """Create a basic Decentralized Environmental Notification Message
+
+        :param uuid: the UUID of this station
+        :param gnss_report: a GNSS report, coming from a GNSS device
+        :param detect_time: time of detection of the event
+        :param cause: cause of the event
+        :param validity_duration: duration the event is valid for
+        :param termination: the type of termination for this event
+        :param sequence_number: the sequence number this alert is a
+                                continuation of; don't set if this alery
+                                is not a continuation of a previous one.
+        """
+        self._gnss_report = gnss_report
+
+        now = time.time()
+        if detection_time is None:
+            detection_time = now
+
+        if sequence_number is None:
+            sequence_number = self._get_seq_num(uuid)
+
+        self._message = dict(
+            {
+                "type": "denm",
+                "origin": "self",
+                "version": "1.1.3",
+                "source_uuid": uuid,
+                "timestamp": etsi.ETSI.si2etsi(now, etsi.ETSI.MILLI_SECOND, 0),
+                "message": {
+                    "protocol_version": 1,
+                    "station_id": self.station_id(uuid),
+                    "management_container": {
+                        "action_id": {
+                            "originating_station_id": self.station_id(uuid),
+                            "sequence_number": sequence_number,
+                        },
+                        "detection_time": etsi.ETSI.unix2etsi_time(detection_time),
+                        "reference_time": etsi.ETSI.unix2etsi_time(now),
+                        "event_position": {
+                            "latitude": etsi.ETSI.si2etsi(
+                                gnss_report.latitude,
+                                etsi.ETSI.DECI_MICRO_DEGREE,
+                                900000001,
+                            ),
+                            "longitude": etsi.ETSI.si2etsi(
+                                gnss_report.longitude,
+                                etsi.ETSI.DECI_MICRO_DEGREE,
+                                1800000001,
+                            ),
+                            "altitude": etsi.ETSI.si2etsi(
+                                gnss_report.altitude,
+                                etsi.ETSI.CENTI_METER,
+                                800001,
+                            ),
+                        },
+                    },
+                    "situation_container": {
+                        "event_type": {
+                            "cause": cause.value,
+                        },
+                    },
+                },
+            },
+        )
+        if termination is not None:
+            self._message["message"]["management_container"][
+                "termination"
+            ] = termination
+        if validity_duration is not None:
+            self._message["message"]["management_container"][
+                "validity_duration"
+            ] = validity_duration
+
+    # We allow retrieving the sequence_number, so the caller can propagate it
+    # to a future continuation, if any, but we do not allow setting it, except
+    # via the constructor, so no @sequence_number.setter
+    @property
+    def sequence_number(self) -> int:
+        return self._message["message"]["management_container"]["action_id"][
+            "sequence_number"
+        ]
+
+    @property
+    def detection_time(self) -> float:
+        return etsi.ETSI.etsi2unix_time(
+            self._message["message"]["management_container"]["detection_time"]
+        )
+
+    @detection_time.setter
+    def detection_time(self, detection_time: float):
+        self._message["message"]["management_container"][
+            "detection_time"
+        ] = etsi.ETSI.unix2etsi_time(detection_time)
+
+    @property
+    def latitude(self) -> float:
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["management_container"]["event_position"][
+                "latitude"
+            ],
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            900000001,
+        )
+
+    @latitude.setter
+    def latitude(self, latitude: float):
+        self._message["message"]["management_container"]["event_position"][
+            "latitude"
+        ] = etsi.ETSI.si2etsi(
+            latitude,
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            900000001,
+        )
+
+    @property
+    def longitude(self) -> float:
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["management_container"]["event_position"][
+                "longitude"
+            ],
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            1800000001,
+        )
+
+    @longitude.setter
+    def longitude(self, longitude: float):
+        self._message["message"]["management_container"]["event_position"][
+            "longitude"
+        ] = etsi.ETSI.si2etsi(
+            longitude,
+            etsi.ETSI.DECI_MICRO_DEGREE,
+            1800000001,
+        )
+
+    @property
+    def altitude(self) -> float:
+        return etsi.ETSI.etsi2si(
+            self._message["message"]["management_container"]["event_position"][
+                "altitude"
+            ],
+            etsi.ETSI.CENTI_METER,
+            800001,
+        )
+
+    @altitude.setter
+    def altitude(self, altitude: float):
+        self._message["message"]["management_container"]["event_position"][
+            "altitude"
+        ] = etsi.ETSI.si2etsi(
+            altitude,
+            etsi.ETSI.CENTI_METER,
+            800001,
+        )
+
+    @property
+    def cause(self) -> Cause:
+        return self.Cause(
+            self._message["message"]["situation_container"]["event_type"]["cause"]
+        )
+
+    @cause.setter
+    def cause(self, cause: Cause):
+        self._message["message"]["situation_container"]["event_type"]["cause"] = cause
+
+    @property
+    def termination(self) -> TerminationType:
+        try:
+            return self._message["message"]["management_container"]["termination"]
+        except KeyError:
+            return None
+
+    @termination.setter
+    def termination(self, termination: TerminationType):
+        self._message["message"]["management_container"]["termination"] = termination
+
+    @classmethod
+    def _get_seq_num(
+        cls,
+        uuid: str,
+    ) -> int:
+        try:
+            cls._seq_nums[uuid] = (cls._seq_nums[uuid] + 1) % 65_536
+        except KeyError:
+            cls._seq_nums[uuid] = 0
+        return cls._seq_nums[uuid]
+
+
+# Shorthand
+DENM = DecentralizedEnvironmentalNotificationMessage

--- a/python/iot3/src/iot3/mobility/etsi.py
+++ b/python/iot3/src/iot3/mobility/etsi.py
@@ -1,0 +1,197 @@
+# Software Name: IoT3 Mobility
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import abc
+import datetime
+import math
+from typing import Optional
+
+
+class ETSI(abc.ABC):
+    """Various ETSI-related constants
+
+    Constants that help convert from SI units to ETSI scaled values.
+
+    Note that the SI unit for angles is the radian, not the degree. However,
+    when dealing with geo coordinates, it is more usual to use degrees to
+    represent latitude and longitude. Converting between degrees and radians
+    is readily available in python (using math.degrees() or math.radians()),
+    so we do not provide a scale for the conversion.
+    """
+
+    # ETSI EPOCH, as a UNIX timestamp (int)
+    EPOCH: int = int(
+        datetime.datetime.fromisoformat(
+            "2004-01-01T00:00:00.000+00:00",
+        ).timestamp()
+    )
+
+    # Length scales
+    METER: float = 1.0
+    DECI_METER: float = METER / 10
+    CENTI_METER: float = METER / 100
+    MILLI_METER: float = METER / 1_000
+    KILO_METER: float = METER * 1_000
+
+    # Time scales
+    SECOND: float = 1.0
+    MILLI_SECOND: float = SECOND / 1_000
+    MICRO_SECOND: float = SECOND / 1_000_000
+    NANO_SECOND: float = SECOND / 1_000_000_000
+    HOUR: float = 3600.0 * SECOND
+
+    # Speed scales
+    METER_PER_SECOND: float = METER / SECOND
+    CENTI_METER_PER_SECOND: float = CENTI_METER / SECOND
+    KILO_METER_PER_HOUR: float = KILO_METER / HOUR
+
+    # Acceleration scales
+    METER_PER_SECOND_SECOND: float = METER / (SECOND * SECOND)
+    DECI_METER_PER_SECOND_SECOND: float = DECI_METER / (SECOND * SECOND)
+
+    # Angle scales
+    DEGREE: float = 1.0
+    DECI_DEGREE: float = DEGREE / 10
+    CENTI_DEGREE: float = DEGREE / 100
+    DECI_MICRO_DEGREE: float = DEGREE / 10_000_000
+
+    # Rotation speed scales
+    DEGREE_PER_SECOND: float = DEGREE / SECOND
+    CENTI_DEGREE_PER_SECOND: float = CENTI_DEGREE / SECOND
+
+    @staticmethod
+    def si2etsi(
+        value: float | None,
+        scale: float,
+        undef: int,
+        range: Optional[dict] = None,
+        out_of_range: Optional[int] = None,
+    ) -> int:
+        """SI to ETSI unit conversions
+
+        Each key in an ETSI object has its own scale, so there is no "ETSI unit"
+        per-se, but a myriad of scales, each applicable to a specific key of a
+        specific object. This function converts from an SI unit to an ETSI scale.
+
+        :param value: the value in the SI unit, or None when the value is unknown
+        :param scale: the ETSI scale of the key
+        :param undef: the special ETSI-scaled value to use when the value is unknown
+        :param validity_range: the lower and upper bounds of the value range as a
+                      dict with keys "min" and "max", in ETSI scale; the bounds are
+                      inclusive, but must not include undef and out_of_range.
+        :param out_of_range: the special ETSI-scaled value to use when the value is
+                             out of range
+        :return: the special ETSI-scaled value 'undef' when the value is None, the
+                 special ETSI-scaled value 'out_of_range' if the value is out of
+                 range, or the value scaled to the ETSI scale otherwise
+
+        For example:
+            si2etsi(
+                get_altitude_or_None(),
+                ETSI.CENTI_METER,
+                800001,
+                {"min": 0, "max": 800000},
+                800002,
+            )
+
+        Assuming that get_altitude_or_None() returns a number when the altitude is
+        known, or None when it is unknown, the above code would return 800001 if the
+        altitude is not known, 800002 if the altitude is strictly lower than 0 or
+        strictly greater than 800000 (8000m), or the altitude as an integral number
+        of centimeters.
+        """
+        if value is None:
+            return undef
+        etsi_value = int(round(value / scale))
+        if range is not None:
+            if etsi_value < range["min"]:
+                etsi_value = out_of_range
+            if etsi_value > range["max"]:
+                etsi_value = out_of_range
+        return etsi_value
+
+    @staticmethod
+    def etsi2si(
+        value: int,
+        scale: float,
+        undef: int,
+        out_of_range: Optional[int] = None,
+    ) -> float | None:
+        """ETSI to SI unit conversions
+
+        Each key in an ETSI object has its own scale, so there is no "ETSI unit"
+        per-se, but a myriad of scales, each applicable to a specific key of a
+        specific object. This function converts from an ETSI scale to an SI unit.
+
+        :param value: the value in an ETSI scale, or its special value when it
+                      is unknown
+        :param scale: the ETSI scale of the key
+        :param undef: the special ETSI-scaled value to use when the value is unknown
+        :param out_of_range: the special ETSI-scaled value to use when the value is
+                             out of range
+        :return: None if the value is either one of the special ETSI-scaled values
+                 'undef' or 'out_of_range', or the value scaled back to SI units
+                 otherwise
+
+        For example:
+            etsi2si(my_cam.altitude, ETSI.CENTI_METER, 800001)
+
+        Assuming that my_cam.altitude contains an integer when the altitude is
+        known, or the special value 800001 when it is unknown, or the special
+        value 800002 when it is out of range, the above code would return the
+        altitude as a floating point numbers of meters, or None if the altitude
+        is not known or out of range.
+        """
+        if value == undef:
+            return None
+        if out_of_range is not None and value == out_of_range:
+            return None
+        return float(value) * scale
+
+    @staticmethod
+    def unix2etsi_time(
+        unix_time: float,
+    ) -> int:
+        """Convert UNIX timestamp to ETSI timestamp
+
+        :param unix_time: The UNIX timestamp, in seconds since the UNIX EPOCH,
+                          with arbitrary sub-second precision
+        :return: The ETSI timestamp, as the number of milliseconds elapsed since
+                 the ETSI EPOCH.
+
+        If the value is a date before the ETSI EPOCH, the returned value is
+        negative; it is left to the caller to decide whether that is usable
+        in their case.
+        """
+        return ETSI.si2etsi(unix_time - ETSI.EPOCH, ETSI.MILLI_SECOND, 0)
+
+    @staticmethod
+    def etsi2unix_time(
+        etsi_time: int,
+    ) -> float:
+        """Convert ETSI timestamp to UNIX timestamp
+
+        :param etsi_time: The ETSI timestamp, as the number of milliseconds
+                          elapsed since the ETSI EPOCH.
+        :return: The UNIX timestamp, in seconds since the UNIX EPOCH, with
+                 arbitrary sub-second precision (in practice, down to millisecond
+                 precision).
+        """
+        return ETSI.etsi2si(etsi_time, ETSI.MILLI_SECOND, 0) + ETSI.EPOCH
+
+    @staticmethod
+    def generation_delta_time(
+        unix_time: float
+    ) -> int:
+        """Convert a UNIX timestamp into an ETSI generation delta time
+
+        :param unix_time:
+        """
+        return ETSI.unix2etsi_time(unix_time) % 65536
+
+    @abc.abstractmethod
+    def __init__(self, *args, **kwargs):
+        """It is not allowed to create an instance of this class."""
+        ...

--- a/python/iot3/src/iot3/mobility/gnss.py
+++ b/python/iot3/src/iot3/mobility/gnss.py
@@ -1,0 +1,317 @@
+# Software Name: IoT3 Mobility
+# SPDX-FileCopyrightText: Copyright (c) 2024 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import copy
+import dataclasses
+import json
+import math
+import socket
+import threading
+import time
+
+from typing import Optional
+
+
+@dataclasses.dataclass(frozen=True)
+class GNSSReport:
+    """A GNSS report.
+
+    All values in SI units (except where noted), with arbitrary precision.
+    Any value (but timestamp) may be None, when unknown or unavailable.
+
+    When a field exist in both radians and degrees, only one may be set when
+    instantiating the class, not both. The other will automatically be set.
+
+    :param timestamp: UNIX timestamp this object was created at, with
+                      arbitrary sub-second precision; this must _not_ be
+                      specified when creating a GNSSReport
+    :param time: Time of the GSS measurement as sent by the GNSS service,
+                 with arbitrary sub-second precision
+    :param latitude: Latitude in degrees
+    :param longitude: Longitude in degrees
+    :param latitude_r: Latitude, in radians
+    :param longitude_r: Longitude, in radians
+    :param altitude: Altitude
+    :param speed: Speed over ground (i.e. without vertical component)
+    :param acceleration: Acceleration
+    :param track: Orientation from true North (geographic North, not
+                  magnetic North!)
+    :param horizontal_error: Error in horizontal (2D) measurement.
+    :param altitude_error: Error in altitude measurement.
+    :param true_heading: True headings (may or may not be equal to track,
+                         above), in degrees
+    :param true_heading_r: True headings (may or may not be equal to track,
+                           above), in radians
+    :param magnetic_heading: Magnetic heading, in degrees
+    :param magnetic_heading_r: Magnetic heading, in radians
+    """
+
+    timestamp: float = None
+    time: float | None = None
+    latitude: float | None = None
+    latitude_r: float | None = None
+    longitude: float | None = None
+    longitude_r: float | None = None
+    altitude: float | None = None
+    speed: float | None = None
+    acceleration: float | None = None
+    track: float | None = None
+    horizontal_error: float | None = None
+    altitude_error: float | None = None
+    true_heading: float | None = None
+    magnetic_heading: float | None = None
+    true_heading_r: float | None = None
+    magnetic_heading_r: float | None = None
+
+    # Frozen dataclasses do not allow directly setting their attributes,
+    # neither directly with dot notation nor with setattr(), so we must
+    # use the root class 'object' to set the attributes:
+    # https://docs.python.org/3/library/dataclasses.html#frozen-instances
+    def __post_init__(self):
+        if getattr(self, "timestamp") is not None:
+            raise AttributeError(
+                "Assigning timestamp is not allowed",
+                name="timestamp",
+                obj=self,
+            )
+        object.__setattr__(self, "timestamp", time.time())
+
+        fields = {
+            # min_inc, max_inc: inclusive boundaries
+            # min_exc, max_exc: exclusibe boundaries
+            "latitude": {
+                "min_inc": -90.0,
+                "max_inc": 90.0,
+            },
+            "longitude": {
+                "min_exc": -180.0,
+                "max_inc": 180.0,
+            },
+            "true_heading": {
+                "min_exc": -180.0,
+                "max_exc": 360.0,
+            },
+            "magnetic_heading": {
+                "min_exc": -180.0,
+                "max_inc": 180.0,
+            },
+        }
+
+        def _range(f, as_radians=False):
+            convert = lambda x: math.radians(x) if as_radians else x
+            rng = ""
+            if "min_inc" in fields[f]:
+                rng += f"[{convert(fields[f]['min_inc'])}"
+            elif "min_exc" in fields[f]:
+                rng += f"]{convert(fields[f]['min_exc'])}"
+            else:
+                rng += "]..."
+            rng += ", "
+            if "max_inc" in fields[f]:
+                rng += f"{convert(fields[f]['max_inc'])}]"
+            elif "max_exc" in fields[f]:
+                rng += f"{convert(fields[f]['max_exc'])}["
+            else:
+                rng += f"...["
+            return rng
+
+        def _validate(f, v, f_r=None, v_r=None):
+            if "min_inc" in fields[f] and v < fields[f]["min_inc"]:
+                raise AttributeError(
+                    f"{f_r or f} {v_r if f_r else v} is out of range {_range(f, f_r)}"
+                )
+            if "min_exc" in fields[f] and v <= fields[f]["min_exc"]:
+                raise AttributeError(
+                    f"{f_r or f} {v_r if f_r else v} is out of range {_range(f, f_r)}"
+                )
+            if "max_inc" in fields[f] and v > fields[f]["max_inc"]:
+                raise AttributeError(
+                    f"{f_r or f} {v_r if f_r else v} is out of range {_range(f, f_r)}"
+                )
+            if "max_exc" in fields[f] and v >= fields[f]["max_exc"]:
+                raise AttributeError(
+                    f"{f_r or f} {v_r if f_r else v} is out of range {_range(f, f_r)}"
+                )
+
+        # For each field, validate that either are set, or none, but not both,
+        # and that they are in range. If one is set, convert to the other.
+        for field in fields:
+            field_r = f"{field}_r"
+            deg = getattr(self, field)
+            rad = getattr(self, field_r)
+            if deg is not None and rad is not None:
+                raise AttributeError(f"Only one of {field} or {field_r} can be set")
+            if deg is not None:
+                _validate(field, deg)
+                object.__setattr__(self, field_r, math.radians(deg))
+            elif rad is not None:
+                deg = math.degrees(rad)
+                _validate(field, deg, field_r, rad)
+                object.__setattr__(self, field, deg)
+
+
+class GNSS:
+    """Simple abstraction to a gpsd daemon.
+
+    The object is a callable that returns a GNSSReport when it has at least
+    a valid latitude and longitude, or None otherwise.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+    ):
+        """Simple abstraction to a gpsd daemon.
+
+        :param host: The hostname or IP address the gpsd daemon runs on;
+                     by default, 127.0.0.1
+        :param port: The TCP port the gpsd daemon listen on; by default 2947
+
+        Both host and port are optional, as the usual setup is to have gpsd
+        run on the local machine, and listen on its well-known port.
+        """
+        self._host = host or "127.0.0.1"
+        self._port = port or 2947
+
+        self._thread = threading.Thread(
+            target=self._loop,
+            name=f"{__name__}.gpsd_client",
+            daemon=True,
+        )
+        self._last = dict()
+        self._sock = None
+        self._should_stop = False
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._should_stop = True
+
+    def join(self, timeout: Optional[float] = None):
+        self._thread.join(timeout)
+
+    def __call__(self):
+        last = copy.deepcopy(self._last)
+
+        try:
+            tpv = last["tpv"]
+        except (TypeError, KeyError):
+            # No measurement yet
+            return None
+
+        now = time.time()
+        if now - last["tpv"]["timestamp"] > 1.0:
+            # Last measurement too old
+            return None
+
+        tpv = json.loads(tpv["msg"])
+        if "lat" not in tpv or "lon" not in tpv:
+            # No latitude or no longitude
+            return None
+
+        params = dict()
+        params["latitude"] = tpv["lat"]
+        params["longitude"] = tpv["lon"]
+
+        params["time"] = tpv.get("time")
+        params["altitude"] = tpv.get("altHAE")
+        params["speed"] = tpv.get("speed")
+        params["track"] = tpv.get("track")
+        params["horizontal_error"] = tpv.get("eph")
+        params["altitude_error"] = tpv.get("epv")
+
+        try:
+            att = last["att"]
+        except KeyError:
+            # Not all GNSS devices provide attitude data
+            pass
+        else:
+            params["acceleration"] = att.get("acc_len")
+            params["true_heading"] = att.get("heading")
+            params["magnetic_heading"] = att.get("mheading")
+
+        return GNSSReport(**params)
+
+    def _connect(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.settimeout(2.0)
+        self._sock.connect((self._host, self._port))
+        self._sock_fd = self._sock.makefile("rwb")
+        # From here on, we're only manipulating the connection via sock_fd
+        self._sock.close()
+        self._sock_fd.write('?WATCH={"enable":true,"json":true};\n'.encode())
+        self._sock_fd.flush()
+
+    def _disconnect(self):
+        try:
+            self._sock_fd.close()
+        except:
+            # already closed, we don't care
+            pass
+        try:
+            self._sock.close()
+        except:
+            # already closed, we don't care
+            pass
+        self._sock = None
+
+    def _loop(self):
+        while True:
+            if self._should_stop:
+                break
+
+            if self._sock is None:
+                try:
+                    self._connect()
+                except (
+                    socket.gaierror,
+                    socket.timeout,
+                    TimeoutError,
+                    ConnectionRefusedError,
+                ):
+                    self._disconnect()
+                    time.sleep(1)
+
+                # Whether we succeeded in connecting or not, restart the
+                # loop, so that we can catch a stop tentative that was
+                # triggered while we were trying to connect.
+                continue
+
+            try:
+                msg_json = self._sock_fd.readline()
+                # When the socket got severed, we don't always notice (no idea
+                # why we don't always get TimeoutError or ConnectionResetError)
+                # but we get a short-read, which gives an empty message. When
+                # the socket is not in error, we never get a short read, so an
+                # empty message is a very good indication that the socket has
+                # some issue...
+                if not msg_json:
+                    raise ConnectionResetError("short read")
+            except (socket.timeout, TimeoutError, ConnectionResetError):
+                self._disconnect()
+                continue
+
+            try:
+                msg = json.loads(msg_json)
+            except json.decoder.JSONDecodeError:
+                # The GPSD protocol specifies a maximum length of messages, and
+                # that, as a consequence, the JSON sentence may get truncated.
+                continue
+
+            try:
+                msg_class = msg["class"].lower()
+            except KeyError:
+                continue
+            if msg_class in ["tpv", "att"]:
+                # Only store those messages we need
+                self._last[msg_class] = {
+                    "timestamp": time.time(),
+                    "msg": msg_json,
+                }
+
+        self._disconnect()

--- a/python/iot3/tests/test-iot3-mobility
+++ b/python/iot3/tests/test-iot3-mobility
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import iot3.core
+import iot3.mobility
+import random
+import time
+
+def recv(*, data, location, cause):
+    print(f"{data}: (lat {location.latitude}, lon {location.longitude}): {cause.name}")
+
+config = iot3.mobility.sample_config
+config["mqtt"] = {
+    "host": "test.mosquitto.org",
+    "port": 1883,
+    "client-id": random.randbytes(16).hex(),
+    "username": None,
+    "password": None,
+}
+
+print("Starting IoT3 Mobility SDK...")
+iot3.mobility.start(
+    config=config,
+    alert_callback=recv,
+    cb_data="alert",
+)
+time.sleep(1)
+
+print("Sending position...")
+iot3.mobility.send_position(
+    latitude=43.6352120,
+    longitude=1.3745620,
+)
+time.sleep(1)
+
+print("Sending alert 'accident'...")
+iot3.mobility.send_alert(
+    latitude=43.6352120,
+    longitude=1.3745620,
+    cause=iot3.mobility.denm.DENM.Cause.accident,
+)
+time.sleep(1)
+
+print("Sending alert 'trafficCondition' as if relayed by an IQM...")
+denm = iot3.mobility.denm.DENM(
+    uuid=config["uuid"],
+    gnss_report=iot3.mobility.gnss.GNSSReport(
+        latitude=43.6352120,
+        longitude=1.3745620,
+    ),
+    cause=iot3.mobility.denm.DENM.Cause.trafficCondition,
+)
+topic_template = f"{config['namespace']}/outQueue/v2x/{{msg_type}}/{{source_uuid}}/{{quadkey}}"
+iot3.core.publish(
+    topic=denm.topic(template=topic_template),
+    payload=denm.to_json(),
+)
+time.sleep(1)
+
+iot3.mobility.stop()

--- a/python/iot3/tests/test-iot3-mobility-gnss
+++ b/python/iot3/tests/test-iot3-mobility-gnss
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import math
+import time
+from iot3.mobility.gnss import GNSSReport, GNSS
+
+print("Basic, empty GNSS report...")
+gnss_report = GNSSReport()
+
+print("Disallow explicit timestamp...")
+try:
+    gnss_report = GNSSReport(
+        timestamp=42,
+    )
+except AttributeError:
+    pass
+else:
+    raise RuntimeError("Timestamp should not be allowed")
+
+print("Validity range...")
+try:
+    gnss_report = GNSSReport(
+        latitude=120,
+    )
+except AttributeError:
+    pass
+else:
+    raise RuntimeError("Out-of-range latitude should not be alowed")
+
+print("Conflicting attributes...")
+try:
+    gnss_report = GNSSReport(
+        latitude=43.635212,
+        latitude_r=1.374562,
+    )
+except AttributeError:
+    pass
+else:
+    raise RuntimeError("Setting both radians and degrees should not be allowed")
+
+print("Attribute degree -> radian conversion...")
+gnss_report = GNSSReport(
+    latitude=43.635212,
+)
+# Can't test floats for equality, so check for a very small delta.
+# 10^-9 radians gives ~6mm delta at the surface of Earth at the equator.
+if math.fabs(gnss_report.latitude_r - math.radians(43.635212)) >= 10 ** -9:
+    raise RuntimeError("Degree -> radian latitude conversion failed")
+
+print("Attribute radian -> degree conversion...")
+gnss_report = GNSSReport(
+    latitude_r=0.761578119,
+)
+# Can't test floats for equality, so check for a very small delta.
+# 5*10^-8 is about the same as 10^-9 radians, above
+if math.fabs(gnss_report.latitude - math.degrees(0.761578119)) >= 5 * 10 ** -8:
+    raise RuntimeError("Degree -> radian latitude conversion failed")
+
+print("gpsd connection to 127.0.0.1:2947...")
+gnss = GNSS(
+    host="127.0.0.1",
+    port=2947,
+)
+gnss.start()
+for i in range(5):
+    time.sleep(1)
+    if gnss() is not None:
+        break
+else:
+    raise RuntimeError("Can't connect to gpsd on 127.0.0.1:2947, is it running?")

--- a/python/iot3/tests/test-iot3-mobility-message
+++ b/python/iot3/tests/test-iot3-mobility-message
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+import json
+import math
+import time
+import iot3.mobility
+from iot3.mobility.etsi import Message
+from iot3.mobility.cam import CAM
+from iot3.mobility.denm import DENM
+from iot3.mobility.gnss import GNSSReport
+
+
+print("CAM with nothing available...")
+msg = CAM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(),
+)
+assert msg["message"]["basic_container"]["reference_position"]["latitude"] == 900000001
+assert (
+    msg["message"]["basic_container"]["reference_position"]["longitude"] == 1800000001
+)
+
+print("CAM with latitude and longitude...")
+msg = CAM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(
+        latitude=43.635212,
+        longitude=1.374562,
+    ),
+)
+# Check with direct access to message structure (ETSI values)
+assert msg["message"]["basic_container"]["reference_position"]["latitude"] == 436352120
+assert msg["message"]["basic_container"]["reference_position"]["longitude"] == 13745620
+# Check with properties (SI values, degrees); ~6mm at Equator on surface of Earth
+assert math.fabs(msg.latitude - 43.6352120) < 5 * 10 ** -8
+assert math.fabs(msg.longitude - 1.3745620) < 5 * 10 ** -8
+
+print("CAM serialisation...")
+json_msg = msg.to_json()
+
+print("CAM de-serialisation...")
+msg = iot3.mobility.message_from_json(msg_json=json_msg)
+assert msg.msg_type == "cam"
+assert math.fabs(msg.latitude - 43.6352120) < 5 * 10 ** -8
+assert math.fabs(msg.longitude - 1.3745620) < 5 * 10 ** -8
+
+print("DENM with nothing set...")
+msg = DENM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(),
+)
+
+print("DENM with latitude, longitude, and cause...")
+detect_time = time.time()
+msg = DENM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(
+        latitude=43.635212,
+        longitude=1.374562,
+    ),
+    cause=DENM.Cause.trafficCondition,
+)
+# UNIX time is a float that encodes seconds, while ETSI time is an int that
+# encodes miliseconds, so we should not have a delta of 1ms or more
+assert math.fabs(detect_time - msg.detection_time) < 10 ** -3
+
+seq_num = msg.sequence_number
+detect_time = msg.detection_time
+
+print("DENM continuation (update)...")
+msg = DENM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(
+        latitude=43.635212,
+        longitude=1.374562,
+    ),
+    detection_time=detect_time,
+    cause=DENM.Cause.trafficCondition,
+    sequence_number=seq_num,
+)
+assert seq_num == msg.sequence_number
+assert msg.cause == DENM.Cause.trafficCondition
+# UNIX time: seconds as a float, ETSI time: ms as an int; => delta max = 1ms
+assert math.fabs(detect_time - msg.detection_time) < 10 ** -3
+
+print("DENM continuation (termination)...")
+msg = DENM(
+    uuid="test_1234",
+    gnss_report=GNSSReport(),
+    detection_time=detect_time,
+    termination=DENM.TerminationType.isNegation,
+    sequence_number=seq_num,
+)
+assert msg.termination == DENM.TerminationType.isNegation
+
+print("DENM serialisation...")
+json_msg = msg.to_json()
+
+print("DENM de-serialisation...")
+msg = iot3.mobility.message_from_json(msg_json=json_msg)
+assert msg.msg_type == "denm"
+assert seq_num == msg.sequence_number
+assert msg.termination == DENM.TerminationType.isNegation
+# UNIX time: seconds as a float, ETSI time: ms as an int; => delta max = 1ms
+assert math.fabs(detect_time - msg.detection_time) < 10 ** -3
+
+print("Invalid generic message...")
+try:
+    msg = Message()
+except TypeError:
+    pass
+else:
+    raise RuntimeError("Generic message should not be allowed")
+
+print("De-serialisation of unrecognised message...")
+try:
+    msg = iot3.mobility.message_from_json(msg_json='""')
+except RuntimeError:
+    pass
+else:
+    raise RuntimeError("Deserialisation of unrecognised message should not succeed...")
+
+print("De-serialisation of broken message...")
+try:
+    msg = iot3.mobility.message_from_json(msg_json=json_msg[:-1])
+except RuntimeError:
+    pass
+else:
+    raise RuntimeError("Deserialisation of broken message should not succeed...")


### PR DESCRIPTION
**Features:**

* Closes: #132

---
**Preparation:**

1. if you do not have a gpsd server listening on `localhost:2947`, spawn one (needs gpsd 3.24 or later):
    * grab the [NMEA sample on Wikipedia](https://en.wikipedia.org/wiki/NMEA_0183#Sample_file) and save it in a file called `NMEA.log`
    * start a gpsfake using that file to emulate a GNSS device:
        ```sh
        TMPDIR=/tmp gpsfake -q -P 2947 -o=-G -u -n -c 0.1 NMEA.log
        ```
2. if you do not have python 3.11 or later, you can use the following to create a container to run all the tests:
    * start a container with python 3.11:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.9-slim-bookworm \
            /bin/bash -il
        ```
    * install the necessary packages:
        ```sh
        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git
        ```
    * attach to the container:
        ```sh
        $ docker container attach iot3
        ```
3. start an MQTT client to dump messages (in another terminal):
    ```sh
    $ mosquitto_sub -h test.mosquitto.org -p 1883 -V mqttv5 -t "default/inQueue/v2x/#" -F %J |jq -C .
    ```

---
**How to test:**

1. Create and activate a virtual-env to run the tests:
    ```
    [python-3.11] $ python3.11 -m venv /tmp/iot3
    [python-3.11] $ . /tmp/iot3/bin/activate
    ```
2. Install the IoT3 SDK:
    ```sh
    [python-3.11] $ pip install python/iot3
    ```
3. Run the IoT3 Mobility SDK test-suite:
    ```sh
    [python-3.11] $ ./python/iot3/tests/test-iot3-mobility-gnss
    [python-3.11] $ ./python/iot3/tests/test-iot3-mobility-message
    [python-3.11] $ ./python/iot3/tests/test-iot3-mobility
    ```

---
**Expected results:**

1. A python venv is created and activated
2. The IoT3 SDK is isntalled succesfully
3. The tests succeed:
    * `./python/iot3/tests/test-iot3-mobility-gnss`
        ```
        Basic, empty GNSS report...
        Disallow explicit timestamp...
        Validity range...
        Conflicting attributes...
        Attribute degree -> radian conversion...
        Attribute radian -> degree conversion...
        gpsd connection to 127.0.0.1:2947...
        ```
    * `./python/iot3/tests/test-iot3-mobility-message`
        ```
        CAM with nothing available...
        CAM with latitude and longitude...
        CAM serialisation...
        CAM de-serialisation...
        DENM with nothing set...
        DENM with latitude, longitude, and cause...
        DENM continuation (update)...
        DENM continuation (termination)...
        DENM serialisation...
        DENM de-serialisation...
        Invalid generic message...
        De-serialisation of unrecognised message...
        De-serialisation of broken message...
        ```
    * `./python/iot3/tests/test-iot3-mobility`
        ```
        Starting IoT3 Mobility SDK...
        Sending position...
        Sending alert 'accident'...
        Sending alert 'trafficCondition' as if relayed by an IQM...
        alert: (lat 43.635211999999996, lon 1.3745619999999998): trafficCondition
        ```
        Note that the _accident_ alert is not reported, while the _trafficCondition_
        one is; the MQTT client reports two messages: 1 CAM, and 1 DENM for the
        _accident_ alert:
        ```
        {
          "tst": "2024-11-19T15:36:14.214301Z+0100",
          "topic": "default/inQueue/v2x/cam/1234/1/2/0/2/2/2/0/2/1/3/3/3/1/0/3/0/0/0/3/3/1/2",
          "qos": 0,
          "retain": 0,
          "payloadlen": 520,
          "properties": {
            "user-properties": {
              "traceparent": "00-0acd4c56355b35d4b743d235de2783fe-46ba88bfbc33dda6-00"
            }
          },
          "payload": {
            "type": "cam",
            "origin": "self",
            "version": "1.1.3",
            "source_uuid": "1234",
            "timestamp": 1732026974008,
            "message": {
              "protocol_version": 1,
              "station_id": 240743,
              "generation_delta_time": 34616,
              "basic_container": {
                "station_type": 0,
                "reference_position": {
                  "latitude": 436352120,
                  "longitude": 13745620,
                  "altitude": 800001
                },
                "confidence": {
                  "position_confidence_ellipse": {
                    "semi_major_confidence": 4095,
                    "semi_minor_confidence": 4095,
                    "semi_major_orientation": 0
                  }
                }
              },
              "high_frequency_container": {
                "heading": 3601,
                "speed": 16383,
                "longitudinal_acceleration": 161
              }
            }
          }
        }
        {
          "tst": "2024-11-19T15:36:15.034743Z+0100",
          "topic": "default/inQueue/v2x/denm/1234/1/2/0/2/2/2/0/2/1/3/3/3/1/0/3/0/0/0/3/3/1/2",
          "qos": 0,
          "retain": 0,
          "payloadlen": 428,
          "properties": {
            "user-properties": {
              "traceparent": "00-09ad8a11a1ac5954f532b8886c5e1c1b-c36f73e3c070d139-00"
            }
          },
          "payload": {
            "type": "denm",
            "origin": "self",
            "version": "1.1.3",
            "source_uuid": "1234",
            "timestamp": 1732026975010,
            "message": {
              "protocol_version": 1,
              "station_id": 240743,
              "management_container": {
                "action_id": {
                  "originating_station_id": 240743,
                  "sequence_number": 0
                },
                "detection_time": 659111775010,
                "reference_time": 659111775010,
                "event_position": {
                  "latitude": 436352120,
                  "longitude": 13745620,
                  "altitude": 800001
                }
              },
              "situation_container": {
                "event_type": {
                  "cause": 2
                }
              }
            }
          }
        }
        ```
