### PR TITLE
python/iqm: allow authentication for telemetry

### DIFF
--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -9,7 +9,9 @@ instance-id = ora_geo_1234
 [telemetry]
 # The OpenTelemetry endpoint (without the trailing /v1/traces)
 endpoint = http://opentelemetry.example.com:1234
-# The username and password to authenticate with against the OpenTelemetry endpoint
+# The type of authentication to perform against the OpenTelemetry endpoint; default: none
+#authentication = <none|basic|digest>
+# The username and password to authenticate with
 #username = user
 #password = secret
 

--- a/python/its-interqueuemanager/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/its_iqm/iqm.py
@@ -47,6 +47,7 @@ class IQM:
             self.otel = iot3.core.otel.Otel(
                 service_name="its-interqueuemanager",
                 endpoint=cfg["telemetry"]["endpoint"],
+                auth=iot3.core.otel.Auth(cfg["telemetry"]["authentication"]),
                 username=cfg["telemetry"]["username"],
                 password=cfg["telemetry"]["password"],
                 batch_period=5.0,

--- a/python/its-interqueuemanager/its_iqm/main.py
+++ b/python/its-interqueuemanager/its_iqm/main.py
@@ -17,6 +17,7 @@ DEFAULTS = {
     },
     "telemetry": {
         "endpoint": None,
+        "authentication": "none",
         "username": None,
         "password": None,
     },


### PR DESCRIPTION
**Changes:**

* Bug fix: closes #224

---
**How to test:**

Pre-requisites:
* an MQTT broker listening on `localhost:1883`; if you do not have one, you can just run:
    ```sh
    $ mosquitto
    ```
* an OpenTelemetry collector with authentication
* a python 3.11 environment; if you do not have one already, use a container:
    ```sh
    $ docker container run \
        --detach \
        --name iot3 \
        --rm \
        -ti \
        --network host \
        -e http_proxy \
       -e https_proxy \
       -e no_proxy \
        --user $(id -u):$(id -u) \
        --mount type=bind,source=$(pwd),destination=$(pwd) \
        --workdir $(pwd) \
        python:3.11.9-slim-bookworm \
        /bin/bash -il
    $ docker container exec -u 0:0 iot3 apt update
    $ docker container exec -u 0:0 iot3 apt install -y build-essential git socat
    $ docker container exec -d iot3 socat UNIX-LISTEN:/tmp/mqtt.socket,fork TCP4:localhost:1883
    $ docker container attach iot3
    ```
* a configuration file in `/tmp/its-iqm.cfg`; replace `HOST`, `PORT`, and `PREFIX` with values appropriate for your OpenTelemetry collector (`PREFIX` should not contain the trailing `/v1/traces` part; `authentication` __must__ be `none` for now):
    ```sh
    $ cat <<_EOF_ >/tmp/its-iqm.cfg
    [general]
    instance-id = v2x_12345678
    prefix = default
    suffix = v2x

    [telemetry]
    endpoint = http://HOST:PORT[PREFIX]
    authentication = none

    [local]
    socket-path = /tmp/mqtt.socket
    _EOF_
    ```

1. Install the _its-iqm_ package:
    ```sh
    $ python3.11 -m venv /tmp/its-iqm
    $ . /tmp/its-iqm/bin/activate
    🐍 $ pip install python/iot3 python/its-interqueuemanager
    ```
2. Test _its-interqueuemanager_ with no authentication:
    * start _its-iqm_:
        ```sh
        🐍 $ its-iqm -c /tmp/its-iqm.cfg
        ```
    * send an MQTT message:
        ```sh
        $ mosquitto_pub -t 'default/inQueue/v2x/cam/test_car_1234/0/1/2/3' -m '"test"' -D PUBLISH user-property traceparent 00-41494a55f9a4f29a1e88d5a1dc36b8ea-e3b20dd98d1992f4-00
        ```
    * wait a few seconds, and check the OpenTelemetry collector for traces.
    * stop _its-iqm_ with `Ctrl-C`
3. Test _its-iqm_ with _BASIC_ authentication:
    * update the configuration file so that the `telemetry` section contains (replace `USERNAME` and `PASSWORD` appropriately):
        ```ini
        [telemetry]
        endpoint = http://HOST:PORT[PREFIX]
        authentication = basic
        username = USERNAME
        password = PASSWORD
        ```
    * start _its-iqm_:
        ```sh
        🐍 $ its-iqm -c /tmp/its-iqm.cfg
        ```
    * send an MQTT message:
        ```sh
        $ mosquitto_pub -t 'default/inQueue/v2x/cam/test_car_1234/0/1/2/3' -m '"test"' -D PUBLISH user-property traceparent 00-b537ac2c2d8bd2f581ea5a7babcde49d-943995a268b44d85-00
        ```
    * wait a few seconds, and check the OpenTelemetry collector for traces.
    * stop _its-vehicle_ with `Ctrl-C`
4. Test _its-iqm_ with incorrect credentials:
    * retry the test in step 3, but with invalid username or password (and change the traceparent property)

---
**Expected results:**

1. The packages are installed successfully.
2. The OpenTelemetry collector shows no trace for _its-iqm_
3. The OpenTelemetry collector shows traces for _its-iqm_
4. The OpenTelemetry collector shows no new trace for _its-iqm_
