### PR TITLE
java/iot3mobility: add IoT3Core getter to IoT3Mobility

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -138,6 +138,13 @@ public class IoT3Mobility {
     }
 
     /**
+     * Retrieve the IoT3Core instance powering IoT3Mobility.
+     */
+    public IoT3Core getIoT3Core() {
+        return ioT3Core;
+    }
+
+    /**
      * Disconnect from the server.
      */
     public void disconnect() {


### PR DESCRIPTION
**What's new**

The IoT3Core instance powering IoT3Mobility is now exposed to the user.

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityExample``` class in the ```examples``` module.
4. Check that you can call the getter `getIoT3Core()` from the `ioT3Mobility` object, and that you have access to its underlying methods (for instance, `mqttPublish()` and `mqttSubscribe()`). 
