### PR TITLE
python: fix installed scripts

### DIFF
--- a/python/its-interqueuemanager/pyproject.toml
+++ b/python/its-interqueuemanager/pyproject.toml
@@ -27,4 +27,4 @@ dependencies = [
 "Bug Tracker" = "https://github.com/Orange-OpenSource/its-client/issues"
 
 [project.scripts]
-its-vehicle = "its_vehicle.main:main"
+its-iqm = "its_iqm.main:main"

--- a/python/its-interqueuemanager/pyproject.toml
+++ b/python/its-interqueuemanager/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/its-iot3",
+    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/iot3",
     "requests==2.32.3",
 ]
 

--- a/python/its-status/pyproject.toml
+++ b/python/its-status/pyproject.toml
@@ -28,4 +28,4 @@ dependencies = [
 "Bug Tracker" = "https://github.com/Orange-OpenSource/its-client/issues"
 
 [project.scripts]
-its-info = "its_status.main:main"
+its-status = "its_status.main:main"

--- a/python/its-status/pyproject.toml
+++ b/python/its-status/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/its-iot3",
+    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/iot3",
     "linuxfd==1.5",
     "psutil==5.8.0",
 ]

--- a/python/its-vehicle/pyproject.toml
+++ b/python/its-vehicle/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 dependencies = [
-    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/its-iot3",
+    "iot3 @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/iot3",
     "its-quadkeys @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/its-quadkeys",
     "linuxfd==1.5",
 ]


### PR DESCRIPTION
**Changes:**

* Bug fix:
    * Closes: #255
    * Fix dependencies on IoT3 (due to unpublished packages)

---
**How to test:**

Pre-requisites:
* a python 3.11 environment; if you do not have one already, use a container:
    ```sh
    $ docker container run \
        --detach \
        --name iot3 \
        --rm \
        -ti \
        --network host \
        -e http_proxy \
       -e https_proxy \
       -e no_proxy \
        --user $(id -u):$(id -u) \
        --mount type=bind,source=$(pwd),destination=$(pwd) \
        --workdir $(pwd) \
        python:3.11.9-slim-bookworm \
        /bin/bash -il
    $ docker container exec -u 0:0 iot3 apt update
    $ docker container exec -u 0:0 iot3 apt install -y build-essential git
    $ docker container attach iot3
    ```
   Note: in the following the `$` prompt means running in a shell that has access to python3.11, while the `🐍 $` prompt means running in the activated _venv_.
1. Install the _its-interqueuemanager_ package:
    ```sh
    $ python3.11 -m venv /tmp/iqm
    $ . /tmp/iqm/bin/activate
    🐍 $ pip install python/its-interqueuemanager
    🐍 $ /tmp/iqm/bin/its-iqm -h
    🐍 $ deactivate
    ```
2. Install the _its-status_ package:
    ```sh
    $ python3.11 -m venv /tmp/status
    $ . /tmp/status/bin/activate
    🐍 $ pip install python/its-status
    🐍 $ /tmp/status/bin/its-status -h
    🐍 $ deactivate
    ```
3. Install the _its-vehicle_ package (note: due to unpublished python packages, we need to resolve dependencies by hand for now):
    ```sh
    $ python3.11 -m venv /tmp/vehicle
    $ . /tmp/vehicle/bin/activate
    🐍 $ pip install linuxfd==1.5 python/iot3
    🐍 $ pip install --no-deps python/its-vehicle
    🐍 $ /tmp/vehicle/bin/its-vehicle -h
    🐍 $ deactivate
    ```

---
**Expected results:**

1. The _its-interqueuemanager_ package installs a script named `its-iqm`; `its-iqm -h` displays help for `its-iqm`.
2. The _its-status_ package installs a script named `its-status`; `its-status -h` displays help for `its-status`.
3. The _its-vehicle_ package installs a script named `its-status`; `its-vehicle -h` displays help for `its-vehicle`.