### PR TITLE
rust: remove unused lifetime declaration

### DIFF
--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -32,7 +32,7 @@ pub struct MqttClient {
     client: AsyncClient,
 }
 
-impl<'client> MqttClient {
+impl MqttClient {
     pub fn new(options: &MqttOptions) -> (Self, EventLoop) {
         let (client, event_loop) = AsyncClient::new(options.clone(), 1000);
         (MqttClient { client }, event_loop)


### PR DESCRIPTION
What's new
---------------

- rust: remove unused lifetime declaration in MqttClient (fixes #260)

How to test
---------------

1. Check that all jobs in workflows succeeded