### PR TITLE
java/iot3core: fix bootstrap for Android compatibility

### DIFF
--- a/java/iot3/core/build.gradle
+++ b/java/iot3/core/build.gradle
@@ -22,6 +22,7 @@ repositories {
 dependencies {
     // Internal dependencies, not exposed to consumers on their own compile classpath.
     implementation 'com.hivemq:hivemq-mqtt-client:1.3.3'
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'io.opentelemetry:opentelemetry-api:1.40.0'
     implementation 'io.opentelemetry:opentelemetry-sdk:1.40.0'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp:1.40.0'


### PR DESCRIPTION
**Fix**

The `OkHttp` library is replacing the Android-incompatible `java.net.http` library (part of Java 11 and Android is based on Java 8).

Closes #288 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityBootstrapExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context";
// Bootstrap parameters
private static final String BOOTSTRAP_ID = "bootstrap_id";
private static final String BOOTSTRAP_LOGIN = "boostrap_login";
private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
private static final boolean ENABLE_TELEMETRY = false;
```
4. Run ```Iot3MobilityBootstrapExample```.

---
**Expected results:**

1. On the console, you should see the following:
```
Bootstrap success
IoT3 ID: <id>
LOGIN: <login>
PASSWORD: <password>
MQTT URI: <mqtt_uri>
TELEMETRY URI: <open_telemetry_uri>
```