### PR TITLE
swift: add core

### DIFF
--- a/swift/ITSClient/Sources/ITSCore/Core.swift
+++ b/swift/ITSClient/Sources/ITSCore/Core.swift
@@ -22,12 +22,11 @@ public actor Core {
         continuationsByTopic = [:]
     }
 
-    public func start(
-        mqttClientConfiguration: MQTTClientConfiguration,
-        telemetryClientConfiguration: TelemetryClientConfiguration?
-    ) async throws(CoreError) {
-        let telemetryClient = telemetryClientConfiguration.map { OpenTelemetryClient(configuration: $0) }
-        let mqttClient = MQTTNIOClient(configuration: mqttClientConfiguration)
+    public func start(coreConfiguration: CoreConfiguration) async throws(CoreError) {
+        let telemetryClient = coreConfiguration.telemetryClientConfiguration.map {
+            OpenTelemetryClient(configuration: $0)
+        }
+        let mqttClient = MQTTNIOClient(configuration: coreConfiguration.mqttClientConfiguration)
 
         try await start(mqttClient: mqttClient, telemetryClient: telemetryClient)
     }

--- a/swift/ITSClient/Sources/ITSCore/Core.swift
+++ b/swift/ITSClient/Sources/ITSCore/Core.swift
@@ -1,0 +1,177 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+public actor Core {
+    private var mqttClient: MQTTClient?
+    private var telemetryClient: TelemetryClient?
+    private var continuationsByTopic: [String: AsyncStream<CoreMQTTMessage>.Continuation]
+    private let spanName = "IoT3 Core MQTT Message"
+    private let traceParentProperty = "traceparent"
+
+    public init() {
+        continuationsByTopic = [:]
+    }
+
+    public func start(
+        mqttClientConfiguration: MQTTClientConfiguration,
+        telemetryClientConfiguration: TelemetryClientConfiguration?
+    ) async throws(CoreError) {
+        let telemetryClient = telemetryClientConfiguration.map { OpenTelemetryClient(configuration: $0) }
+        let mqttClient = MQTTNIOClient(configuration: mqttClientConfiguration)
+
+        try await start(mqttClient: mqttClient, telemetryClient: telemetryClient)
+    }
+
+    public func subscribe(to topic: String) async throws(CoreError) -> AsyncStream<CoreMQTTMessage> {
+        guard let mqttClient else {
+            throw .notStarted
+        }
+
+        do {
+            try await mqttClient.subscribe(to: topic)
+        } catch {
+            throw .mqttError(EquatableError(wrappedError: error))
+        }
+
+        return AsyncStream { continuation in
+            continuationsByTopic[topic] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { [weak self] in
+                    try await self?.unsubscribe(from: topic)
+                }
+            }
+        }
+    }
+
+    public func unsubscribe(from topic: String) async throws(CoreError) {
+        guard let mqttClient else {
+            throw .notStarted
+        }
+
+        defer {
+            let continuation = continuationsByTopic[topic]
+            continuation?.finish()
+            continuationsByTopic.removeValue(forKey: topic)
+        }
+
+        do {
+            try await mqttClient.unsubscribe(from: topic)
+        } catch {
+            throw .mqttError(EquatableError(wrappedError: error))
+        }
+    }
+
+    public func publish(message: CoreMQTTMessage) async throws(CoreError) {
+        guard let mqttClient else {
+            throw .notStarted
+        }
+
+        let spanID = await startSentMessageSpan(message)
+        var traceParent: String?
+        if let spanID {
+            let context = await telemetryClient?.updateContext(withSpanID: spanID)
+            traceParent = context?[traceParentProperty]
+        }
+
+        do {
+            let userProperty = traceParent.map { MQTTMessageUserProperty(key: traceParentProperty, value: $0) }
+            let message = MQTTMessage(payload: message.payload,
+                                      topic: message.topic,
+                                      userProperty: userProperty)
+            try await mqttClient.publish(message)
+            await stopSpan(spanID: spanID)
+        } catch {
+            await stopSpan(spanID: spanID, errorMessage: error.localizedDescription)
+            throw .mqttError(EquatableError(wrappedError: error))
+        }
+    }
+
+    public func stop() async throws(CoreError) {
+        for topic in continuationsByTopic.keys {
+            try await unsubscribe(from: topic)
+        }
+
+        do {
+            try await mqttClient?.disconnect()
+        } catch {
+            throw .mqttError(EquatableError(wrappedError: error))
+        }
+        mqttClient = nil
+
+        await telemetryClient?.stop()
+        telemetryClient = nil
+    }
+
+    func start(mqttClient: MQTTClient, telemetryClient: TelemetryClient?) async throws(CoreError) {
+        guard self.mqttClient == nil && self.telemetryClient == nil else {
+            return
+        }
+
+        self.mqttClient = mqttClient
+        await mqttClient.setMessageReceivedHandler(messageReceivedHandler: { message in
+            Task { [weak self] in
+                guard let self else { return }
+
+                let spanID = await startReceivedMessageSpan(message)
+                await stopSpan(spanID: spanID)
+
+                let topicContinuation = await continuationsByTopic[message.topic]
+                topicContinuation?.yield(CoreMQTTMessage(payload: message.payload, topic: message.topic))
+            }
+        })
+        self.telemetryClient = telemetryClient
+
+        do {
+            try await self.mqttClient?.connect()
+        } catch {
+            throw .mqttError(EquatableError(wrappedError: error))
+        }
+
+        await self.telemetryClient?.start()
+    }
+
+    private func startReceivedMessageSpan(_ message: MQTTMessage) async -> String? {
+        let traceParent = traceParent(from: message)
+        let attributes = buildAttributes(payload: message.payload, topic: message.topic)
+        let context = traceParent.map { [traceParentProperty: $0] } ?? [:]
+        return await telemetryClient?.startSpan(name: spanName,
+                                                type: .consumer,
+                                                attributes: attributes,
+                                                fromContext: context)
+    }
+
+    private func startSentMessageSpan(_ message: CoreMQTTMessage) async -> String? {
+        let attributes = buildAttributes(payload: message.payload, topic: message.topic)
+        return await telemetryClient?.startSpan(name: spanName,
+                                                type: .producer,
+                                                attributes: attributes)
+    }
+
+    private func traceParent(from message: MQTTMessage) -> String? {
+        guard let userProperty = message.userProperty else { return nil }
+
+        return userProperty.key == traceParentProperty ? userProperty.value : nil
+    }
+
+    private func buildAttributes(payload: Data, topic: String) -> [String: Sendable] {
+        ["iot3.core.mqtt.topic": topic,
+         "iot3.core.mqtt.payload_size": payload.count,
+         "iot3.core.sdk_language": "swift"]
+    }
+
+    private func stopSpan(spanID: String?, errorMessage: String? = nil) async {
+        guard let spanID else { return }
+
+        await telemetryClient?.stopSpan(spanID: spanID, errorMessage: errorMessage)
+    }
+}

--- a/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
@@ -1,0 +1,23 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+public struct CoreConfiguration: Sendable {
+    let mqttClientConfiguration: MQTTClientConfiguration
+    let telemetryClientConfiguration: TelemetryClientConfiguration?
+
+    init(
+        mqttClientConfiguration: MQTTClientConfiguration,
+        telemetryClientConfiguration: TelemetryClientConfiguration?
+    ) {
+        self.mqttClientConfiguration = mqttClientConfiguration
+        self.telemetryClientConfiguration = telemetryClientConfiguration
+    }
+}

--- a/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
@@ -9,11 +9,16 @@
  * Software description: Swift ITS client.
  */
 
+/// A structure to configure the core.
 public struct CoreConfiguration: Sendable {
     let mqttClientConfiguration: MQTTClientConfiguration
     let telemetryClientConfiguration: TelemetryClientConfiguration?
 
-    init(
+    /// Initializes a `CoreConfiguration`.
+    /// - Parameters:
+    ///   - mqttClientConfiguration: The MQTT client configuration.
+    ///   - telemetryClientConfiguration: The telemetry client configuration. Can be nil to opt-out telemetry.
+    public init(
         mqttClientConfiguration: MQTTClientConfiguration,
         telemetryClientConfiguration: TelemetryClientConfiguration?
     ) {

--- a/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
@@ -20,7 +20,7 @@ public struct CoreConfiguration: Sendable {
     ///   - telemetryClientConfiguration: The telemetry client configuration. Can be nil to opt-out telemetry.
     public init(
         mqttClientConfiguration: MQTTClientConfiguration,
-        telemetryClientConfiguration: TelemetryClientConfiguration?
+        telemetryClientConfiguration: TelemetryClientConfiguration? = nil
     ) {
         self.mqttClientConfiguration = mqttClientConfiguration
         self.telemetryClientConfiguration = telemetryClientConfiguration

--- a/swift/ITSClient/Sources/ITSCore/CoreError.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreError.swift
@@ -11,7 +11,10 @@
 
 import Foundation
 
+/// The errors thrown by the core.
 public enum CoreError: Error, Equatable {
+    /// The core must be started before performing this action.
     case notStarted
+    /// A MQTT error occured.
     case mqttError(EquatableError)
 }

--- a/swift/ITSClient/Sources/ITSCore/CoreError.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreError.swift
@@ -1,0 +1,17 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+public enum CoreError: Error, Equatable {
+    case notStarted
+    case mqttError(EquatableError)
+}

--- a/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
@@ -17,4 +17,13 @@ public struct CoreMQTTMessage: Sendable {
     public let payload: Data
     /// The topic on which the message is received or sent.
     public let topic: String
+
+    /// Initializes a `CoreMQTTMessage`
+    /// - Parameters:
+    ///   - payload: The message payload.
+    ///   - topic: The topic on which the message is received or sent.
+    public init(payload: Data, topic: String) {
+        self.payload = payload
+        self.topic = topic
+    }
 }

--- a/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
@@ -1,0 +1,17 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+public struct CoreMQTTMessage: Sendable {
+    let payload: Data
+    let topic: String
+}

--- a/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreMQTTMessage.swift
@@ -11,7 +11,10 @@
 
 import Foundation
 
+/// The representation of a message received or sent by the core.
 public struct CoreMQTTMessage: Sendable {
-    let payload: Data
-    let topic: String
+    /// The message payload.
+    public let payload: Data
+    /// The topic on which the message is received or sent.
+    public let topic: String
 }

--- a/swift/ITSClient/Sources/ITSCore/EquatableError.swift
+++ b/swift/ITSClient/Sources/ITSCore/EquatableError.swift
@@ -9,10 +9,13 @@
  * Software description: Swift ITS client.
  */
 
+/// A structure to manage equatable errors for underlying errors.
 public struct EquatableError: Error, Equatable {
+    /// The wrapped error.
     public let wrappedError: any Error & Equatable
     private let equalsClosure: (@Sendable (any Error & Equatable) -> Bool)
 
+    /// The localized  description.
     public var localizedDescription: String {
         return wrappedError.localizedDescription
     }

--- a/swift/ITSClient/Sources/ITSCore/EquatableError.swift
+++ b/swift/ITSClient/Sources/ITSCore/EquatableError.swift
@@ -1,0 +1,29 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+public struct EquatableError: Error, Equatable {
+    public let wrappedError: any Error & Equatable
+    private let equalsClosure: (@Sendable (any Error & Equatable) -> Bool)
+
+    public var localizedDescription: String {
+        return wrappedError.localizedDescription
+    }
+
+    init<T: Error & Equatable>(wrappedError: T) {
+        self.wrappedError = wrappedError
+        // To avoid generic on struct, do the test in the closure and store it
+        equalsClosure = { $0 as? T == wrappedError }
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.equalsClosure(rhs.wrappedError)
+    }
+}

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClient.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClient.swift
@@ -11,12 +11,13 @@
 
 import Foundation
 
-protocol MQTTClient: Actor {
+protocol MQTTClient: Sendable {
     var isConnected: Bool { get }
     
     init(configuration: MQTTClientConfiguration, messageReceivedHandler: (@Sendable @escaping (MQTTMessage) -> Void))
     func connect() async throws(MQTTClientError)
     func subscribe(to topic: String) async throws(MQTTClientError)
+    func unsubscribe(from topic: String) async throws(MQTTClientError)
     func disconnect() async throws(MQTTClientError)
     func publish(_ message: MQTTMessage) async throws(MQTTClientError)
 }

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClient.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClient.swift
@@ -11,14 +11,14 @@
 
 import Foundation
 
-protocol MQTTClient: Sendable {
+protocol MQTTClient: Actor {
     var isConnected: Bool { get }
-    
-    init(configuration: MQTTClientConfiguration, messageReceivedHandler: (@Sendable @escaping (MQTTMessage) -> Void))
+
+    init(configuration: MQTTClientConfiguration)
+    func setMessageReceivedHandler(messageReceivedHandler: (@escaping @Sendable (MQTTMessage) -> Void))
     func connect() async throws(MQTTClientError)
     func subscribe(to topic: String) async throws(MQTTClientError)
     func unsubscribe(from topic: String) async throws(MQTTClientError)
     func disconnect() async throws(MQTTClientError)
     func publish(_ message: MQTTMessage) async throws(MQTTClientError)
 }
-

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
@@ -9,6 +9,7 @@
  * Software description: Swift ITS client.
  */
 
+/// A structure to configure a MQTT client.
 public struct MQTTClientConfiguration: Sendable {
     let host: String
     let port: Int
@@ -18,7 +19,16 @@ public struct MQTTClientConfiguration: Sendable {
     let useSSL: Bool
     let useWebSockets: Bool
 
-    init(
+    /// Initializes a `MQTTClientConfiguration`.
+    /// - Parameters:
+    ///   - host: The MQTT server host.
+    ///   - port: The MQTT server port.
+    ///   - clientIdentifier: The MQTT client identifier.
+    ///   - userName: The MQTT user name if authentication is enabled on the server.
+    ///   - password: The MQTT password if authentication is enabled on the server.
+    ///   - useSSL: `true` to use an encrypted connection to the server.
+    ///   - useWebSockets: `true` to use a websocket connection to the server.
+    public init(
         host: String,
         port: Int,
         clientIdentifier: String,

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
@@ -9,7 +9,7 @@
  * Software description: Swift ITS client.
  */
 
-struct MQTTClientConfiguration {
+public struct MQTTClientConfiguration: Sendable {
     let host: String
     let port: Int
     let clientIdentifier: String
@@ -17,7 +17,7 @@ struct MQTTClientConfiguration {
     let password: String?
     let useSSL: Bool
     let useWebSockets: Bool
-    
+
     init(
         host: String,
         port: Int,

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientError.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientError.swift
@@ -19,3 +19,22 @@ enum MQTTClientError: Error {
     case disconnectionFailed
     case sendPayloadFailed
 }
+
+extension MQTTClientError {
+    var localizedDescription: String {
+        switch self {
+        case .connectionFailed:
+            return "The connection to the server has failed."
+        case .clientNotConnected:
+            return "Unable to perform the operation because the client is not connected."
+        case .subscriptionFailed:
+            return "The subscription has failed."
+        case .unsubscriptionFailed:
+            return "The unsubscription has failed."
+        case .disconnectionFailed:
+            return "The disconnection from the server has failed."
+        case .sendPayloadFailed:
+            return "The MQTT message can't be sent."
+        }
+    }
+}

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientError.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientError.swift
@@ -15,6 +15,7 @@ enum MQTTClientError: Error {
     case connectionFailed
     case clientNotConnected
     case subscriptionFailed
+    case unsubscriptionFailed
     case disconnectionFailed
     case sendPayloadFailed
 }

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTMessage.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTMessage.swift
@@ -14,4 +14,12 @@ import Foundation
 struct MQTTMessage {
     let payload: Data
     let topic: String
+    let userProperty: MQTTMessageUserProperty?
 }
+
+struct MQTTMessageUserProperty {
+    let key: String
+    let value: String
+}
+
+extension MQTTMessageUserProperty: Equatable {}

--- a/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-struct TelemetryClientConfiguration {
+public struct TelemetryClientConfiguration: Sendable {
     let url: URL
     let user: String?
     let password: String?

--- a/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 
+/// A structure to configure a telemetry client.
 public struct TelemetryClientConfiguration: Sendable {
     let url: URL
     let user: String?
@@ -19,7 +20,15 @@ public struct TelemetryClientConfiguration: Sendable {
     let scheduleDelay: TimeInterval
     let batchSize: Int
 
-    init(
+    /// Initializes a `TelemetryClientConfiguration`.
+    /// - Parameters:
+    ///   - url: The server url.
+    ///   - user: The user name if authentication is enabled on the server.
+    ///   - password: The password if authentication is enabled on the server.
+    ///   - serviceName: The service name to use.
+    ///   - scheduleDelay: The delay to send spans (Default: 5 seconds).
+    ///   - batchSize: The maximum of spans to send in a batch (Default: 50).
+    public init(
         url: URL,
         user: String? = nil,
         password: String? = nil,

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -82,8 +82,7 @@ struct CoreTests {
 
         // When
         let topic = "its-topic-test"
-        let coreConfiguration = CoreConfiguration(mqttClientConfiguration: coreConfiguration.mqttClientConfiguration,
-                                                  telemetryClientConfiguration: nil)
+        let coreConfiguration = CoreConfiguration(mqttClientConfiguration: coreConfiguration.mqttClientConfiguration)
         try await core.start(coreConfiguration: coreConfiguration)
         let message = CoreMQTTMessage(payload: Data(), topic: topic)
         try await core.publish(message: message)

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -1,0 +1,234 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import Testing
+@testable import ITSCore
+
+struct CoreTests {
+    private let mockMQTTClient: MockMQTTClient
+    private let mockTelemetryClient: MockTelemetryClient
+
+    init() {
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "",
+                                                              port: 0,
+                                                              clientIdentifier: "",
+                                                              useSSL: false)
+        mockMQTTClient = MockMQTTClient(configuration: mqttClientConfiguration)
+        let telemetryClientConfiguration = TelemetryClientConfiguration(url: URL(string: "http://foo.com")!,
+                                                                        serviceName: "")
+        mockTelemetryClient = MockTelemetryClient(configuration: telemetryClientConfiguration)
+    }
+
+    @Test("Core start with telemetry configuration should connect to MQTT and start telemetry")
+    func core_start_with_telemetry_should_connect_to_MQTT_and_start_telemetry() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+
+        // Then
+        #expect(await mockMQTTClient.isConnected)
+        #expect(await mockMQTTClient.setMessageReceivedHandlerCallsCount == 1)
+        #expect(await mockMQTTClient.connectCallsCount == 1)
+        #expect(await mockTelemetryClient.startCallsCount == 1)
+    }
+
+    @Test("Core stop should finish subscribe stream and telemetry")
+    func core_stop_should_finish_subscribe_stream_and_telemetry() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        Task {
+            try await Task.sleep(for: .seconds(0.5))
+            try await core.stop()
+        }
+
+        // Then
+        try await confirmation(expectedCount: 1) { confirmation in
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+            confirmation()
+        }
+        #expect(await !mockMQTTClient.isConnected)
+        #expect(await mockTelemetryClient.stopCallsCount == 1)
+    }
+
+    @Test("Core should forward received messages and send a telemetry span")
+    func core_should_forward_received_messages_and_send_telemetry_span() async throws {
+        // Given
+        let core = Core()
+        let topic = "topic"
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        let incomingMessage = MQTTMessage(payload: Data(), topic: topic, userProperty: nil)
+        Task {
+            try await Task.sleep(for: .seconds(0.5))
+            await mockMQTTClient.simulateMessageReceived(incomingMessage)
+            await mockMQTTClient.simulateMessageReceived(incomingMessage)
+            try await Task.sleep(for: .seconds(0.5))
+            try await core.unsubscribe(from: topic)
+        }
+
+        // Then
+        try await confirmation(expectedCount: 2) { confirmation in
+            for await message in try await core.subscribe(to: topic) {
+                #expect(message.payload == incomingMessage.payload)
+                #expect(message.topic == incomingMessage.topic)
+                confirmation()
+            }
+        }
+        #expect(await mockTelemetryClient.startSpanWithContextCallsCount == 2)
+        #expect(await mockTelemetryClient.stopSpanCallsCount == 2)
+    }
+
+    @Test("Core start should throw an error when MQTT client fails to connect")
+    func core_start_should_throw_error_when_mqtt_client_fails_to_connect() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            mockMQTTClient.throwsConnectError = true
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            Issue.record("start should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.connectionFailed))
+            }
+        }
+    }
+
+    @Test("Core subscribe stream should throw an error when not started")
+    func core_subscribe_stream_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        let task = Task {
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+        }
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            try await task.value
+        }
+    }
+
+    @Test("Core subscribe stream should throw an error when MQTT error occurs")
+    func core_subscribe_stream_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+        mockMQTTClient.throwsSubscribeError = true
+        let task = Task {
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+        }
+
+        // Then
+        do {
+            try await task.value
+        } catch {
+            if case .mqttError(let wrappedError) = error as? CoreError {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.subscriptionFailed))
+            }
+        }
+    }
+
+    @Test("Core unsubscribe should throw an error when not started")
+    func core_unsubscribe_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            // When
+            try await core.unsubscribe(from: "topic")
+        }
+    }
+
+    @Test("Core unsubscribe should throw an error when MQTT error occurs")
+    func core_unsubscribe_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            mockMQTTClient.throwsUnsubscribeError = true
+            try await core.unsubscribe(from: "topic")
+            Issue.record("unsubscribe should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.unsubscriptionFailed))
+            }
+        }
+    }
+
+    @Test("Core publish should send a message and send a telemetry span")
+    func core_publish_should_send_message_and_send_telemetry_span() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+        try await core.publish(message: message)
+
+        // Then
+        #expect(await mockMQTTClient.publishCallsCount == 1)
+        #expect(await mockTelemetryClient.startSpanCallsCount == 1)
+        #expect(await mockTelemetryClient.stopSpanCallsCount == 1)
+    }
+
+    @Test("Core publish should throw an error when not started")
+    func core_publish_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            // When
+            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+            try await core.publish(message: message)
+        }
+    }
+
+    @Test("Core publish should throw an error when MQTT error occurs")
+    func core_publish_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            mockMQTTClient.throwsPublishError = true
+            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+            try await core.publish(message: message)
+            Issue.record("publish should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.sendPayloadFailed))
+            }
+        }
+    }
+}

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -14,221 +14,81 @@ import Testing
 @testable import ITSCore
 
 struct CoreTests {
-    private let mockMQTTClient: MockMQTTClient
-    private let mockTelemetryClient: MockTelemetryClient
+    private let coreConfiguration: CoreConfiguration
 
-    init() {
-        let mqttClientConfiguration = MQTTClientConfiguration(host: "",
-                                                              port: 0,
-                                                              clientIdentifier: "",
+    init() throws {
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "test.mosquitto.org",
+                                                              port: 1883,
+                                                              clientIdentifier: UUID().uuidString,
                                                               useSSL: false)
-        mockMQTTClient = MockMQTTClient(configuration: mqttClientConfiguration)
-        let telemetryClientConfiguration = TelemetryClientConfiguration(url: URL(string: "http://foo.com")!,
-                                                                        serviceName: "")
-        mockTelemetryClient = MockTelemetryClient(configuration: telemetryClientConfiguration)
+        let url = try #require(URL(string: "http://localhost:4318"))
+        let telemetryClientConfiguration = TelemetryClientConfiguration(url: url,
+                                                                        serviceName: "its-tests-service")
+        coreConfiguration = CoreConfiguration(mqttClientConfiguration: mqttClientConfiguration,
+                                              telemetryClientConfiguration: telemetryClientConfiguration)
     }
 
-    @Test("Core start with telemetry configuration should connect to MQTT and start telemetry")
-    func core_start_with_telemetry_should_connect_to_MQTT_and_start_telemetry() async throws {
+    @Test("A message sent to a subscribed topic should be received and create a linked span")
+    func message_sent_to_subscribed_topic_should_be_received_and_create_linked_span() async throws {
         // Given
         let core = Core()
 
         // When
-        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
-
-        // Then
-        #expect(await mockMQTTClient.isConnected)
-        #expect(await mockMQTTClient.setMessageReceivedHandlerCallsCount == 1)
-        #expect(await mockMQTTClient.connectCallsCount == 1)
-        #expect(await mockTelemetryClient.startCallsCount == 1)
-    }
-
-    @Test("Core stop should finish subscribe stream and telemetry")
-    func core_stop_should_finish_subscribe_stream_and_telemetry() async throws {
-        // Given
-        let core = Core()
-
-        // When
-        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        let topic = "its-topic-test"
+        let incomingMessage = CoreMQTTMessage(payload: Data(), topic: topic)
+        try await core.start(coreConfiguration: coreConfiguration)
         Task {
             try await Task.sleep(for: .seconds(0.5))
-            try await core.stop()
+            try await core.publish(message: incomingMessage)
+            try await Task.sleep(for: .seconds(0.5))
+            try await core.stop() // Stop to flush spans
         }
 
-        // Then
         try await confirmation(expectedCount: 1) { confirmation in
-            for await _ in try await core.subscribe(to: "topic") {
-            }
-            confirmation()
-        }
-        #expect(await !mockMQTTClient.isConnected)
-        #expect(await mockTelemetryClient.stopCallsCount == 1)
-    }
-
-    @Test("Core should forward received messages and send a telemetry span")
-    func core_should_forward_received_messages_and_send_telemetry_span() async throws {
-        // Given
-        let core = Core()
-        let topic = "topic"
-
-        // When
-        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
-        let incomingMessage = MQTTMessage(payload: Data(), topic: topic, userProperty: nil)
-        Task {
-            try await Task.sleep(for: .seconds(0.5))
-            await mockMQTTClient.simulateMessageReceived(incomingMessage)
-            await mockMQTTClient.simulateMessageReceived(incomingMessage)
-            try await Task.sleep(for: .seconds(0.5))
-            try await core.unsubscribe(from: topic)
-        }
-
-        // Then
-        try await confirmation(expectedCount: 2) { confirmation in
             for await message in try await core.subscribe(to: topic) {
+                // Then
                 #expect(message.payload == incomingMessage.payload)
                 #expect(message.topic == incomingMessage.topic)
                 confirmation()
             }
         }
-        #expect(await mockTelemetryClient.startSpanWithContextCallsCount == 2)
-        #expect(await mockTelemetryClient.stopSpanCallsCount == 2)
+
+        // Wait a bit for the spans flush
+        try await Task.sleep(for: .seconds(0.5))
     }
 
-    @Test("Core start should throw an error when MQTT client fails to connect")
-    func core_start_should_throw_error_when_mqtt_client_fails_to_connect() async throws {
-        // Given
-        let core = Core()
-
-        do {
-            // When
-            mockMQTTClient.throwsConnectError = true
-            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
-            Issue.record("start should throw an error")
-        } catch {
-            // Then
-            if case .mqttError(let wrappedError) = error {
-                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.connectionFailed))
-            }
-        }
-    }
-
-    @Test("Core subscribe stream should throw an error when not started")
-    func core_subscribe_stream_should_throw_error_when_not_started() async throws {
+    @Test("A message sent with an error should create a span with an error")
+    func message_sent_with_error_should_create_span_with_error() async throws {
         // Given
         let core = Core()
 
         // When
-        let task = Task {
-            for await _ in try await core.subscribe(to: "topic") {
-            }
-        }
-
-        // Then
-        await #expect(throws: CoreError.notStarted) {
-            try await task.value
+        let topic = "#"
+        try await core.start(coreConfiguration: coreConfiguration)
+        let message = CoreMQTTMessage(payload: Data(), topic: topic)
+        do {
+            try await core.publish(message: message)
+        } catch {
+            try await core.stop() // Stop to flush spans
+            // Wait a bit for the spans flush
+            try await Task.sleep(for: .seconds(0.5))
         }
     }
 
-    @Test("Core subscribe stream should throw an error when MQTT error occurs")
-    func core_subscribe_stream_should_throw_error_when_mqtt_error_occurs() async throws {
+    @Test("Send a message without a telemetry configuration should not create a span")
+    func send_message_without_telemetry_should_not_create_span() async throws {
         // Given
         let core = Core()
 
         // When
-        try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
-        mockMQTTClient.throwsSubscribeError = true
-        let task = Task {
-            for await _ in try await core.subscribe(to: "topic") {
-            }
-        }
-
-        // Then
-        do {
-            try await task.value
-        } catch {
-            if case .mqttError(let wrappedError) = error as? CoreError {
-                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.subscriptionFailed))
-            }
-        }
-    }
-
-    @Test("Core unsubscribe should throw an error when not started")
-    func core_unsubscribe_should_throw_error_when_not_started() async throws {
-        // Given
-        let core = Core()
-
-        // Then
-        await #expect(throws: CoreError.notStarted) {
-            // When
-            try await core.unsubscribe(from: "topic")
-        }
-    }
-
-    @Test("Core unsubscribe should throw an error when MQTT error occurs")
-    func core_unsubscribe_should_throw_error_when_mqtt_error_occurs() async throws {
-        // Given
-        let core = Core()
-
-        do {
-            // When
-            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
-            mockMQTTClient.throwsUnsubscribeError = true
-            try await core.unsubscribe(from: "topic")
-            Issue.record("unsubscribe should throw an error")
-        } catch {
-            // Then
-            if case .mqttError(let wrappedError) = error {
-                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.unsubscriptionFailed))
-            }
-        }
-    }
-
-    @Test("Core publish should send a message and send a telemetry span")
-    func core_publish_should_send_message_and_send_telemetry_span() async throws {
-        // Given
-        let core = Core()
-
-        // When
-        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
-        let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+        let topic = "its-topic-test"
+        let coreConfiguration = CoreConfiguration(mqttClientConfiguration: coreConfiguration.mqttClientConfiguration,
+                                                  telemetryClientConfiguration: nil)
+        try await core.start(coreConfiguration: coreConfiguration)
+        let message = CoreMQTTMessage(payload: Data(), topic: topic)
         try await core.publish(message: message)
-
-        // Then
-        #expect(await mockMQTTClient.publishCallsCount == 1)
-        #expect(await mockTelemetryClient.startSpanCallsCount == 1)
-        #expect(await mockTelemetryClient.stopSpanCallsCount == 1)
-    }
-
-    @Test("Core publish should throw an error when not started")
-    func core_publish_should_throw_error_when_not_started() async throws {
-        // Given
-        let core = Core()
-
-        // Then
-        await #expect(throws: CoreError.notStarted) {
-            // When
-            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
-            try await core.publish(message: message)
-        }
-    }
-
-    @Test("Core publish should throw an error when MQTT error occurs")
-    func core_publish_should_throw_error_when_mqtt_error_occurs() async throws {
-        // Given
-        let core = Core()
-
-        do {
-            // When
-            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
-            mockMQTTClient.throwsPublishError = true
-            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
-            try await core.publish(message: message)
-            Issue.record("publish should throw an error")
-        } catch {
-            // Then
-            if case .mqttError(let wrappedError) = error {
-                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.sendPayloadFailed))
-            }
-        }
+        try await core.stop() // Stop as you want to flush spans
+        // Wait a bit for the spans flush
+        try await Task.sleep(for: .seconds(0.5))
     }
 }

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreUnitTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreUnitTests.swift
@@ -1,0 +1,234 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import Testing
+@testable import ITSCore
+
+struct CoreUnitTests {
+    private let mockMQTTClient: MockMQTTClient
+    private let mockTelemetryClient: MockTelemetryClient
+
+    init() {
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "",
+                                                              port: 0,
+                                                              clientIdentifier: "",
+                                                              useSSL: false)
+        mockMQTTClient = MockMQTTClient(configuration: mqttClientConfiguration)
+        let telemetryClientConfiguration = TelemetryClientConfiguration(url: URL(string: "http://foo.com")!,
+                                                                        serviceName: "")
+        mockTelemetryClient = MockTelemetryClient(configuration: telemetryClientConfiguration)
+    }
+
+    @Test("Core start with telemetry configuration should connect to MQTT and start telemetry")
+    func core_start_with_telemetry_should_connect_to_MQTT_and_start_telemetry() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+
+        // Then
+        #expect(await mockMQTTClient.isConnected)
+        #expect(await mockMQTTClient.setMessageReceivedHandlerCallsCount == 1)
+        #expect(await mockMQTTClient.connectCallsCount == 1)
+        #expect(await mockTelemetryClient.startCallsCount == 1)
+    }
+
+    @Test("Core stop should finish subscribe stream and telemetry")
+    func core_stop_should_finish_subscribe_stream_and_telemetry() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        Task {
+            try await Task.sleep(for: .seconds(0.5))
+            try await core.stop()
+        }
+
+        // Then
+        try await confirmation(expectedCount: 1) { confirmation in
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+            confirmation()
+        }
+        #expect(await !mockMQTTClient.isConnected)
+        #expect(await mockTelemetryClient.stopCallsCount == 1)
+    }
+
+    @Test("Core should forward received messages and send a telemetry span")
+    func core_should_forward_received_messages_and_send_telemetry_span() async throws {
+        // Given
+        let core = Core()
+        let topic = "topic"
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        let incomingMessage = MQTTMessage(payload: Data(), topic: topic, userProperty: nil)
+        Task {
+            try await Task.sleep(for: .seconds(0.5))
+            await mockMQTTClient.simulateMessageReceived(incomingMessage)
+            await mockMQTTClient.simulateMessageReceived(incomingMessage)
+            try await Task.sleep(for: .seconds(0.5))
+            try await core.unsubscribe(from: topic)
+        }
+
+        // Then
+        try await confirmation(expectedCount: 2) { confirmation in
+            for await message in try await core.subscribe(to: topic) {
+                #expect(message.payload == incomingMessage.payload)
+                #expect(message.topic == incomingMessage.topic)
+                confirmation()
+            }
+        }
+        #expect(await mockTelemetryClient.startSpanWithContextCallsCount == 2)
+        #expect(await mockTelemetryClient.stopSpanCallsCount == 2)
+    }
+
+    @Test("Core start should throw an error when MQTT client fails to connect")
+    func core_start_should_throw_error_when_mqtt_client_fails_to_connect() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            mockMQTTClient.throwsConnectError = true
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            Issue.record("start should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.connectionFailed))
+            }
+        }
+    }
+
+    @Test("Core subscribe stream should throw an error when not started")
+    func core_subscribe_stream_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        let task = Task {
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+        }
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            try await task.value
+        }
+    }
+
+    @Test("Core subscribe stream should throw an error when MQTT error occurs")
+    func core_subscribe_stream_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+        mockMQTTClient.throwsSubscribeError = true
+        let task = Task {
+            for await _ in try await core.subscribe(to: "topic") {
+            }
+        }
+
+        // Then
+        do {
+            try await task.value
+        } catch {
+            if case .mqttError(let wrappedError) = error as? CoreError {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.subscriptionFailed))
+            }
+        }
+    }
+
+    @Test("Core unsubscribe should throw an error when not started")
+    func core_unsubscribe_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            // When
+            try await core.unsubscribe(from: "topic")
+        }
+    }
+
+    @Test("Core unsubscribe should throw an error when MQTT error occurs")
+    func core_unsubscribe_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            mockMQTTClient.throwsUnsubscribeError = true
+            try await core.unsubscribe(from: "topic")
+            Issue.record("unsubscribe should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.unsubscriptionFailed))
+            }
+        }
+    }
+
+    @Test("Core publish should send a message and send a telemetry span")
+    func core_publish_should_send_message_and_send_telemetry_span() async throws {
+        // Given
+        let core = Core()
+
+        // When
+        try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
+        let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+        try await core.publish(message: message)
+
+        // Then
+        #expect(await mockMQTTClient.publishCallsCount == 1)
+        #expect(await mockTelemetryClient.startSpanCallsCount == 1)
+        #expect(await mockTelemetryClient.stopSpanCallsCount == 1)
+    }
+
+    @Test("Core publish should throw an error when not started")
+    func core_publish_should_throw_error_when_not_started() async throws {
+        // Given
+        let core = Core()
+
+        // Then
+        await #expect(throws: CoreError.notStarted) {
+            // When
+            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+            try await core.publish(message: message)
+        }
+    }
+
+    @Test("Core publish should throw an error when MQTT error occurs")
+    func core_publish_should_throw_error_when_mqtt_error_occurs() async throws {
+        // Given
+        let core = Core()
+
+        do {
+            // When
+            try await core.start(mqttClient: mockMQTTClient, telemetryClient: nil)
+            mockMQTTClient.throwsPublishError = true
+            let message = CoreMQTTMessage(payload: Data(), topic: "topic")
+            try await core.publish(message: message)
+            Issue.record("publish should throw an error")
+        } catch {
+            // Then
+            if case .mqttError(let wrappedError) = error {
+                #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.sendPayloadFailed))
+            }
+        }
+    }
+}

--- a/swift/ITSClient/Tests/ITSCoreTests/MQTTNIOClientTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/MQTTNIOClientTests.swift
@@ -28,7 +28,7 @@ struct MQTTNIOClientTests {
         try await mqttClient.connect()
         
         // Then
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
     }
     
     @Test("MQTT anonymous connection with SSL should succeed")
@@ -44,7 +44,7 @@ struct MQTTNIOClientTests {
         try await mqttClient.connect()
         
         // Then
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
     }
     
     @Test("MQTT authenticated connection should succeed")
@@ -62,7 +62,7 @@ struct MQTTNIOClientTests {
         try await mqttClient.connect()
         
         // Then
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
     }
     
     @Test("MQTT websocket connection should succeed")
@@ -79,7 +79,7 @@ struct MQTTNIOClientTests {
         try await mqttClient.connect()
         
         // Then
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
     }
     
     @Test("MQTT message should be received if published on a subscribed topic")
@@ -110,6 +110,33 @@ struct MQTTNIOClientTests {
         }
     }
     
+    @Test("MQTT message should not be received if published on a unsubscribed topic")
+    func mqtt_message_should_not_be_received_if_published_on_a_unsubscribed_topic() async throws {
+        // Given
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "test.mosquitto.org",
+                                                              port: 1883,
+                                                              clientIdentifier: clientIdentifier,
+                                                              useSSL: false)
+        let topic = "its-test-topic"
+        let payload = "payload"
+        
+        try await confirmation(expectedCount: 0) { confirmation in
+            let mqttClient = MQTTNIOClient(configuration: mqttClientConfiguration) { message in
+                confirmation()
+            }
+            
+            // When
+            try await mqttClient.connect()
+            try await mqttClient.subscribe(to: topic)
+            try await mqttClient.unsubscribe(from: topic)
+            try await mqttClient.publish(MQTTMessage(payload: payload.data(using: .utf8)!,
+                                                     topic: topic,
+                                                     userProperty: nil))
+            // Wait the message
+            try await Task.sleep(for: .seconds(0.5))
+        }
+    }
+    
     @Test("MQTT disconnect after connection should succeed")
     func mqtt_disconnect_after_connection_should_succeed() async throws {
         // Given
@@ -121,11 +148,11 @@ struct MQTTNIOClientTests {
         
         // When
         try await mqttClient.connect()
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
         try await mqttClient.disconnect()
         
         // Then
-        #expect(await !mqttClient.isConnected)
+        #expect(!mqttClient.isConnected)
     }
     
     @Test("MQTT disconnect after connection and subscription should succeed")
@@ -139,12 +166,12 @@ struct MQTTNIOClientTests {
         
         // When
         try await mqttClient.connect()
-        #expect(await mqttClient.isConnected)
+        #expect(mqttClient.isConnected)
         try await mqttClient.subscribe(to: "test")
         try await mqttClient.disconnect()
         
         // Then
-        #expect(await !mqttClient.isConnected)
+        #expect(!mqttClient.isConnected)
     }
     
     @Test("MQTT subscription without connection should fail")

--- a/swift/ITSClient/Tests/ITSCoreTests/MQTTNIOClientTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/MQTTNIOClientTests.swift
@@ -29,6 +29,8 @@ struct MQTTNIOClientTests {
 
         // Then
         #expect(await mqttClient.isConnected)
+
+        try await mqttClient.disconnect()
     }
 
     @Test("MQTT anonymous connection with SSL should succeed")
@@ -45,6 +47,8 @@ struct MQTTNIOClientTests {
 
         // Then
         #expect(await mqttClient.isConnected)
+
+        try await mqttClient.disconnect()
     }
 
     @Test("MQTT authenticated connection should succeed")
@@ -63,6 +67,8 @@ struct MQTTNIOClientTests {
 
         // Then
         #expect(await mqttClient.isConnected)
+
+        try await mqttClient.disconnect()
     }
 
     @Test("MQTT websocket connection should succeed")
@@ -80,6 +86,8 @@ struct MQTTNIOClientTests {
 
         // Then
         #expect(await mqttClient.isConnected)
+
+        try await mqttClient.disconnect()
     }
 
     @Test("MQTT message should be received if published on a subscribed topic")
@@ -111,6 +119,8 @@ struct MQTTNIOClientTests {
                                                      userProperty: userProperty))
             // Wait the message
             try await Task.sleep(for: .seconds(0.5))
+
+            try await mqttClient.disconnect()
         }
     }
 
@@ -139,6 +149,8 @@ struct MQTTNIOClientTests {
                                                      userProperty: nil))
             // Wait the message
             try await Task.sleep(for: .seconds(0.5))
+
+            try await mqttClient.disconnect()
         }
     }
 

--- a/swift/ITSClient/Tests/ITSCoreTests/MockMQTTClient.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/MockMQTTClient.swift
@@ -1,0 +1,84 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+@testable import ITSCore
+
+actor MockMQTTClient: MQTTClient {
+    var isConnected: Bool = false
+    private var topics: [String] = []
+    private var messageReceivedHandler: (@Sendable (MQTTMessage) -> Void)?
+    var setMessageReceivedHandlerCallsCount: Int = 0
+    var connectCallsCount: Int = 0
+    var subscribeCallsCount: Int = 0
+    var unsubscribeCallsCount: Int = 0
+    var disconnectCallsCount: Int = 0
+    var publishCallsCount: Int = 0
+    nonisolated(unsafe) var throwsConnectError: Bool = false
+    nonisolated(unsafe) var throwsSubscribeError: Bool = false
+    nonisolated(unsafe) var throwsUnsubscribeError: Bool = false
+    nonisolated(unsafe) var throwsPublishError: Bool = false
+
+    init(configuration: MQTTClientConfiguration) {}
+
+    func setMessageReceivedHandler(messageReceivedHandler handler: @escaping (@Sendable (MQTTMessage) -> Void)) {
+        messageReceivedHandler = handler
+        setMessageReceivedHandlerCallsCount += 1
+    }
+
+    func connect() async throws(MQTTClientError) {
+        if throwsConnectError {
+            throw .connectionFailed
+        }
+
+        isConnected = true
+        connectCallsCount += 1
+    }
+
+    func subscribe(to topic: String) async throws(MQTTClientError) {
+        if throwsSubscribeError {
+            throw .subscriptionFailed
+        }
+
+        topics.append(topic)
+        subscribeCallsCount += 1
+    }
+
+    func unsubscribe(from topic: String) async throws(MQTTClientError) {
+        if throwsUnsubscribeError {
+            throw .unsubscriptionFailed
+        }
+
+        topics.removeAll(where: { $0 == topic })
+        unsubscribeCallsCount += 1
+    }
+
+    func disconnect() async throws(MQTTClientError) {
+        isConnected = false
+        disconnectCallsCount += 1
+    }
+
+    func publish(_ message: MQTTMessage) async throws(MQTTClientError) {
+        if throwsPublishError {
+            throw .sendPayloadFailed
+        }
+
+        publishCallsCount += 1
+    }
+
+    func simulateMessageReceived(_ message: MQTTMessage) {
+        guard topics.contains(message.topic) else { return }
+
+        Task { [weak self] in
+            await self?.messageReceivedHandler?(message)
+        }
+    }
+}

--- a/swift/ITSClient/Tests/ITSCoreTests/MockTelemetryClient.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/MockTelemetryClient.swift
@@ -1,0 +1,55 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+@testable import ITSCore
+
+actor MockTelemetryClient: TelemetryClient {
+    var startCallsCount: Int = 0
+    var stopCallsCount: Int = 0
+    var startSpanCallsCount: Int = 0
+    var startSpanWithContextCallsCount: Int = 0
+    var stopSpanCallsCount: Int = 0
+
+    init(configuration: TelemetryClientConfiguration) {
+    }
+
+    func start() {
+        startCallsCount += 1
+    }
+
+    func stop() {
+        stopCallsCount += 1
+    }
+
+    func startSpan(name: String, type: SpanType, attributes: [String: Any]) -> SpanID? {
+        startSpanCallsCount += 1
+        return "span1"
+    }
+
+    func startSpan(
+        name: String,
+        type: SpanType,
+        attributes: [String: Any],
+        fromContext context: [String: String]
+    ) -> SpanID? {
+        startSpanWithContextCallsCount += 1
+        return "span2"
+    }
+
+    func stopSpan(spanID: SpanID, errorMessage: String?) {
+        stopSpanCallsCount += 1
+    }
+
+    func updateContext(withSpanID spanID: SpanID) -> [String: String] {
+        [:]
+    }
+}


### PR DESCRIPTION

**What's new**

Add a implementation of the Core which uses a MQTTClient and a TelemetryClient to perform MQTT operations with traces.

---
**How to test**

1. Clone the its-client project and check out the branch under review
2. Run a local OpenTelemetry collector with a http endpoint on port 4318:
    ```sh
     $ docker container run \
          --rm \
          -p 16686:16686 \
          -p 4318:4318 \
          jaegertracing/all-in-one:1.58
     ```
3. Run the test CoreTests.message_sent_to_subscribed_topic_should_be_received_and_create_linked_span:
    ```sh
    swift test --filter CoreTests.message_sent_to_subscribed_topic_should_be_received_and_create_linked_span   
    ```
   Expected result:  Check on the Jaeger UI (on http://localhost:16686/) that that 1 producer span and 1 consumer span which references the producer have been created.
4. Run the test CoreTests.message_sent_with_error_should_create_span_with_error:
    ```sh
    swift test --filter CoreTests.message_sent_with_error_should_create_span_with_error   
    ```
   Expected result:  Check on the Jaeger UI (on http://localhost:16686/)  that 1 producer span has been created with an error. 
5. Run the test CoreTests.send_message_without_telemetry_should_not_create_span:
    ```sh
    swift test --filter CoreTests.send_message_without_telemetry_should_not_create_span   
    ```
   Expected result:  Check on the Jaeger UI (on http://localhost:16686/) that no span have been created.

Closes #284 