### PR TITLE
java: make telemetry optional

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -26,9 +26,9 @@ import java.net.URI;
  */
 public class IoT3Core {
 
-    private final MqttClient mqttClient;
-    private final OpenTelemetryClient openTelemetryClient;
-    private final Lwm2mClient lwm2mClient;
+    private MqttClient mqttClient = null;
+    private OpenTelemetryClient openTelemetryClient = null;
+    private Lwm2mClient lwm2mClient = null;
 
     /**
      * Instantiate the IoT3.0 Core SDK.
@@ -58,56 +58,60 @@ public class IoT3Core {
                     String telemetryEndpoint,
                     String telemetryUsername,
                     String telemetryPassword) {
-        // instantiate the OpenTelemetry client
-        OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.Scheme.HTTP;
-        scheme.setCustomPort(telemetryPort);
-        this.openTelemetryClient = new OpenTelemetryClient(
-                scheme,
-                telemetryHost,
-                telemetryEndpoint,
-                mqttClientId,
-                telemetryUsername,
-                telemetryPassword);
-        // instantiate the MQTT client
-        this.mqttClient = new MqttClient(
-                mqttHost,
-                mqttPort,
-                mqttUsername,
-                mqttPassword,
-                mqttClientId,
-                mqttUseTls,
-                new MqttCallback() {
-                    @Override
-                    public void connectionLost(Throwable cause) {
-                        ioT3CoreCallback.mqttConnectionLost(cause);
-                    }
+        // instantiate the OpenTelemetry client if its parameters have been set with the builder
+        if(telemetryHost != null) {
+            OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.Scheme.HTTP;
+            scheme.setCustomPort(telemetryPort);
+            this.openTelemetryClient = new OpenTelemetryClient(
+                    scheme,
+                    telemetryHost,
+                    telemetryEndpoint,
+                    mqttClientId,
+                    telemetryUsername,
+                    telemetryPassword);
+        }
+        // instantiate the MQTT client if its parameters have been set with the builder
+        if(mqttHost != null) {
+            this.mqttClient = new MqttClient(
+                    mqttHost,
+                    mqttPort,
+                    mqttUsername,
+                    mqttPassword,
+                    mqttClientId,
+                    mqttUseTls,
+                    new MqttCallback() {
+                        @Override
+                        public void connectionLost(Throwable cause) {
+                            ioT3CoreCallback.mqttConnectionLost(cause);
+                        }
 
-                    @Override
-                    public void messageArrived(String topic, String message) {
-                        ioT3CoreCallback.mqttMessageArrived(topic, message);
-                    }
+                        @Override
+                        public void messageArrived(String topic, String message) {
+                            ioT3CoreCallback.mqttMessageArrived(topic, message);
+                        }
 
-                    @Override
-                    public void connectComplete(boolean reconnect, String serverURI) {
-                        ioT3CoreCallback.mqttConnectComplete(reconnect, serverURI);
-                    }
+                        @Override
+                        public void connectComplete(boolean reconnect, String serverURI) {
+                            ioT3CoreCallback.mqttConnectComplete(reconnect, serverURI);
+                        }
 
-                    @Override
-                    public void messagePublished(Throwable publishFailure) {
-                        ioT3CoreCallback.mqttMessagePublished(publishFailure);
-                    }
+                        @Override
+                        public void messagePublished(Throwable publishFailure) {
+                            ioT3CoreCallback.mqttMessagePublished(publishFailure);
+                        }
 
-                    @Override
-                    public void subscriptionComplete(Throwable subscriptionFailure) {
-                        ioT3CoreCallback.mqttSubscriptionComplete(subscriptionFailure);
-                    }
+                        @Override
+                        public void subscriptionComplete(Throwable subscriptionFailure) {
+                            ioT3CoreCallback.mqttSubscriptionComplete(subscriptionFailure);
+                        }
 
-                    @Override
-                    public void unsubscriptionComplete(Throwable unsubscriptionFailure) {
-                        ioT3CoreCallback.mqttUnsubscriptionComplete(unsubscriptionFailure);
-                    }
-                },
-                openTelemetryClient);
+                        @Override
+                        public void unsubscriptionComplete(Throwable unsubscriptionFailure) {
+                            ioT3CoreCallback.mqttUnsubscriptionComplete(unsubscriptionFailure);
+                        }
+                    },
+                    openTelemetryClient);
+        }
         // instantiate the LwM2M client
         this.lwm2mClient = new Lwm2mClient();
     }
@@ -212,14 +216,14 @@ public class IoT3Core {
      * Build an instance of IoT3Core.
      */
     public static class IoT3CoreBuilder {
-        private String mqttHost;
+        private String mqttHost = null; // will remain null if not initialized
         private int mqttPort;
         private String mqttUsername;
         private String mqttPassword;
         private String mqttClientId;
         private boolean mqttUseTls;
         private IoT3CoreCallback ioT3CoreCallback;
-        private String telemetryHost;
+        private String telemetryHost = null; // will remain null if not initialized
         private int telemetryPort;
         private String telemetryEndpoint;
         private String telemetryUsername;
@@ -233,7 +237,7 @@ public class IoT3Core {
         /**
          * Set the MQTT parameters of your IoT3Core instance.
          *
-         * @param mqttHost the host or IP address of the MQTT broker
+         * @param mqttHost the host or IP address of the MQTT broker, must not be null
          * @param mqttPort the port of the MQTT broker
          * @param mqttUsername the username for authentication with the MQTT broker
          * @param mqttPassword the password for authentication with the MQTT broker
@@ -246,6 +250,7 @@ public class IoT3Core {
                                           String mqttPassword,
                                           String mqttClientId,
                                           boolean mqttUseTls) {
+            if(mqttHost == null) throw new IllegalArgumentException("mqttHost cannot be null");
             this.mqttHost = mqttHost;
             this.mqttPort = mqttPort;
             this.mqttUsername = mqttUsername;
@@ -258,7 +263,7 @@ public class IoT3Core {
         /**
          * Set the OpenTelemetry parameters of your IoT3Core instance.
          *
-         * @param telemetryHost the host or IP address of the OpenTelemetry server
+         * @param telemetryHost the host or IP address of the OpenTelemetry server, must not be null
          * @param telemetryPort the port of the OpenTelemetry server
          * @param telemetryEndpoint the endpoint of the OpenTelemetry server (e.g. /endpoint/example)
          * @param telemetryUsername the username for authentication with the OpenTelemetry server
@@ -269,6 +274,7 @@ public class IoT3Core {
                                                String telemetryEndpoint,
                                                String telemetryUsername,
                                                String telemetryPassword) {
+            if(telemetryHost == null) throw new IllegalArgumentException("telemetryHost cannot be null");
             this.telemetryHost = telemetryHost;
             this.telemetryPort = telemetryPort;
             this.telemetryEndpoint = telemetryEndpoint;

--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -62,11 +62,10 @@ public class IoT3Core {
                     String telemetryPassword) {
         // instantiate the OpenTelemetry client if its parameters have been set with the builder
         if(telemetryHost != null) {
-            OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.getScheme(telemetryScheme);
-            scheme.setCustomPort(telemetryPort);
             this.openTelemetryClient = new OpenTelemetryClient(
-                    scheme,
+                    telemetryScheme,
                     telemetryHost,
+                    telemetryPort,
                     telemetryEndpoint,
                     mqttClientId,
                     telemetryUsername,
@@ -280,6 +279,7 @@ public class IoT3Core {
                                                String telemetryUsername,
                                                String telemetryPassword) {
             if(telemetryHost == null) throw new IllegalArgumentException("telemetryHost cannot be null");
+            this.telemetryScheme = telemetryScheme;
             this.telemetryHost = telemetryHost;
             this.telemetryPort = telemetryPort;
             this.telemetryEndpoint = telemetryEndpoint;

--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -40,6 +40,7 @@ public class IoT3Core {
      * @param mqttClientId unique MQTT client ID
      * @param mqttUseTls use TLS for a secure connection with the MQTT broker
      * @param ioT3CoreCallback interface to retrieve the different clients outputs
+     * @param telemetryScheme Open Telemetry scheme (HTTP, HTTPS...)
      * @param telemetryHost Open Telemetry server address
      * @param telemetryPort port of the Open Telemetry server
      * @param telemetryEndpoint endpoint of the Open Telemetry server URL
@@ -53,6 +54,7 @@ public class IoT3Core {
                     String mqttClientId,
                     boolean mqttUseTls,
                     IoT3CoreCallback ioT3CoreCallback,
+                    String telemetryScheme,
                     String telemetryHost,
                     int telemetryPort,
                     String telemetryEndpoint,
@@ -60,7 +62,7 @@ public class IoT3Core {
                     String telemetryPassword) {
         // instantiate the OpenTelemetry client if its parameters have been set with the builder
         if(telemetryHost != null) {
-            OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.Scheme.HTTP;
+            OpenTelemetryClient.Scheme scheme = OpenTelemetryClient.getScheme(telemetryScheme);
             scheme.setCustomPort(telemetryPort);
             this.openTelemetryClient = new OpenTelemetryClient(
                     scheme,
@@ -223,6 +225,7 @@ public class IoT3Core {
         private String mqttClientId;
         private boolean mqttUseTls;
         private IoT3CoreCallback ioT3CoreCallback;
+        private String telemetryScheme;
         private String telemetryHost = null; // will remain null if not initialized
         private int telemetryPort;
         private String telemetryEndpoint;
@@ -263,13 +266,15 @@ public class IoT3Core {
         /**
          * Set the OpenTelemetry parameters of your IoT3Core instance.
          *
+         * @param telemetryScheme the scheme of the OpenTelemetry server (e.g. http, https)
          * @param telemetryHost the host or IP address of the OpenTelemetry server, must not be null
          * @param telemetryPort the port of the OpenTelemetry server
          * @param telemetryEndpoint the endpoint of the OpenTelemetry server (e.g. /endpoint/example)
          * @param telemetryUsername the username for authentication with the OpenTelemetry server
          * @param telemetryPassword the password for authentication with the OpenTelemetry server
          */
-        public IoT3CoreBuilder telemetryParams(String telemetryHost,
+        public IoT3CoreBuilder telemetryParams(String telemetryScheme,
+                                               String telemetryHost,
                                                int telemetryPort,
                                                String telemetryEndpoint,
                                                String telemetryUsername,
@@ -299,7 +304,7 @@ public class IoT3Core {
          * the bootstrap configuration.
          * <p>
          * Use instead of {@link #mqttParams(String, int, String, String, String, boolean)}
-         * and {@link #telemetryParams(String, int, String, String, String)}.
+         * and {@link #telemetryParams(String, String, int, String, String, String)}.
          *
          * @param bootstrapConfig the bootstrap configuration object you get from the
          * {@link com.orange.iot3core.bootstrap.BootstrapHelper} bootstrap sequence
@@ -313,6 +318,7 @@ public class IoT3Core {
             this.mqttClientId = bootstrapConfig.getIot3Id();
             this.mqttUseTls = bootstrapConfig.isServiceSecured(BootstrapConfig.Service.MQTT);
             URI telemetryUri = bootstrapConfig.getServiceUri(BootstrapConfig.Service.OPEN_TELEMETRY);
+            this.telemetryScheme = telemetryUri.getScheme();
             this.telemetryHost = telemetryUri.getHost();
             this.telemetryPort = telemetryUri.getPort();
             this.telemetryEndpoint = telemetryUri.getPath();
@@ -335,6 +341,7 @@ public class IoT3Core {
                     mqttClientId,
                     mqttUseTls,
                     ioT3CoreCallback,
+                    telemetryScheme,
                     telemetryHost,
                     telemetryPort,
                     telemetryEndpoint,

--- a/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
@@ -75,7 +75,7 @@ public class BootstrapHelper {
                 BootstrapConfig bootstrapConfig = new BootstrapConfig(jsonResponse);
                 bootstrapCallback.boostrapSuccess(bootstrapConfig);
             }
-        } catch (InterruptedException | URISyntaxException | IOException exception) {
+        } catch (IllegalArgumentException | InterruptedException | IOException | URISyntaxException exception) {
             bootstrapCallback.boostrapError(exception);
         }
     }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -150,56 +150,66 @@ public class MqttClient {
 
     public void publishMessage(String topic, String message, boolean retained, int qos) {
         LOGGER.log(Level.INFO, "Sending message: " + topic + " | "+ message);
-        if(isValidMqttPubTopic(topic)) {
-            Span span = openTelemetryClient.startSpan("IoT3 Core MQTT Message", SpanKind.PRODUCER);
-            span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"), topic);
-            span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
-                    String.valueOf(message.length()));
-            span.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
 
-            // Inject the trace context into a map
-            Map<String, String> contextMap = new HashMap<>();
-            GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(Context.current().with(span),
-                    contextMap, (carrier, key, value) -> {
-                        assert carrier != null;
-                        carrier.put(key, value);
-                    });
+        MqttQos mqttQos = MqttQos.AT_MOST_ONCE;
+        if(qos == 1) mqttQos = MqttQos.AT_LEAST_ONCE;
+        if(qos == 2) mqttQos = MqttQos.EXACTLY_ONCE;
 
-            // Create user properties with traceparent
-            Mqtt5UserProperties userProperties = Mqtt5UserProperties.builder()
-                    .add(Mqtt5UserProperty.of("traceparent", contextMap.get("traceparent")))
-                    .build();
+        if(isValidMqttPubTopic(topic) && mqttClient != null) {
+            var publishBuilder = mqttClient.publishWith()
+                    .topic(topic)
+                    .payload(message.getBytes())
+                    .qos(mqttQos)
+                    .retain(retained);
 
-            // Send the message with user properties
-            final long pubTimestamp = System.currentTimeMillis();
-            MqttQos mqttQos = MqttQos.AT_MOST_ONCE;
-            if(qos == 1) mqttQos = MqttQos.AT_LEAST_ONCE;
-            if(qos == 2) mqttQos = MqttQos.EXACTLY_ONCE;
-            if(mqttClient != null) {
-                mqttClient.publishWith()
-                        .topic(topic)
-                        .payload(message.getBytes())
-                        .userProperties(userProperties)
-                        .qos(mqttQos)
-                        .retain(retained)
-                        .send()
-                        .whenComplete((mqtt3Publish, throwable) -> {
-                            if (throwable != null) {
-                                span.setStatus(StatusCode.ERROR, throwable.getMessage());
-                                span.end();
-                                LOGGER.log(Level.WARNING, "Failed publishing message... "
-                                        + throwable.getMessage());
-                            } else {
-                                span.end();
-                                LOGGER.log(Level.INFO, "Success publishing message ["
-                                        + (System.currentTimeMillis() - pubTimestamp) + " ms]");
-                            }
-                            callback.messagePublished(throwable);
+            if(openTelemetryClient != null) {
+                Span span = openTelemetryClient.startSpan("IoT3 Core MQTT Message", SpanKind.PRODUCER);
+                span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"), topic);
+                span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
+                        String.valueOf(message.length()));
+                span.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
+
+                // Inject the trace context into a map
+                Map<String, String> contextMap = new HashMap<>();
+                GlobalOpenTelemetry.getPropagators().getTextMapPropagator().inject(Context.current().with(span),
+                        contextMap, (carrier, key, value) -> {
+                            assert carrier != null;
+                            carrier.put(key, value);
                         });
+
+                // Create user properties with traceparent
+                Mqtt5UserProperties userProperties = Mqtt5UserProperties.builder()
+                        .add(Mqtt5UserProperty.of("traceparent", contextMap.get("traceparent")))
+                        .build();
+
+                // send message with user properties
+                publishBuilder.userProperties(userProperties)
+                        .send()
+                        .whenComplete((mqtt5Publish, throwable)
+                                -> onPublishComplete(span, throwable));
             } else {
-                LOGGER.log(Level.INFO, NULL_CLIENT);
+                // send message without user properties
+                publishBuilder.send()
+                        .whenComplete((mqtt5Publish, throwable)
+                                -> onPublishComplete(null, throwable));
             }
+        } else if(mqttClient == null) {
+            LOGGER.log(Level.INFO, NULL_CLIENT);
         }
+    }
+
+    private void onPublishComplete(Span span, Throwable throwable) {
+        if (throwable != null) {
+            if(span != null) {
+                span.setStatus(StatusCode.ERROR, throwable.getMessage());
+                span.end();
+            }
+            LOGGER.log(Level.WARNING, "Failed publishing message... " + throwable.getMessage());
+        } else {
+            if(span != null) span.end();
+            LOGGER.log(Level.INFO, "Success publishing message: ");
+        }
+        callback.messagePublished(throwable);
     }
 
     public void publishMessage(String topic, String message, boolean retained) {
@@ -213,48 +223,50 @@ public class MqttClient {
     private void processPublish(Mqtt5Publish publish) {
         String message = new String(publish.getPayloadAsBytes());
 
-        // Extract user properties
-        String traceparent = publish.getUserProperties().asList().stream()
-                .filter(property -> property.getName().toString().equals("traceparent"))
-                .findFirst()
-                .map(property -> property.getValue().toString())
-                .orElse(null);
+        if(openTelemetryClient != null) {
+            // Extract user properties
+            String traceparent = publish.getUserProperties().asList().stream()
+                    .filter(property -> property.getName().toString().equals("traceparent"))
+                    .findFirst()
+                    .map(property -> property.getValue().toString())
+                    .orElse(null);
 
-        // Create a context map with the traceparent
-        Map<String, String> contextMap = new HashMap<>();
-        if (traceparent != null) {
-            contextMap.put("traceparent", traceparent);
+            // Create a context map with the traceparent
+            Map<String, String> contextMap = new HashMap<>();
+            if (traceparent != null) {
+                contextMap.put("traceparent", traceparent);
+            }
+
+            // Extract the trace context from the context map
+            TextMapGetter<Map<String, String>> getter = new TextMapGetter<>() {
+                @Override
+                public Iterable<String> keys(Map<String, String> carrier) {
+                    return carrier.keySet();
+                }
+
+                @Override
+                public String get(Map<String, String> carrier, String key) {
+                    return carrier.get(key);
+                }
+            };
+
+            Context extractedContext = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
+                    .extract(Context.current(), contextMap, getter);
+            SpanContext receivedSpanContext = Span.fromContext(extractedContext).getSpanContext();
+
+            // Create a new span with a link to the received span context
+            Span receivedSpan = openTelemetryClient.startSpanWithLink(
+                    "IoT3 Core MQTT Message",
+                    SpanKind.CONSUMER,
+                    receivedSpanContext.getTraceId(),
+                    receivedSpanContext.getSpanId());
+            receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"),
+                    publish.getTopic().toString());
+            receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
+                    String.valueOf(message.length()));
+            receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
+            receivedSpan.end();
         }
-
-        // Extract the trace context from the context map
-        TextMapGetter<Map<String, String>> getter = new TextMapGetter<>() {
-            @Override
-            public Iterable<String> keys(Map<String, String> carrier) {
-                return carrier.keySet();
-            }
-
-            @Override
-            public String get(Map<String, String> carrier, String key) {
-                return carrier.get(key);
-            }
-        };
-
-        Context extractedContext = GlobalOpenTelemetry.getPropagators().getTextMapPropagator()
-                .extract(Context.current(), contextMap, getter);
-        SpanContext receivedSpanContext = Span.fromContext(extractedContext).getSpanContext();
-
-        // Create a new span with a link to the received span context
-        Span receivedSpan = openTelemetryClient.startSpanWithLink(
-                "IoT3 Core MQTT Message",
-                SpanKind.CONSUMER,
-                receivedSpanContext.getTraceId(),
-                receivedSpanContext.getSpanId());
-        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"),
-                publish.getTopic().toString());
-        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
-                String.valueOf(message.length()));
-        receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
-        receivedSpan.end();
 
         LOGGER.log(Level.INFO, "MQTT message arrived on: " + publish.getTopic() + " | " + message);
         callback.messageArrived(publish.getTopic().toString(), message);

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
@@ -150,4 +150,12 @@ public class OpenTelemetryClient {
         }
     }
 
+    public static Scheme getScheme(String scheme) {
+        return switch (scheme) {
+            case "https" -> Scheme.HTTPS;
+            case "grpc" -> Scheme.GRPC;
+            default -> Scheme.HTTP;
+        };
+    }
+
 }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
@@ -26,20 +26,23 @@ public class OpenTelemetryClient {
     private final String serviceName;
     private Tracer tracer;
     private SdkTracerProvider tracerProvider;
-    private final Scheme scheme;
+    private final String scheme;
     private final String host;
+    private final int port;
     private final String endpoint;
     private final String username;
     private final String password;
 
-    public OpenTelemetryClient(Scheme scheme,
+    public OpenTelemetryClient(String scheme,
                                String host,
+                               int port,
                                String endpoint,
                                String serviceName,
                                String username,
                                String password) {
         this.scheme = scheme;
         this.host = host;
+        this.port = port;
         this.endpoint = endpoint;
         this.serviceName = serviceName;
         this.username = username;
@@ -48,7 +51,7 @@ public class OpenTelemetryClient {
     }
 
     private void initialize() {
-        String url = scheme.getScheme() + "://" + host + ":" + scheme.getPort() + endpoint;
+        String url = scheme + "://" + host + ":" + port + endpoint;
         OpenTelemetry openTelemetry = initOpenTelemetry(url, username, password);
         this.tracer = openTelemetry.getTracer(serviceName);
     }
@@ -119,43 +122,6 @@ public class OpenTelemetryClient {
 
     public void connect() {
         initialize();
-    }
-
-    public enum Scheme {
-        HTTP("http", 4318),
-        HTTPS("https", 4318),
-        GRPC("grpc", 4317);
-
-        private final String scheme;
-        private final int defaultPort;
-        private int customPort;
-
-        Scheme(String scheme, int defaultPort) {
-            this.scheme = scheme;
-            this.defaultPort = defaultPort;
-            this.customPort = -1;
-        }
-
-        public String getScheme() {
-            return scheme;
-        }
-
-        public int getPort() {
-            if(customPort < 0) return defaultPort;
-            else return customPort;
-        }
-
-        public void setCustomPort(int customPort) {
-            this.customPort = customPort;
-        }
-    }
-
-    public static Scheme getScheme(String scheme) {
-        return switch (scheme) {
-            case "https" -> Scheme.HTTPS;
-            case "grpc" -> Scheme.GRPC;
-            default -> Scheme.HTTP;
-        };
     }
 
 }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/OpenTelemetryClient.java
@@ -60,7 +60,10 @@ public class OpenTelemetryClient {
         // Encoding the username and password in Base64 for the Basic Authentication header
         String credentials = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
 
-        if (!endpoint.endsWith("/v1/traces")) endpoint += "/v1/traces";
+        if (!endpoint.endsWith("/v1/traces")) {
+            if(!endpoint.endsWith("/")) endpoint += "/";
+            endpoint += "v1/traces";
+        }
 
         OtlpHttpSpanExporter spanExporter = OtlpHttpSpanExporter.builder()
                 .setEndpoint(endpoint)

--- a/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
@@ -17,6 +17,7 @@ public class Iot3CoreExample {
     private static final String EXAMPLE_MQTT_CLIENT_ID = "mqtt_client_id";
     private static final boolean EXAMPLE_MQTT_USE_TLS = true;
     // OpenTelemetry parameters
+    private static final String EXAMPLE_OTL_SCHEME = "http";
     private static final String EXAMPLE_OTL_HOST = "telemetry_host";
     private static final int EXAMPLE_OTL_PORT = 4318;
     private static final String EXAMPLE_OTL_ENDPOINT = "/telemetry/endpoint";
@@ -34,7 +35,8 @@ public class Iot3CoreExample {
                         EXAMPLE_MQTT_PASSWORD,
                         EXAMPLE_MQTT_CLIENT_ID,
                         EXAMPLE_MQTT_USE_TLS)
-                .telemetryParams(EXAMPLE_OTL_HOST,
+                .telemetryParams(EXAMPLE_OTL_SCHEME,
+                        EXAMPLE_OTL_HOST,
                         EXAMPLE_OTL_PORT,
                         EXAMPLE_OTL_ENDPOINT,
                         EXAMPLE_OTL_USERNAME,

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
@@ -42,6 +42,7 @@ public class Iot3MobilityBootstrapExample {
     private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
     private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
     private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
+    private static final boolean ENABLE_TELEMETRY = true;
 
     private static IoT3Mobility ioT3Mobility;
 
@@ -79,7 +80,7 @@ public class Iot3MobilityBootstrapExample {
     private static void initIoT3Mobility(BootstrapConfig bootstrapConfig) {
         // instantiate IoT3Mobility and its callback
         ioT3Mobility = new IoT3Mobility.IoT3MobilityBuilder(EXAMPLE_UUID, EXAMPLE_CONTEXT)
-                .bootstrapConfig(bootstrapConfig)
+                .bootstrapConfig(bootstrapConfig, ENABLE_TELEMETRY)
                 .callback(new IoT3MobilityCallback() {
                     @Override
                     public void connectionLost(Throwable cause) {

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
@@ -39,6 +39,7 @@ public class Iot3MobilityExample {
     private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
     private static final boolean EXAMPLE_MQTT_USE_TLS = false;
     // OpenTelemetry parameters
+    private static final String EXAMPLE_OTL_SCHEME = "http";
     private static final String EXAMPLE_OTL_HOST = "telemetry_host";
     private static final int EXAMPLE_OTL_PORT = 4318;
     private static final String EXAMPLE_OTL_ENDPOINT = "/telemetry/endpoint";
@@ -55,7 +56,8 @@ public class Iot3MobilityExample {
                         EXAMPLE_MQTT_USERNAME,
                         EXAMPLE_MQTT_PASSWORD,
                         EXAMPLE_MQTT_USE_TLS)
-                .telemetryParams(EXAMPLE_OTL_HOST,
+                .telemetryParams(EXAMPLE_OTL_SCHEME,
+                        EXAMPLE_OTL_HOST,
                         EXAMPLE_OTL_PORT,
                         EXAMPLE_OTL_ENDPOINT,
                         EXAMPLE_OTL_USERNAME,

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -61,6 +61,7 @@ public class IoT3Mobility {
      * @param mqttPassword MQTT password
      * @param mqttUseTls use TLS for a secure connection with the MQTT broker
      * @param ioT3MobilityCallback callback to retrieve connection status
+     * @param telemetryScheme Open Telemetry scheme (e.g. http, https)
      * @param telemetryHost Open Telemetry server address
      * @param telemetryPort port of the Open Telemetry server
      * @param telemetryEndpoint endpoint of the Open Telemetry server URL
@@ -75,6 +76,7 @@ public class IoT3Mobility {
                         String mqttPassword,
                         boolean mqttUseTls,
                         IoT3MobilityCallback ioT3MobilityCallback,
+                        String telemetryScheme,
                         String telemetryHost,
                         int telemetryPort,
                         String telemetryEndpoint,
@@ -127,7 +129,8 @@ public class IoT3Mobility {
                 .callback(ioT3CoreCallback);
 
         if(telemetryHost != null) {
-            ioT3CoreBuilder.telemetryParams(telemetryHost,
+            ioT3CoreBuilder.telemetryParams(telemetryScheme,
+                    telemetryHost,
                     telemetryPort,
                     telemetryEndpoint,
                     telemetryUsername,
@@ -410,6 +413,7 @@ public class IoT3Mobility {
         private String mqttPassword;
         private boolean mqttUseTls;
         private IoT3MobilityCallback ioT3MobilityCallback;
+        private String telemetryScheme;
         private String telemetryHost = null; // will remain null if not initialized
         private int telemetryPort;
         private String telemetryEndpoint;
@@ -452,18 +456,21 @@ public class IoT3Mobility {
         /**
          * Optional. Set the OpenTelemetry parameters of your IoT3Mobility instance.
          *
+         * @param telemetryScheme the scheme of the OpenTelemetry server (e.g. http, https)
          * @param telemetryHost the host or IP address of the OpenTelemetry server, must not be null
          * @param telemetryPort the port of the OpenTelemetry server
          * @param telemetryEndpoint the endpoint of the OpenTelemetry server (e.g. /endpoint/example)
          * @param telemetryUsername the username for authentication with the OpenTelemetry server
          * @param telemetryPassword the password for authentication with the OpenTelemetry server
          */
-        public IoT3Mobility.IoT3MobilityBuilder telemetryParams(String telemetryHost,
-                                                        int telemetryPort,
-                                                        String telemetryEndpoint,
-                                                        String telemetryUsername,
-                                                        String telemetryPassword) {
+        public IoT3Mobility.IoT3MobilityBuilder telemetryParams(String telemetryScheme,
+                                                                String telemetryHost,
+                                                                int telemetryPort,
+                                                                String telemetryEndpoint,
+                                                                String telemetryUsername,
+                                                                String telemetryPassword) {
             if(telemetryHost == null) throw new IllegalArgumentException("telemetryHost cannot be null");
+            this.telemetryScheme = telemetryScheme;
             this.telemetryHost = telemetryHost;
             this.telemetryPort = telemetryPort;
             this.telemetryEndpoint = telemetryEndpoint;
@@ -477,7 +484,7 @@ public class IoT3Mobility {
          * the bootstrap configuration.
          * <p>
          * Use instead of {@link #mqttParams(String, int, String, String, boolean)}
-         * and {@link #telemetryParams(String, int, String, String, String)}.
+         * and {@link #telemetryParams(String, String, int, String, String, String)}.
          *
          * @param bootstrapConfig the bootstrap configuration object you get from the
          * @param enableTelemetry enable telemetry for performance measurements
@@ -493,6 +500,7 @@ public class IoT3Mobility {
             this.mqttUseTls = bootstrapConfig.isServiceSecured(BootstrapConfig.Service.MQTT);
             if(enableTelemetry) {
                 URI telemetryUri = bootstrapConfig.getServiceUri(BootstrapConfig.Service.OPEN_TELEMETRY);
+                this.telemetryScheme = telemetryUri.getScheme();
                 this.telemetryHost = telemetryUri.getHost();
                 this.telemetryPort = telemetryUri.getPort();
                 this.telemetryEndpoint = telemetryUri.getPath();
@@ -528,6 +536,7 @@ public class IoT3Mobility {
                     mqttPassword,
                     mqttUseTls,
                     ioT3MobilityCallback,
+                    telemetryScheme,
                     telemetryHost,
                     telemetryPort,
                     telemetryEndpoint,


### PR DESCRIPTION
**Features**;

Telemetry is now optional for the IoT3 Core and Mobility SDKs.

Closes #235 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityBootstrapExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context";
// Bootstrap parameters
private static final String BOOTSTRAP_ID = "bootstrap_id";
private static final String BOOTSTRAP_LOGIN = "boostrap_login";
private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
private static final boolean ENABLE_TELEMETRY = false; // enable or disable telemetry here
```
4. Run ```Iot3MobilityBootstrapExample```.

---
**Expected results:**

1. On the console, you should see the following:
```
Bootstrap success
IoT3 ID: <id>
LOGIN: <login>
PASSWORD: <password>
MQTT URI: <mqtt_uri>
TELEMETRY URI: <open_telemetry_uri>
```
2. On the console, you should then see that the MQTT connection has been established successfully and that mobility messages are being published and received periodically (CAM, CPM and DENM).
3. On Jaeger, you should see that telemetry is only being reported when `ENABLE_TELEMETRY` is set to `true`.