### PR TITLE
Java: fix JSON issues

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/JsonUtil.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/JsonUtil.java
@@ -7,8 +7,23 @@
  */
 package com.orange.iot3mobility.its.json;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 public class JsonUtil {
 
     public static final int UNKNOWN = Integer.MIN_VALUE;
+
+    public static boolean isNullOrEmpty(JSONObject jsonObject) {
+        // use the zero length test instead of the isEmpty() method
+        // to make the SDK compatible with Android apps
+        return jsonObject == null || jsonObject.length() == 0;
+    }
+
+    public static boolean isNullOrEmpty(JSONArray jsonArray) {
+        // use the zero length test instead of the isEmpty() method
+        // to make the SDK compatible with Android apps
+        return jsonArray == null || jsonArray.length() == 0;
+    }
 
 }

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathHistory.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathHistory.java
@@ -45,7 +45,7 @@ public class PathHistory {
     }
 
     public static PathHistory jsonParser(JSONArray jsonPathHistory) {
-        if(jsonPathHistory == null || jsonPathHistory.isEmpty()) return new PathHistory(null);
+        if(JsonUtil.isNullOrEmpty(jsonPathHistory)) return new PathHistory(null);
         ArrayList<PathPoint> pathPoints = new ArrayList<>();
         try {
             for(int i = 0; i < jsonPathHistory.length(); i++) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathPoint.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathPoint.java
@@ -70,7 +70,7 @@ public class PathPoint {
     }
 
     public static PathPoint jsonParser(JSONObject jsonPathPoint) {
-        if(jsonPathPoint == null || jsonPathPoint.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonPathPoint)) return null;
         JSONObject jsonPathPosition = jsonPathPoint.optJSONObject(JsonKey.PathPoint.PATH_POSITION.key());
         PathPosition pathPosition = PathPosition.jsonParser(jsonPathPosition);
         int pathDeltaTime = jsonPathPoint.optInt(JsonKey.PathPoint.PATH_DELTA_TIME.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathPosition.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PathPosition.java
@@ -83,7 +83,7 @@ public class PathPosition {
     }
 
     public static PathPosition jsonParser(JSONObject jsonPathPosition) {
-        if(jsonPathPosition == null || jsonPathPosition.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonPathPosition)) return null;
         try {
             int deltaLatitude = jsonPathPosition.getInt(JsonKey.PathPosition.DELTA_LATITUDE.key());
             int deltaLongitude = jsonPathPosition.getInt(JsonKey.PathPosition.DELTA_LONGITUDE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/Position.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/Position.java
@@ -106,7 +106,7 @@ public class Position {
     }
 
     public static Position jsonParser(JSONObject jsonPosition) {
-        if(jsonPosition == null || jsonPosition.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonPosition)) return null;
         try {
             long latitude = jsonPosition.getLong(JsonKey.Position.LATITUDE.key());
             long longitude = jsonPosition.getLong(JsonKey.Position.LONGITUDE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidence.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidence.java
@@ -74,7 +74,7 @@ public class PositionConfidence {
     }
 
     public static PositionConfidence jsonParser(JSONObject jsonPositionConfidence) {
-        if(jsonPositionConfidence == null || jsonPositionConfidence.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonPositionConfidence)) return null;
         JSONObject jsonPositionConfidenceEllipse = jsonPositionConfidence.optJSONObject(JsonKey.Confidence.POSITION_CONFIDENCE_ELLIPSE.key());
         PositionConfidenceEllipse positionConfidenceEllipse = PositionConfidenceEllipse.jsonParser(jsonPositionConfidenceEllipse);
         int altitudeConfidence = jsonPositionConfidence.optInt(JsonKey.Confidence.ALTITUDE.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidence.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidence.java
@@ -53,7 +53,8 @@ public class PositionConfidence {
     private void createJson() {
         try {
             if(positionConfidenceEllipse != null)
-                jsonPositionConfidence.put(JsonKey.Confidence.POSITION_CONFIDENCE_ELLIPSE.key(), positionConfidenceEllipse);
+                jsonPositionConfidence.put(JsonKey.Confidence.POSITION_CONFIDENCE_ELLIPSE.key(),
+                        positionConfidenceEllipse.getJsonPositionConfidenceEllipse());
             if(altitudeConfidence != UNKNOWN)
                 jsonPositionConfidence.put(JsonKey.Confidence.ALTITUDE.key(), altitudeConfidence);
         } catch (JSONException e) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidenceEllipse.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/PositionConfidenceEllipse.java
@@ -78,7 +78,7 @@ public class PositionConfidenceEllipse {
     }
 
     public static PositionConfidenceEllipse jsonParser(JSONObject jsonPositionConfidenceEllipse) {
-        if(jsonPositionConfidenceEllipse == null || jsonPositionConfidenceEllipse.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonPositionConfidenceEllipse)) return null;
         int semiMajorConfidence = jsonPositionConfidenceEllipse.optInt(JsonKey.Confidence.POSITION_SEMI_MAJOR_CONFIDENCE.key(), UNKNOWN);;
         int semiMinorConfidence = jsonPositionConfidenceEllipse.optInt(JsonKey.Confidence.POSITION_SEMI_MINOR_CONFIDENCE.key(), UNKNOWN);;
         int semiMajorOrientation = jsonPositionConfidenceEllipse.optInt(JsonKey.Confidence.POSITION_SEMI_MAJOR_ORIENTATION.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/BasicContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/BasicContainer.java
@@ -8,6 +8,7 @@
 package com.orange.iot3mobility.its.json.cam;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.Position;
 import com.orange.iot3mobility.its.json.PositionConfidence;
 
@@ -126,7 +127,7 @@ public class BasicContainer {
     }
 
     public static BasicContainer jsonParser(JSONObject jsonBasicContainer) {
-        if(jsonBasicContainer == null || jsonBasicContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonBasicContainer)) return null;
         try {
             int stationType = jsonBasicContainer.getInt(JsonKey.BasicContainer.STATION_TYPE.key());
             JSONObject jsonPosition = jsonBasicContainer.getJSONObject(JsonKey.BasicContainer.POSITION.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/CAM.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/CAM.java
@@ -8,6 +8,7 @@
 package com.orange.iot3mobility.its.json.cam;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.MessageBase;
 
@@ -268,7 +269,7 @@ public class CAM extends MessageBase {
      * @return {@link CAM}
      */
     public static CAM jsonParser(JSONObject jsonCAM) {
-        if(jsonCAM == null || jsonCAM.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonCAM)) return null;
         try {
             String type = jsonCAM.getString(JsonKey.Header.TYPE.key());
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/HighFrequencyContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/HighFrequencyContainer.java
@@ -12,6 +12,7 @@ import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 import com.orange.iot3mobility.its.EtsiUtils;
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.cpm.PerceivedObject;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -357,7 +358,7 @@ public class HighFrequencyContainer {
                 jsonHighFrequencyContainer.put(JsonKey.HighFrequencyContainer.CURVATURE_CALCULATION_MODE.key(), curvatureCalculationMode);
             if(!accelerationControl.isEmpty())
                 jsonHighFrequencyContainer.put(JsonKey.HighFrequencyContainer.ACCELERATION_CONTROL.key(), accelerationControl);
-            if(!confidence.isEmpty())
+            if(!JsonUtil.isNullOrEmpty(confidence))
                 jsonHighFrequencyContainer.put(JsonKey.HighFrequencyContainer.CONFIDENCE.key(), confidence);
         } catch (JSONException e) {
             LOGGER.log(Level.WARNING, "HighFrequencyContainer JSON build error", "Error: " + e);
@@ -780,7 +781,7 @@ public class HighFrequencyContainer {
     }
 
     public static HighFrequencyContainer jsonParser(JSONObject jsonHighFrequencyContainer) {
-        if(jsonHighFrequencyContainer == null || jsonHighFrequencyContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonHighFrequencyContainer)) return null;
         int heading = jsonHighFrequencyContainer.optInt(JsonKey.HighFrequencyContainer.HEADING.key(), UNKNOWN);
         int speed = jsonHighFrequencyContainer.optInt(JsonKey.HighFrequencyContainer.SPEED.key(), UNKNOWN);
         int driveDirection = jsonHighFrequencyContainer.optInt(JsonKey.HighFrequencyContainer.DRIVE_DIRECTION.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/LowFrequencyContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cam/LowFrequencyContainer.java
@@ -8,6 +8,7 @@
 package com.orange.iot3mobility.its.json.cam;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.PathHistory;
 
 import org.json.JSONArray;
@@ -130,7 +131,7 @@ public class LowFrequencyContainer {
     }
 
     public static LowFrequencyContainer jsonParser(JSONObject jsonLowFreqContainer) {
-        if(jsonLowFreqContainer == null || jsonLowFreqContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonLowFreqContainer)) return null;
         try {
             int vehicleRole = jsonLowFreqContainer.getInt(JsonKey.LowFrequencyContainer.VEHICLE_ROLE.key());
             String exteriorLights = jsonLowFreqContainer.optString(JsonKey.LowFrequencyContainer.EXTERIOR_LIGHTS.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/CPM.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/CPM.java
@@ -10,6 +10,7 @@ package com.orange.iot3mobility.its.json.cpm;
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.MessageBase;
 
@@ -331,7 +332,7 @@ public class CPM extends MessageBase {
      * @return {@link CPM}
      */
     public static CPM jsonParser(JSONObject jsonCPM) {
-        if(jsonCPM == null || jsonCPM.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonCPM)) return null;
         try {
             String type = jsonCPM.getString(JsonKey.Header.TYPE.key());
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ClassificationItem.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ClassificationItem.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import com.orange.iot3mobility.its.StationType;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -238,7 +239,7 @@ public class ClassificationItem {
     }
 
     public static ClassificationItem jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             JSONObject jsonObjectClass = json.getJSONObject(JsonCpmKey.Classification.OBJECT_CLASS.key());
             ObjectClassVehicle objectClassVehicle = ObjectClassVehicle.jsonParser(jsonObjectClass);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/DetectionArea.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/DetectionArea.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -182,7 +183,7 @@ public class DetectionArea {
     }
 
     public static DetectionArea jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         JSONObject jsonVehicleSensor = json.optJSONObject(JsonCpmKey.DetectionArea.VEHICLE_SENSOR.key());
         VehicleSensor vehicleSensor = VehicleSensor.jsonParser(jsonVehicleSensor);
         JSONObject jsonStationarySensorRadial = json.optJSONObject(JsonCpmKey.DetectionArea.STATIONARY_SENSOR_RADIAL.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ManagementContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ManagementContainer.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.Position;
 import com.orange.iot3mobility.its.json.PositionConfidence;
 
@@ -89,7 +90,7 @@ public class ManagementContainer {
     }
 
     public static ManagementContainer jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int stationType = json.getInt(JsonCpmKey.ManagementContainer.STATION_TYPE.key());
             JSONObject jsonReferencePosition = json.getJSONObject(JsonCpmKey.ManagementContainer.REFERENCE_POSITION.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassOther.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassOther.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -53,7 +54,7 @@ public class ObjectClassOther {
     }
 
     public static ObjectClassOther jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.OTHER.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectClassOther(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassSingleVru.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassSingleVru.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -115,7 +116,7 @@ public class ObjectClassSingleVru {
     }
 
     public static ObjectClassSingleVru jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         JSONObject jsonSingleVru = json.optJSONObject(JsonCpmKey.ObjectClass.SINGLE_VRU.key());
         if(jsonSingleVru != null) {
             ObjectVruPedestrian objectVruPedestrian = ObjectVruPedestrian.jsonParser(jsonSingleVru);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassVehicle.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectClassVehicle.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -67,7 +68,7 @@ public class ObjectClassVehicle {
     }
 
     public static ObjectClassVehicle jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.VEHICLE.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectClassVehicle(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruAnimal.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruAnimal.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -55,7 +56,7 @@ public class ObjectVruAnimal {
     }
 
     public static ObjectVruAnimal jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.ANIMAL.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectVruAnimal(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruBicyclist.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruBicyclist.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -56,7 +57,7 @@ public class ObjectVruBicyclist {
     }
 
     public static ObjectVruBicyclist jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.BICYCLIST.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectVruBicyclist(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruMotorcyclist.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruMotorcyclist.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -56,7 +57,7 @@ public class ObjectVruMotorcyclist {
     }
 
     public static ObjectVruMotorcyclist jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.MOTORCYLCIST.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectVruMotorcyclist(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruPedestrian.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/ObjectVruPedestrian.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -55,7 +56,7 @@ public class ObjectVruPedestrian {
     }
 
     public static ObjectVruPedestrian jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int subclass = json.optInt(JsonCpmKey.ObjectClass.PEDESTRIAN.key(), UNKNOWN);
         if(subclass != UNKNOWN) return new ObjectVruPedestrian(subclass);
         else return null;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/Offset.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/Offset.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -106,7 +107,7 @@ public class Offset {
     }
 
     public static Offset jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int x = json.getInt(JsonCpmKey.Offset.X.key());
             int y = json.getInt(JsonCpmKey.Offset.Y.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingRsuContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingRsuContainer.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -94,7 +95,7 @@ public class OriginatingRsuContainer {
     }
 
     public static OriginatingRsuContainer jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int region = json.optInt(JsonCpmKey.OriginatingRsuContainer.REGION.key(), UNKNOWN);
         int intersectionReferenceId = json.optInt(JsonCpmKey.OriginatingRsuContainer.INTERSECTION_REFERENCE_ID.key(), UNKNOWN);
         int roadSegmentReferenceId = json.optInt(JsonCpmKey.OriginatingRsuContainer.ROAD_SEGMENT_REFERENCE_ID.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingVehicleConfidence.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingVehicleConfidence.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -184,7 +185,7 @@ public class OriginatingVehicleConfidence {
     }
 
     public static OriginatingVehicleConfidence jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         int heading = json.optInt(JsonCpmKey.OriginatingVehicleContainer.HEADING.key(), UNKNOWN);
         int speed = json.optInt(JsonCpmKey.OriginatingVehicleContainer.SPEED.key(), UNKNOWN);
         int vehicleLength = json.optInt(JsonCpmKey.OriginatingVehicleContainer.VEHICLE_LENGTH.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingVehicleContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/OriginatingVehicleContainer.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -226,7 +227,7 @@ public class OriginatingVehicleContainer {
     }
 
     public static OriginatingVehicleContainer jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int heading = json.getInt(JsonCpmKey.OriginatingVehicleContainer.HEADING.key());
             int speed = json.getInt(JsonCpmKey.OriginatingVehicleContainer.SPEED.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObject.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObject.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -712,7 +713,7 @@ public class PerceivedObject {
                 for(ClassificationItem classificationItem: classification) {
                     if(classificationItem != null) jsonClassification.put(classificationItem.getJson());
                 }
-                if(!jsonClassification.isEmpty())
+                if(!JsonUtil.isNullOrEmpty(jsonClassification))
                     json.put(JsonCpmKey.PerceivedObjectContainer.CLASSIFICATION.key(), jsonClassification);
             }
             json.put(JsonCpmKey.PerceivedObjectContainer.CONFIDENCE.key(), confidence.getJson());
@@ -1153,7 +1154,7 @@ public class PerceivedObject {
     }
 
     public static PerceivedObject jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int objectId = json.getInt(JsonCpmKey.PerceivedObjectContainer.OBJECT_ID.key());
             int timeOfMeasurement = json.getInt(JsonCpmKey.PerceivedObjectContainer.TIME_OF_MEASUREMENT.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObjectConfidence.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObjectConfidence.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -885,7 +886,7 @@ public class PerceivedObjectConfidence {
     }
 
     public static PerceivedObjectConfidence jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int xDistance = json.getInt(JsonCpmKey.ObjectDistance.X_DISTANCE.key());
             int yDistance = json.getInt(JsonCpmKey.ObjectDistance.Y_DISTANCE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObjectContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/PerceivedObjectContainer.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -49,7 +50,7 @@ public class PerceivedObjectContainer {
     }
 
     public static PerceivedObjectContainer jsonParser(JSONArray jsonArray) {
-        if(jsonArray == null || jsonArray.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonArray)) return null;
         try {
             ArrayList<PerceivedObject> perceivedObjects = new ArrayList<>();
             for (int i = 0; i < jsonArray.length(); i++) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/SensorInformation.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/SensorInformation.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -111,7 +112,7 @@ public class SensorInformation {
     }
 
     public static SensorInformation jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int sensorId = json.getInt(JsonCpmKey.SensorInformationContainer.SENSOR_ID.key());
             int type = json.getInt(JsonCpmKey.SensorInformationContainer.TYPE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/SensorInformationContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/SensorInformationContainer.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -57,7 +58,7 @@ public class SensorInformationContainer {
     }
 
     public static SensorInformationContainer jsonParser(JSONArray jsonArray) {
-        if(jsonArray == null || jsonArray.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonArray)) return null;
         try {
             ArrayList<SensorInformation> sensorInformationList = new ArrayList<>();
             for (int i = 0; i < jsonArray.length(); i++) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationDataContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationDataContainer.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -77,7 +78,7 @@ public class StationDataContainer {
     }
 
     public static StationDataContainer jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         JSONObject jsonOriginatingVehicleContainer = json.optJSONObject(JsonCpmKey.StationDataContainer.ORIGINATING_VEHICLE_CONTAINER.key());
         OriginatingVehicleContainer originatingVehicleContainer = OriginatingVehicleContainer.jsonParser(jsonOriginatingVehicleContainer);
         JSONObject jsonOriginatingRsuContainer = json.optJSONObject(JsonCpmKey.StationDataContainer.ORIGINATING_RSU_CONTAINER.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorCircular.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorCircular.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -78,7 +79,7 @@ public class StationarySensorCircular {
     }
 
     public static StationarySensorCircular jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             JSONObject jsonNodeCenterPoint = json.optJSONObject(JsonCpmKey.StationarySensorCircular.NODE_CENTER_POINT.key());
             Offset nodeCenterPoint = Offset.jsonParser(jsonNodeCenterPoint);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorEllipse.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorEllipse.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -133,7 +134,7 @@ public class StationarySensorEllipse {
     }
 
     public static StationarySensorEllipse jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             JSONObject jsonNodeCenterPoint = json.optJSONObject(JsonCpmKey.StationarySensorEllipseRect.NODE_CENTER_POINT.key());
             Offset nodeCenterPoint = Offset.jsonParser(jsonNodeCenterPoint);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorPolygon.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorPolygon.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.cpm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class StationarySensorPolygon {
     }
 
     public static StationarySensorPolygon jsonParser(JSONArray jsonArray) {
-        if(jsonArray == null || jsonArray.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonArray)) return null;
         ArrayList<Offset> offsetPoints = new ArrayList<>();
         for (int i = 0; i < jsonArray.length(); i++) {
             Offset offsetPoint = Offset.jsonParser(jsonArray.optJSONObject(i));

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorRadial.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorRadial.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -161,7 +162,7 @@ public class StationarySensorRadial {
     }
 
     public static StationarySensorRadial jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int range = json.getInt(JsonCpmKey.StationarySensorRadial.RANGE.key());
             int horizontalOpeningAngleStart = json.getInt(JsonCpmKey.StationarySensorRadial.HORIZONTAL_OPENING_ANGLE_START.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorRectangle.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/StationarySensorRectangle.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -133,7 +134,7 @@ public class StationarySensorRectangle {
     }
 
     public static StationarySensorRectangle jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             JSONObject jsonNodeCenterPoint = json.optJSONObject(JsonCpmKey.StationarySensorEllipseRect.NODE_CENTER_POINT.key());
             Offset nodeCenterPoint = Offset.jsonParser(jsonNodeCenterPoint);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/VehicleSensor.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/VehicleSensor.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -141,7 +142,7 @@ public class VehicleSensor {
     }
 
     public static VehicleSensor jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int refPointId = json.getInt(JsonCpmKey.VehicleSensor.REF_POINT_ID.key());
             int xSensorOffset = json.getInt(JsonCpmKey.VehicleSensor.X_SENSOR_OFFSET.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/VehicleSensorProperty.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/cpm/VehicleSensorProperty.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.cpm;
 
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -168,7 +169,7 @@ public class VehicleSensorProperty {
     }
 
     public static VehicleSensorProperty jsonParser(JSONObject json) {
-        if(json == null || json.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(json)) return null;
         try {
             int range = json.getInt(JsonCpmKey.VehicleSensorProperty.RANGE.key());
             int horizontalOpeningAngleStart = json.getInt(JsonCpmKey.VehicleSensorProperty.HORIZONTAL_OPENING_ANGLE_START.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/ActionId.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/ActionId.java
@@ -11,6 +11,7 @@ import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -72,7 +73,7 @@ public class ActionId {
     }
 
     public static ActionId jsonParser(JSONObject jsonActionId) {
-        if(jsonActionId == null || jsonActionId.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonActionId)) return null;
         try {
             long originStationId = jsonActionId.getLong(JsonKey.ActionId.ORIGINATING_STATION_ID.key());
             int sequenceNumber = jsonActionId.optInt(JsonKey.ActionId.SEQUENCE_NUMBER.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/AlacarteContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/AlacarteContainer.java
@@ -11,6 +11,7 @@ import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -107,7 +108,7 @@ public class AlacarteContainer {
     }
 
     public static AlacarteContainer jsonParser(JSONObject jsonAlacarteContainer) {
-        if(jsonAlacarteContainer == null || jsonAlacarteContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonAlacarteContainer)) return null;
         int lanePosition = jsonAlacarteContainer.optInt(JsonKey.AlacarteContainer.LANE_POSITION.key(), UNKNOWN);
         int impactReduction = jsonAlacarteContainer.optInt(JsonKey.AlacarteContainer.IMPACT_REDUCTION.key(), UNKNOWN);
         final int externalTemperature = jsonAlacarteContainer.optInt(JsonKey.AlacarteContainer.EXTERNAL_TEMPERATURE.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/DENM.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/DENM.java
@@ -8,6 +8,7 @@
 package com.orange.iot3mobility.its.json.denm;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.MessageBase;
 
@@ -291,7 +292,7 @@ public class DENM extends MessageBase {
      * @return {@link DENM}
      */
     public static DENM jsonParser(JSONObject jsonDENM) {
-        if(jsonDENM == null || jsonDENM.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonDENM)) return null;
         try {
             String type = jsonDENM.getString(JsonKey.Header.TYPE.key());
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/EventType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/EventType.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.denm;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -63,7 +64,7 @@ public class EventType {
     }
 
     public static EventType jsonParser(JSONObject jsonEventType) {
-        if(jsonEventType == null || jsonEventType.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonEventType)) return null;
         try {
             int cause = jsonEventType.getInt(JsonKey.EventType.CAUSE.key());
             int subcause = jsonEventType.getInt(JsonKey.EventType.SUBCAUSE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/LinkedCause.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/LinkedCause.java
@@ -9,6 +9,7 @@ package com.orange.iot3mobility.its.json.denm;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -63,7 +64,7 @@ public class LinkedCause {
     }
 
     public static LinkedCause jsonParser(JSONObject jsonLinkedCause) {
-        if(jsonLinkedCause == null || jsonLinkedCause.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonLinkedCause)) return null;
         try {
             int cause = jsonLinkedCause.getInt(JsonKey.EventType.CAUSE.key());
             int subcause = jsonLinkedCause.getInt(JsonKey.EventType.SUBCAUSE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/LocationContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/LocationContainer.java
@@ -11,6 +11,7 @@ import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -97,7 +98,7 @@ public class LocationContainer {
             jsonLocationContainer.put(JsonKey.LocationContainer.TRACES.key(), traces.getJsonTraces());
             if(roadType != UNKNOWN)
                 jsonLocationContainer.put(JsonKey.LocationContainer.ROAD_TYPE.key(), roadType);
-            if(!confidence.isEmpty())
+            if(!JsonUtil.isNullOrEmpty(confidence))
                 jsonLocationContainer.put(JsonKey.LocationContainer.CONFIDENCE.key(), confidence);
         } catch (JSONException e) {
             LOGGER.log(Level.WARNING, "LocationContainer JSON build error", "Error: " + e);
@@ -133,7 +134,7 @@ public class LocationContainer {
     }
 
     public static LocationContainer jsonParser(JSONObject jsonLocationContainer) {
-        if(jsonLocationContainer == null || jsonLocationContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonLocationContainer)) return null;
         try {
             int eventSpeed = jsonLocationContainer.optInt(JsonKey.LocationContainer.EVENT_SPEED.key(), UNKNOWN);
             int eventPositionHeading = jsonLocationContainer.optInt(JsonKey.LocationContainer.EVENT_POSITION_HEADING.key(), UNKNOWN);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/ManagementContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/ManagementContainer.java
@@ -10,6 +10,7 @@ package com.orange.iot3mobility.its.json.denm;
 import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.Position;
 import com.orange.iot3mobility.its.json.PositionConfidence;
 
@@ -305,7 +306,7 @@ public class ManagementContainer {
     }
 
     public static ManagementContainer jsonParser(JSONObject jsonManagementContainer) {
-        if(jsonManagementContainer == null || jsonManagementContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonManagementContainer)) return null;
         try {
             JSONObject jsonActionId = jsonManagementContainer.getJSONObject(JsonKey.ManagementContainer.ACTION_ID.key());
             ActionId actionId = ActionId.jsonParser(jsonActionId);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/SituationContainer.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/SituationContainer.java
@@ -11,6 +11,7 @@ import static com.orange.iot3mobility.its.json.JsonUtil.UNKNOWN;
 
 import com.orange.iot3mobility.its.json.JsonKey;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -101,7 +102,7 @@ public class SituationContainer {
     }
 
     public static SituationContainer jsonParser(JSONObject jsonSituationContainer) {
-        if(jsonSituationContainer == null || jsonSituationContainer.isEmpty()) return null;
+        if(JsonUtil.isNullOrEmpty(jsonSituationContainer)) return null;
         try {
             int infoQuality = jsonSituationContainer.optInt(JsonKey.SituationContainer.INFO_QUALITY.key(), UNKNOWN);
             JSONObject jsonEventType = jsonSituationContainer.getJSONObject(JsonKey.SituationContainer.EVENT_TYPE.key());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/Traces.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/json/denm/Traces.java
@@ -7,6 +7,7 @@
  */
 package com.orange.iot3mobility.its.json.denm;
 
+import com.orange.iot3mobility.its.json.JsonUtil;
 import com.orange.iot3mobility.its.json.PathHistory;
 
 import org.json.JSONArray;
@@ -42,7 +43,7 @@ public class Traces {
     }
 
     public static Traces jsonParser(JSONArray jsonTraces) {
-        if(jsonTraces == null || jsonTraces.isEmpty()) return new Traces(null);
+        if(JsonUtil.isNullOrEmpty(jsonTraces)) return new Traces(null);
         ArrayList<PathHistory> pathHistories = new ArrayList<>();
         for(int i = 0; i < jsonTraces.length(); i++) {
             PathHistory pathHistory = PathHistory.jsonParser(jsonTraces.optJSONArray(i));


### PR DESCRIPTION
**Fixes**;

- The Java IoT3Mobility SDK can now be used by Android apps to exchange ITS messages in JSON format.
- The DENM optional position confidence ellipse is now properly set in the JSON message.

Closes #281 

---
**To do**

No specific tests needed (unless you want to build an Android app to test the first part). 
Just review the code changes.