### PR TITLE
python/iot3: make OTLP optional in simple API

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,7 +3,7 @@ Authors
 
 * Frédéric GARDES <frederic(dot)gardes(at)orange(dot)com>
 * Nicolas BUFFON <nicolas(dot)buffon(at)orange(dot)com>
-* Yann MORIN <yann(dot)morin(at)orange(dot)com>
-* Mathieu LEFEBVRE <mathieu1(dot)lefebvre(at)orange(dot)com
-* François SUC <francois(dot)suc(at)orange(dot)com
-* Pierre-Yves LAPERSONNE <pierreyves(dot)lapersonne(at)orange(dot)com
+* Yann E. MORIN <yann(dot)morin(at)orange(dot)com>
+* Mathieu LEFEBVRE <mathieu1(dot)lefebvre(at)orange(dot)com>
+* François SUC <francois(dot)suc(at)orange(dot)com>
+* Pierre-Yves LAPERSONNE <pierreyves(dot)lapersonne(at)orange(dot)com>

--- a/python/iot3/pyproject.toml
+++ b/python/iot3/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "paho-mqtt>=2.1.0",
     "requests>=2.31.0",
-    "its-quadkeys @ git+https://github.com/Orange-OpenSource/its-client@2083d20a59c5191a1258ece823c0741fce672443#subdirectory=python/its-quadkeys"
+    "its-quadkeys @ git+https://github.com/Orange-OpenSource/its-client@4ef72eaabacc7504640becb86974a2cfbf9846b3#subdirectory=python/its-quadkeys"
 ]
 
 [project.urls]

--- a/python/iot3/src/iot3/core/__init__.py
+++ b/python/iot3/src/iot3/core/__init__.py
@@ -202,22 +202,12 @@ def start(
     o_kwargs = dict()
 
     if "otel" in config:
-        for auth in _otel.Auth:
-            if config["otel"]["auth"] == auth.value:
-                o_kwargs["auth"] = auth
-                if auth != otel.Auth.NONE:
-                    o_kwargs["username"] = config["otel"]["username"]
-                    o_kwargs["password"] = config["otel"]["password"]
-                break
-        else:
-            raise ValueError(f"unknown authentication {config['otel']['auth']}")
+        o_kwargs["auth"] = _otel.Auth(config["otel"]["auth"])
+        if o_kwargs["auth"] != _otel.Auth.NONE:
+            o_kwargs["username"] = config["otel"]["username"]
+            o_kwargs["password"] = config["otel"]["password"]
 
-        for comp in _otel.Compression:
-            if config["otel"]["compression"] == comp.value:
-                o_kwargs["compression"] = comp
-                break
-        else:
-            raise ValueError(f"unknown compression {config['otel']['compression']}")
+        o_kwargs["compression"] = _otel.Compression(config["otel"]["compression"])
 
         o = _otel.Otel(
             service_name=config["otel"]["service_name"],

--- a/python/iot3/src/iot3/core/__init__.py
+++ b/python/iot3/src/iot3/core/__init__.py
@@ -276,7 +276,7 @@ def is_ready() -> bool:
 
 
 def wait_for_ready():
-    """Wait until the IoT2 Core SDK is ready.
+    """Wait until the IoT3 Core SDK is ready.
 
     Beware that this may take an indeterminate amount of time; in
     case the MQTT client can't connect at all, wait_for_ready()

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -32,7 +32,7 @@ class MqttClient:
         password: Optional[str] = None,
         msg_cb: Optional[MsgCallbackType] = None,
         msg_cb_data: Any = None,
-        span_ctxmgr_cb: Optional[SpanCallableType] = otel.Otel.noexport_span,
+        span_ctxmgr_cb: Optional[SpanCallableType] = None,
     ):
         """
         Create an MQTT client
@@ -121,7 +121,7 @@ class MqttClient:
             if tls is None:
                 tls = port != 1883
 
-        self.span_ctxmgr_cb = span_ctxmgr_cb
+        self.span_ctxmgr_cb = span_ctxmgr_cb or otel.Otel.noexport_span
 
         self.client = paho.mqtt.client.Client(
             callback_api_version=paho.mqtt.enums.CallbackAPIVersion.VERSION2,

--- a/python/iot3/tests/test-iot3-core
+++ b/python/iot3/tests/test-iot3-core
@@ -6,8 +6,10 @@ import time
 
 
 def recv(data, topic, payload):
-    print(f"{topic[:16]}: {payload[:16]}")
+    print(f"{topic}: {payload[:16]}")
 
+
+print("IoT3 Core SDK with MQTT and OTLP")
 
 config = iot3.core.sample_config
 config["mqtt"] = {
@@ -19,6 +21,28 @@ config["mqtt"] = {
 }
 
 topic = "test/" + random.randbytes(16).hex() + "/iot3"
+
+iot3.core.start(
+    config=config,
+    message_callback=recv,
+)
+
+iot3.core.subscribe(f"{topic}/+")
+
+iot3.core.publish(f"{topic}/dropped", "dropped")
+time.sleep(1)
+
+iot3.core.publish(f"{topic}/passed", "passed")
+time.sleep(1)
+
+iot3.core.stop()
+
+
+print("IoT3 Core SDK with MQTT and no OTLP")
+
+del config["otel"]
+
+topic = "test/" + random.randbytes(16).hex() + "/iot3/no-otlp"
 
 iot3.core.start(
     config=config,


### PR DESCRIPTION
**Changes:**

* Feature: allow using the simple API without OTLP

Closes: #236 

---
**How to test:**

0. Pre-requisites:
    * an OpenTelemetry collector on localhost:
        ```sh
        $ docker container run \
            --rm \
            -p 16686:16686 \
            -p 4318:4318 \
            jaegertracing/all-in-one:1.58
        ```
    * a python 3.11 environment; if you do not have one already, use a container:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.9-slim-bookworm \
            /bin/bash -il
        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git
        $ docker container attach iot3
        ```
       Note: in the following tests, the `$` prompt means running in a shell that has access to python3.11, while the `🐍 $` prompt means running in the activated _venv_.
1. Install the IoT3 SDK package:
    ```sh
    $ python3.11 -m venv /tmp/iot3
    $ . /tmp/iot3/bin/activate
    🐍 $ pip install python/iot3
    ```
2. Run the IoT3 test-suite for the simple API:
    ```
    🐍 $ python/iot3/tests/test-iot3-core
    ```

---
**Expected results:**

1. The IoT3 SDK package is isntalled
2. The test-suite succeeds:
    * the test reports (`[...]` is a hex string):
        ```
        IoT3 Core SDK with MQTT and OTLP
        test/[...]/iot3/passed: b'passed'
        IoT3 Core SDK with MQTT and no OTLP
        test/[...]/iot3/no-otlp/passed: b'passed'
        ```
    * The Jaeger UI (on http://localhost:16686/) contains exactly three traces which MQTT topic (in _Tags_ -> _iot3.core.mqtt.topic_) does not contain the _no-otlp_ component:
        * one trace reports a failure due to not being connected;
        * one trace reports a publish;
        * one trace reports a receive with a reference to the publish, above.