### PR TITLE
python: handle retain in IoT3 SDK, allow filtering in IQM

### DIFF
--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -287,6 +287,7 @@ class MqttClient:
     ):
         opts = paho.mqtt.client.SubscribeOptions(
             qos=2,
+            retainAsPublished=True,
         )
         self.client.subscribe(
             list(map(lambda t: (t, opts), self.subscriptions)),

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -275,8 +275,11 @@ class MqttClient:
         *,
         topics: list[str],
     ):
+        opts = paho.mqtt.client.SubscribeOptions(
+            qos=0,
+        )
         self.client.subscribe(
-            list(map(lambda t: (t, 0), self.subscriptions)),
+            list(map(lambda t: (t, opts), self.subscriptions)),
         )
 
     # In theory, we would not need this method, as we could very well

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -181,12 +181,12 @@ class MqttClient:
             name="IoT3 Core MQTT Message",
             kind=otel.SpanKind.PRODUCER,
         ) as span:
-            new_traceparent = span.to_traceparent()
-            span.set_attribute(key="iot3.core.mqtt.topic", value=topic)
-            span.set_attribute(key="iot3.core.mqtt.payload_size", value=len(payload))
             properties = paho.mqtt.properties.Properties(
                 paho.mqtt.packettypes.PacketTypes.PUBLISH,
             )
+            new_traceparent = span.to_traceparent()
+            span.set_attribute(key="iot3.core.mqtt.topic", value=topic)
+            span.set_attribute(key="iot3.core.mqtt.payload_size", value=len(payload))
             if new_traceparent:
                 properties.UserProperty = ("traceparent", new_traceparent)
             msg_info = self.client.publish(

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -276,7 +276,7 @@ class MqttClient:
         topics: list[str],
     ):
         opts = paho.mqtt.client.SubscribeOptions(
-            qos=0,
+            qos=2,
         )
         self.client.subscribe(
             list(map(lambda t: (t, opts), self.subscriptions)),

--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -214,7 +214,7 @@ class MqttClient:
         with self.subscriptions_lock:
             sub = topics.difference(self.subscriptions)
             if sub and self.client.is_connected():
-                self.client.subscribe(list(map(lambda t: (t, 0), sub)))
+                self._do_subscribe(topics=sub)
             self.subscriptions.update(topics)
 
     def subscribe_replace(self, *, topics: list[str]):
@@ -242,7 +242,7 @@ class MqttClient:
                 if unsub:
                     self.client.unsubscribe(list(unsub))
                 if sub:
-                    self.client.subscribe(list(map(lambda t: (t, 0), sub)))
+                    self._do_subscribe(topics=sub)
             self.subscriptions.clear()
             self.subscriptions.update(topics)
 
@@ -269,6 +269,15 @@ class MqttClient:
         # unsubscribe().
         with self.subscriptions_lock:
             self.unsubscribe(topics=self.subscriptions)
+
+    def _do_subscribe(
+        self,
+        *,
+        topics: list[str],
+    ):
+        self.client.subscribe(
+            list(map(lambda t: (t, 0), self.subscriptions)),
+        )
 
     # In theory, we would not need this method, as we could very well
     # have set   self.client.on_message = msg_cb   and be done with
@@ -313,6 +322,4 @@ class MqttClient:
     ):
         with self.subscriptions_lock:
             if self.subscriptions:
-                self.client.subscribe(
-                    list(map(lambda t: (t, 0), self.subscriptions)),
-                )
+                self._do_subscribe(topics=self.subscriptions)

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -27,6 +27,41 @@ socket-path = /run/mosquitto/mqtt.socket
 # Name of the local inter-queue; default: interQueue
 #interqueue = interQueue
 
+# Sections which name starts with 'filtering.' (with the dot) followed
+# by an arbitrary identifier, define filtering rules and actions.
+#[filter.NAME]
+# The prefix or regexp to match topic against; only one kind of match can
+# be specified for a given filter (either by prefix or by regexp), but
+# multiple such match can be specified with a multi-line value.
+# Placeholders {{XXX}} will be replaced before attempting a match:
+#  - {{instance-id}}: replaced by general.instance-id
+#  - {{prefix}}: if general.prefix is set, this placeholder is replaced
+#    with it, with a trailing '/' appended; otherwise, an empty string;
+#  - {{suffix}}: replaced by general.suffix if set, an empty string otherwise;
+#  - {{inQueue}}, {{outQueue}}, {{interQueue}}: placeholders matching the
+#    inQueue, outQueue, and interQueue, respectively.
+#in_prefix =
+#   prefix-str-1
+#   prefix-str-2
+#in_regex = regex-1
+#   regex-2
+#out_prefix = prefix-str
+#out_regex = regex
+# What to do with the message:
+# - drop the message if the topic matches:
+#drop
+# - set the message as retained or as not retained:
+#retain = True / False
+# - set the message as retained and set property Message Expiry Interval
+#   to the specified value (in seconds):
+#retain = INT
+# - set the message as retained and set property Message Expiry Interval
+#   to the value from the JSON payload object at the specified dotted
+#   path; if the path does not exist or is not an integer, use the
+#   fallback value if specified, otherwise same as if retain was not
+#   specified:
+#retain = json:DOTTED.PATH.IN.JSON.PAYLOAD [FALLBACK_INT]
+
 [authority]
 # Type of central authority, one of: file, http, mqtt
 type = file

--- a/python/its-interqueuemanager/src/its_iqm/filters.py
+++ b/python/its-interqueuemanager/src/its_iqm/filters.py
@@ -1,0 +1,147 @@
+# Software Name: its-interqueuemanager
+# SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+import itertools
+import json
+import logging
+import re
+
+
+class Filter:
+    def __init__(
+        self,
+        *,
+        name: str,
+        filter_cfg: dict,
+        instance_id: str,
+        prefix: str,
+        suffix: str,
+        queues: dict,
+    ):
+        self.name = name
+
+        placeholders = {
+            "instance-id": instance_id,
+            "prefix": prefix,
+            "suffix": suffix,
+        }
+        placeholders.update(queues)
+
+        self._patterns = None
+        for filter_type, filter_kind in itertools.product(
+            ["in", "out"],
+            ["prefix", "regex"],
+        ):
+            try:
+                patterns = filter_cfg[filter_type + "_" + filter_kind]
+            except KeyError:
+                continue
+
+            if self._patterns is not None:
+                raise ValueError(f"Filter {name} defines multiple patterns")
+            patterns = list(filter(None, patterns.split("\n")))
+            for ph in placeholders:
+                patterns = list(
+                    map(
+                        lambda s: s.replace("{{" + ph + "}}", placeholders[ph]),
+                        patterns,
+                    ),
+                )
+            if filter_kind == "regex":
+                patterns = list(map(re.compile, patterns))
+
+            self._patterns = patterns
+            self._type = filter_type
+            self._kind = filter_kind
+
+        if patterns is None:
+            raise ValueError(f"Filter '{name}' does not define patterns")
+
+        self._drop = "drop" in filter_cfg
+
+        match filter_cfg.get("retain"):
+            case None:
+                self._retain = None
+            case "True" | "true" | "False" | "false" as b:
+                self._retain = b in ["True", "true"]
+            case str(s) if re.match("^\d+$", s):
+                self._retain = int(s)
+            case str(s) if s.startswith("json:") and re.match(".* \d+$", s):
+                path, fallback = s[5:].split(" ")
+                self._retain = {
+                    "path": path.split("."),
+                    "fallback": int(fallback),
+                }
+            case str(s) if s.startswith("json:"):
+                self._retain = {
+                    "path": s[5:].split("."),
+                    "fallback": None,
+                }
+            case _v:
+                raise ValueError(f"Unable to parse retain value '{_v}'")
+
+        logging.debug(f"Created new filter {name}:")
+        logging.debug(f"  - type: {self._type}")
+        logging.debug(f"  - kind: {self._kind}")
+        logging.debug(f"  - patterns: {self._patterns}")
+        logging.debug(f"  - drop: {self._drop}")
+        logging.debug(f"  - retain: {self._retain}")
+
+    @property
+    def type(self):
+        return self._type
+
+    def apply(
+        self,
+        *,
+        topic: str,
+        payload: bytes,
+        retain: bool | int,
+    ):
+        for pattern in self._patterns:
+            if self._kind == "prefix" and topic.startswith(pattern):
+                break
+            if self._kind == "regex" and pattern.match(topic):
+                break
+        else:
+            logging.debug(f"{self.name}[{self._type}]: no match for {topic}")
+            return topic, payload, retain
+
+        logging.debug(
+            f"{self.name}[{self._type}]: match for {topic} with {self._kind} {pattern}"
+        )
+
+        if self._drop:
+            logging.debug(f"{self.name}:   - dropped")
+            return None, None, None
+
+        match self._retain:
+            case None:
+                logging.debug("{self.name}:   - retain: None")
+            case bool(b):
+                logging.debug(f"{self.name}:   - retain: {b}")
+                retain = b
+            case int(i):
+                logging.debug(f"{self.name}:   - retain: {i}")
+                retain = i
+            case {"path": path, "fallback": fallback}:
+                logging.debug(f"{self.name}:   - retain: {path}")
+                try:
+                    data = json.loads(payload)
+                    for p in path:
+                        data = data[p]
+                except (json.decoder.JSONDecodeError, KeyError, TypeError):
+                    if fallback is not None:
+                        logging.debug(f"{self.name}:     - using fallback {fallback}")
+                        retain = fallback
+                else:
+                    retain = data
+
+        logging.debug(f"{self.name}: Result of filter:")
+        logging.debug(f"{self.name}:   - topic: {topic}")
+        logging.debug(f"{self.name}:   - payload: {payload}")
+        logging.debug(f"{self.name}:   - retain: {retain}")
+
+        return topic, payload, retain

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -28,13 +28,14 @@ class IQM:
         outqueue = "outQueue"
         interqueue = self.cfg["local"]["interqueue"]
         if prefix is not None:  # can be an empty string for a /-rooted queue
-            inqueue = f"{prefix}/{inqueue}"
-            outqueue = f"{prefix}/{outqueue}"
-            interqueue = f"{prefix}/{interqueue}"
+            prefix = prefix + "/"
+        else:
+            prefix = ""
         if suffix:  # can *not* be an empty string
-            inqueue += f"/{suffix}"
-            outqueue += f"/{suffix}"
-            interqueue += f"/{suffix}"
+            suffix = "/" + suffix
+        inqueue = prefix + inqueue + suffix
+        outqueue = prefix + outqueue + suffix
+        interqueue = prefix + interqueue + suffix
 
         # Neighbours will publish there too, so keep it to avoid recomputing
         # it every time

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import configparser
 import iot3.core.mqtt
 import iot3.core.otel
-import its_iqm.authority
 import logging
 import time
+from . import authority
 
 
 class IQM:
@@ -79,7 +79,7 @@ class IQM:
         # will need to have a valid local_qm to pass to the neighbours
         # queue managers, so we need to handle the central authority
         # after we create the local QM.
-        self.authority = its_iqm.authority.Authority(
+        self.authority = authority.Authority(
             self.instance_id,
             self.cfg["authority"],
             self.update_cb,

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -10,6 +10,7 @@ import iot3.core.otel
 import logging
 import time
 from . import authority
+from . import filters
 
 
 class IQM:
@@ -41,6 +42,12 @@ class IQM:
         # it every time
         self.outqueue = outqueue
 
+        queues = {
+            "inQueue": inqueue,
+            "outQueue": outqueue,
+            "interQueue": interqueue,
+        }
+
         if cfg["telemetry"]["endpoint"]:
             self.otel = iot3.core.otel.Otel(
                 service_name="its-interqueuemanager",
@@ -57,12 +64,29 @@ class IQM:
             self.otel = None
             self.span_cb = iot3.core.otel.Otel.noexport_span
 
+        self.filters = {
+            "in": list(),
+            "out": list(),
+        }
+        for sect_name in [s for s in cfg if s.startswith("filter.")]:
+            filter_name = sect_name[7:]
+            new_filter = filters.Filter(
+                name=filter_name,
+                filter_cfg=cfg[sect_name],
+                instance_id=self.instance_id,
+                prefix=prefix,
+                suffix=suffix,
+                queues=queues,
+            )
+            self.filters[new_filter.type].append(new_filter)
+
         logging.info("create local qm")
 
         qm_data = {
             "copy_qm": None,
             "copy_from": inqueue,
             "copy_to": [outqueue, interqueue],
+            "filters": self.filters,
         }
 
         self.local_qm = iot3.core.mqtt.MqttClient(
@@ -161,6 +185,7 @@ class IQM:
                 "copy_qm": self.local_qm,
                 "copy_from": interqueue,
                 "copy_to": [self.outqueue],
+                "filters": self.filters,
             }
             creds = {
                 "username": None,
@@ -190,10 +215,32 @@ class IQM:
         payload: bytes,
         **_kwargs,
     ):
-        mqtt_cli = data["copy_qm"] or self.local_qm
-        for cp_to in data["copy_to"]:
-            new_topic = cp_to + topic[len(data["copy_from"]) :]
-            mqtt_cli.publish(
-                topic=new_topic,
+        retain = False
+        for in_filter in data["filters"]["in"]:
+            topic, payload, retain = in_filter.apply(
+                topic=topic,
                 payload=payload,
+                retain=retain,
             )
+            if topic is None:
+                break
+        else:
+            mqtt_cli = data["copy_qm"] or self.local_qm
+            for cp_to in data["copy_to"]:
+                new_topic = cp_to + topic[len(data["copy_from"]) :]
+                new_payload = payload
+                new_retain = retain
+                for out_filter in data["filters"]["out"]:
+                    new_topic, new_payload, new_retain = out_filter.apply(
+                        topic=new_topic,
+                        payload=new_payload,
+                        retain=new_retain,
+                    )
+                    if new_topic is None:
+                        break
+                else:
+                    mqtt_cli.publish(
+                        topic=new_topic,
+                        payload=new_payload,
+                        retain=new_retain,
+                    )

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -12,9 +12,6 @@ import logging
 import time
 
 
-DEFAULT_AUTH = {"username": None, "passwod": None}
-
-
 class IQM:
     def __init__(
         self: IQM,

--- a/python/its-interqueuemanager/src/its_iqm/main.py
+++ b/python/its-interqueuemanager/src/its_iqm/main.py
@@ -61,7 +61,7 @@ def main():
     )
 
     logging.info(f"loading config file {args.config}...")
-    cfg = configparser.ConfigParser()
+    cfg = configparser.ConfigParser(allow_no_value=True)
     with open(args.config) as f:
         cfg.read_file(f)
 


### PR DESCRIPTION
**Changes:**

* IoT3 SDK:
    * handle retain
    * handle Message Expiry Interval MQTT property
* InterQueueManager:
    * implement filtering
        * match topic on regex or prefix
        * drop
        * set retain and Message Expiry Interval

Closes #292
Closes #293

---
**How to test:**

_**Note:** in the folowing: lines starting with `$` are to be executed on your machine, as a non-root user; lines starting with `(docker)$` are to be executed in the Docker container; lines starting with `(docker)🐍 $` are to be executed in the Docker container, in the python `venv`._

1. Prepare an environment
    1. ensure a mosquitto broker is listening on `localhost:1883`, without any ACL; if not, start one (no need to be root):
        ```sh
        $ mosquitto
        ```
       then in another terminal, run an MQTT client that dumps mesages going through the broker:
        ```sh
        $ mosquitto_sub --retain-as-published -t '#' -V 5 -F %J
        ```
    2. in another terminal, start a container with python 3.11 and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            ${DOCKER_PROXY}python:3.11.9-slim-bookworm \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential socat
        $ docker container exec -d iot3 socat UNIX-LISTEN:/tmp/mqtt.socket,fork TCP4:localhost:1883

        $ docker container attach iot3
        ```
       Note: the socat command exposes the MQTT broker, listening on `localhost:1883`, inside the container, listening on the UNIX socket `/tmp/mqtt.socket`.
    3. prepare a configuration file for the IQM:
        ```sh
        (docker)$ cat >/tmp/its-iqm.cfg <<_EOF_
        [general]
        instance-id = ora_geo_1234
        prefix = default
        suffix =
        
        [local]
        socket-path = /tmp/mqtt.socket
        
        [authority]
        reload = 1000000
        
        [filter.drop-short]
        in_regex = ^{{inQueue}}/.{,2}/
        drop
        
        [filter.cam-no-retain]
        in_prefix = {{inQueue}}/cam/
        retain = False
        
        [filter.health-no-inter]
        out_regex = ^{{interQueue}}/health$
        drop
        
        [filter.multi-retain]
        out_prefix =
            {{outQueue}}/denm/
            {{interQueue}}/denm/
        retain = json:blob.foo.bar 27
        
        [filter.retain-no-default]
        out_prefix = {{outQueue}}/cpm/
        retain = json:blob.foo.bar
        _EOF_
        ```
    4. prepare a Python 3.11 environment, and install the Python packages:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --no-cache-dir install ./python/iot3/
        (docker)🐍 $ pip --no-cache-dir install --no-deps ./python/its-interqueuemanager/
        ```
       Note: we use `--nop-deps` when installing the IQM, because it would try to install the IoT3 SDK from a set commit in git, rather than use the one we just installed the line before.
    5. start the IQM:
        ```sh
        (docker)🐍 $ its-iqm --debug -c /tmp/its-iqm.cfg
        ```
3. Test the filters:
    1. `drop-short`
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/f0/bar -m '"some-message"'
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: match for default/inQueue/f0/bar with regex re.compile('^default/inQueue/.{,2}/')
            filters: drop-short:   - dropped
            ```
        * message is not propagated to outQueue or interQueue
    2. `cam-no-retain`
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/cam/0/1/2/3 -m '{"blob": {"foo": {"bar": 16}}}' --retain -D PUBLISH message-expiry-interval 12
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: no match for default/inQueue/cam/0/1/2/3
            filters: cam-no-retain[in]: match for default/inQueue/cam/0/1/2/3 with prefix default/inQueue/cam/
            filters: cam-no-retain:   - retain: False
            filters: cam-no-retain: Result of filter:
            filters: cam-no-retain:   - topic: default/inQueue/cam/0/1/2/3
            filters: cam-no-retain:   - payload: b'{"blob": {"foo": {"bar": 16}}}'
            filters: cam-no-retain:   - retain: False
            filters: health-no-inter[out]: no match for default/outQueue/cam/0/1/2/3
            filters: multi-retain[out]: no match for default/outQueue/cam/0/1/2/3
            filters: retain-no-default[out]: no match for default/outQueue/cam/0/1/2/3
            filters: health-no-inter[out]: no match for default/interQueue/cam/0/1/2/3
            filters: multi-retain[out]: no match for default/interQueue/cam/0/1/2/3
            filters: retain-no-default[out]: no match for default/interQueue/cam/0/1/2/3
            ```
        * message on outQueue is without retain, and without expiry
        * message on interQueue is without retain, and without expiry
    3. `multi-retain` with matching JSON object
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/denm/0/1/2/3 -m '{"blob": {"foo": {"bar": 16}}}'
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: no match for default/inQueue/denm/0/1/2/3
            filters: cam-no-retain[in]: no match for default/inQueue/denm/0/1/2/3
            filters: health-no-inter[out]: no match for default/outQueue/denm/0/1/2/3
            filters: multi-retain[out]: match for default/outQueue/denm/0/1/2/3 with prefix default/outQueue/denm/
            filters: multi-retain:   - retain: ['blob', 'foo', 'bar']
            filters: multi-retain: Result of filter:
            filters: multi-retain:   - topic: default/outQueue/denm/0/1/2/3
            filters: multi-retain:   - payload: b'{"blob": {"foo": {"bar": 16}}}'
            filters: multi-retain:   - retain: 16
            filters: retain-no-default[out]: no match for default/outQueue/denm/0/1/2/3
            filters: health-no-inter[out]: no match for default/interQueue/denm/0/1/2/3
            filters: multi-retain[out]: match for default/interQueue/denm/0/1/2/3 with prefix default/interQueue/denm/
            filters: multi-retain:   - retain: ['blob', 'foo', 'bar']
            filters: multi-retain: Result of filter:
            filters: multi-retain:   - topic: default/interQueue/denm/0/1/2/3
            filters: multi-retain:   - payload: b'{"blob": {"foo": {"bar": 16}}}'
            filters: multi-retain:   - retain: 16
            filters: retain-no-default[out]: no match for default/interQueue/denm/0/1/2/3
            ```
        * message on outQueue is retained with 16s expiry
        * message on interQueue is retained with 16s expiry
    4. `multi-retain` without matching JSON object
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/denm/0/1/2/3 -m '"not an object"'
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: no match for default/inQueue/denm/0/1/2/3
            filters: cam-no-retain[in]: no match for default/inQueue/denm/0/1/2/3
            filters: health-no-inter[out]: no match for default/outQueue/denm/0/1/2/3
            filters: multi-retain[out]: match for default/outQueue/denm/0/1/2/3 with prefix default/outQueue/denm/
            filters: multi-retain:   - retain: ['blob', 'foo', 'bar']
            filters: multi-retain:     - using fallback 27
            filters: multi-retain: Result of filter:
            filters: multi-retain:   - topic: default/outQueue/denm/0/1/2/3
            filters: multi-retain:   - payload: b'"not an object"'
            filters: multi-retain:   - retain: 27
            filters: retain-no-default[out]: no match for default/outQueue/denm/0/1/2/3
            filters: health-no-inter[out]: no match for default/interQueue/denm/0/1/2/3
            filters: multi-retain[out]: match for default/interQueue/denm/0/1/2/3 with prefix default/interQueue/denm/
            filters: multi-retain:   - retain: ['blob', 'foo', 'bar']
            filters: multi-retain:     - using fallback 27
            filters: multi-retain: Result of filter:
            filters: multi-retain:   - topic: default/interQueue/denm/0/1/2/3
            filters: multi-retain:   - payload: b'"not an object"'
            filters: multi-retain:   - retain: 27
            filters: retain-no-default[out]: no match for default/interQueue/denm/0/1/2/3
            ```
        * message on outQueue is retained with 27s expiry
        * message on interQueue is retained with 27s expiry
    5. `retain-no-default`
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/cpm/0/1/2/3 -m '"not an object"'
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: no match for default/inQueue/cpm/0/1/2/3
            filters: cam-no-retain[in]: no match for default/inQueue/cpm/0/1/2/3
            filters: health-no-inter[out]: no match for default/outQueue/cpm/0/1/2/3
            filters: multi-retain[out]: no match for default/outQueue/cpm/0/1/2/3
            filters: retain-no-default[out]: match for default/outQueue/cpm/0/1/2/3 with prefix default/outQueue/cpm/
            filters: retain-no-default:   - retain: ['blob', 'foo', 'bar']
            filters: retain-no-default: Result of filter:
            filters: retain-no-default:   - topic: default/outQueue/cpm/0/1/2/3
            filters: retain-no-default:   - payload: b'"not an object"'
            filters: retain-no-default:   - retain: False
            filters: health-no-inter[out]: no match for default/interQueue/cpm/0/1/2/3
            filters: multi-retain[out]: no match for default/interQueue/cpm/0/1/2/3
            filters: retain-no-default[out]: no match for default/interQueue/cpm/0/1/2/3
            ```
        * message on outQueue is not retained
        * message on interQueue is not retained
    6. `health-no-inter`
        ```sh
        $ mosquitto_pub -V 5 -t default/inQueue/health -m '"good"'
        ```
        * iqm logs say:
            ```
            filters: drop-short[in]: no match for default/inQueue/health
            filters: cam-no-retain[in]: no match for default/inQueue/health
            filters: health-no-inter[out]: no match for default/outQueue/health
            filters: multi-retain[out]: no match for default/outQueue/health
            filters: retain-no-default[out]: no match for default/outQueue/health
            filters: health-no-inter[out]: match for default/interQueue/health with regex re.compile('^default/interQueue/health$')
            filters: health-no-inter:   - dropped
            ```
        * message on outQueue is not retained
        * message is not on interQueue
