### PR TITLE
Java: fix road hazard handling

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
@@ -49,7 +49,8 @@ public class RoadHazardManager {
                 ioT3RoadHazardCallback.denmArrived(denm);
 
                 //associate the received DENM to a RoadHazard object
-                String uuid = denm.getSourceUuid() + "_" + denm.getStationId();
+                String uuid = denm.getManagementContainer().getActionId().getOriginatingStationId()
+                        + "_" + denm.getManagementContainer().getActionId().getSequenceNumber();
                 int cause = denm.getSituationContainer().getEventType().getCause();
                 int subcause = denm.getSituationContainer().getEventType().getSubcause();
                 LatLng position = new LatLng(

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
@@ -64,11 +64,16 @@ public class RoadHazardManager {
                     synchronized (ROAD_HAZARD_MAP) {
                         RoadHazard roadHazard = ROAD_HAZARD_MAP.get(uuid);
                         if(roadHazard != null) {
-                            roadHazard.updateTimestamp(timestamp);
-                            roadHazard.setPosition(position);
-                            roadHazard.setLifetime(lifetime);
-                            roadHazard.setDenm(denm);
-                            ioT3RoadHazardCallback.roadHazardUpdate(roadHazard);
+                            if(terminate) {
+                                ROAD_HAZARD_MAP.values().remove(roadHazard);
+                                ioT3RoadHazardCallback.roadHazardExpired(roadHazard);
+                            } else {
+                                roadHazard.updateTimestamp(timestamp);
+                                roadHazard.setPosition(position);
+                                roadHazard.setLifetime(lifetime);
+                                roadHazard.setDenm(denm);
+                                ioT3RoadHazardCallback.roadHazardUpdate(roadHazard);
+                            }
                         }
                     }
                 } else if(!terminate && !expired) {


### PR DESCRIPTION
**Fixes**

- Fixed the UUID of `RoadHazard` from the combination of the `DENM`'s `source_uuid` and `station_id`, to the correct combination of `originating_station_id` and `sequence_number`.
- Fixed handling of `DENM` termination to trigger the removal of the corresponding `RoadHazard` from the HashMap holding the active road hazards + notification to the callback.

Closes #280 

---
**To do**

Just review the code changes.