### PR TITLE
python/its-vehicle: make authentication configurable

### DIFF
--- a/python/its-vehicle/its-vehicle.cfg
+++ b/python/its-vehicle/its-vehicle.cfg
@@ -59,6 +59,8 @@ speed-thresholds = SPEED[ SPEED [...]]
 [telemetry]
 # The OpenTelemetry endpoint (without the trailing /v1/traces)
 endpoint = http://opentelemetry.example.com:1234
+# The type of authentication to use, default 'none'
+#authentication = <none|basic|digest>
 # The username and password to authenticate with against the OpenTelemetry endpoint
 #username = user
 #password = secret

--- a/python/its-vehicle/its_vehicle/main.py
+++ b/python/its-vehicle/its_vehicle/main.py
@@ -24,6 +24,7 @@ DEFAULTS = {
     },
     "telemetry": {
         "endpoint": None,
+        "authentication": "none",
         "username": None,
         "password": None,
     },
@@ -114,7 +115,7 @@ def main():
         otel = iot3.core.otel.Otel(
             service_name="its-vehicle",
             endpoint=cfg["telemetry"]["endpoint"],
-            auth=iot3.core.otel.Auth.BASIC,
+            auth=iot3.core.otel.Auth(cfg["telemetry"]["authentication"]),
             username=cfg["telemetry"]["username"],
             password=cfg["telemetry"]["password"],
             batch_period=5.0,


### PR DESCRIPTION
**Changes:**

* Bug fix: closes #192

---
**How to test:**

Pre-requisites:
* a python 3.11 environment; if you do not have one already, use a container:
    ```sh
    $ docker container run \
        --detach \
        --name iot3 \
        --rm \
        -ti \
        --network host \
        -e http_proxy \
       -e https_proxy \
       -e no_proxy \
        --user $(id -u):$(id -u) \
        --mount type=bind,source=$(pwd),destination=$(pwd) \
        --workdir $(pwd) \
        python:3.11.9-slim-bookworm \
        /bin/bash -il
    $ docker container exec -u 0:0 iot3 apt update
    $ docker container exec -u 0:0 iot3 apt install -y build-essential
    $ docker container attach iot3
    ```
* a gpsd daemon listening on _localhost_ on port 2947; if you do not have one already (needs gpsd 3.24 or later; `NEMA.log` is a file containing NME sentences, like the sample on [Wikipedia](https://en.wikipedia.org/wiki/NMEA_0183#Sample_file)):
    ```sh
    TMPDIR=/tmp gpsfake -q -P 2947 -o=-G -u -n -c 0.1 NMEA.log
    ```
* an OpenTelemetry collector with authentication; if you do not have one already, use a container:
    ```sh
    $ docker run \
        --rm \
        -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
        -p 16686:16686 \
        -p 4318:4318 \
        jaegertracing/all-in-one:1.58
    ```
* a configuration file in `/tmp/its-vehicle.cfg`; replace `HOST`, `PORT`, and `PREFIX` with values appropriate for your OpenTelemetry collector (`PREFIX` should not contain the trailing `/v1/traces` part):
    ```ini
    [general]
    instance-id = test-me
    type = CAM
    report-freq = 0.5
    topic-pub-prefix = PROJECT/inQueue/SUFFIX/
    topic-sub-prefix = PROJECT/outQueue/SUFFIX/
    depth = 22
    messages = cam cpm denm
    depth-sub-cam = 18
    depth-sub-cpm = 18
    depth-sub-denm = 15
    speed-thresholds = 8.33 19.44 27.78

    [telemetry]
    endpoint = http://HOST:PORT[PREFIX]

    [broker.main]
    host = localhost
    port = 1883
    username = USERNAME
    password = PASSWORD

    [gpsd]
    port = 2947
    persistence = 10.0
    ```

1. Install the _its-vehicle_ package:
    ```sh
    $ python3.11 -m venv /tmp/its-vehicle
    $ . /tmp/its-vehicle/bin/activate
    🐍 $ pip install python/iot3 python/its-quadkeys python/its-vehicle
    ```
2. Test _its-vehicle_ with no authentication:
    * start _its-vehicle_:
        ```sh
        🐍 $ its-vehicle -c /tmp/its-vehicle.cfg
        ```
    * wait a few seconds, and check the OpenTelemetry collector for traces.
    * stop _its-vehicle_ with `Ctrl-C`
3. Test _its-vehicle_ with _BASIC_ authentication:
    * update the configuration file so that the `telemetry` section contains (replace `USERNAME` and `PASSWORD` appropriately):
        ```ini
        [telemetry]
        endpoint = http://HOST:PORT[PREFIX]
        authentication = basic
        username = USERNAME
        password = PASSWORD
        ```
    * start _its-vehicle_:
        ```sh
        🐍 $ its-vehicle -c /tmp/its-vehicle.cfg
        ```
    * wait a few seconds, and check the OpenTelemetry collector for traces.
    * stop _its-vehicle_ with `Ctrl-C`
4. Test _its-vehicle_ with incorrect credentials:
    * rety the test in step 3, but with invalid username or password

---
**Expected results:**

1. The packages are installed successfully.
2. The OpenTelemetry collector shows no trace for _its-vehicle_
3. The OpenTelemetry collector shows traces for _its-vehicle_
4. The OpenTelemetry collector shows no trace for _its-vehicle_
