### PR TITLE
java: add raw message callback

### DIFF
--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
@@ -191,6 +191,10 @@ public class Iot3MobilityBootstrapExample {
             }
         });
 
+        // set the RawMessageCallback to be informed of any message being received by the SDK, before treatment
+        // this callback is intended for users who prefer to process messages themselves
+        ioT3Mobility.setRawMessageCallback(message -> System.out.println("Raw message received: " + message));
+
         // let's set a Region of Interest for each object type (IoT3Mobility will handle the subscriptions)
         LatLng roiPosition = new LatLng(48.625218, 2.243448); // UTAC TEQMO test track coordinates
         setRegionOfInterest(roiPosition);

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
@@ -1,9 +1,6 @@
 package com.orange;
 
-import com.orange.iot3mobility.IoT3Mobility;
-import com.orange.iot3mobility.IoT3MobilityCallback;
-import com.orange.iot3mobility.TrueTime;
-import com.orange.iot3mobility.Utils;
+import com.orange.iot3mobility.*;
 import com.orange.iot3mobility.its.EtsiUtils;
 import com.orange.iot3mobility.its.HazardType;
 import com.orange.iot3mobility.its.StationType;
@@ -171,6 +168,10 @@ public class Iot3MobilityExample {
                 System.out.println("CPM received: " + cpm.getJson());
             }
         });
+
+        // set the RawMessageCallback to be informed of any message being received by the SDK, before treatment
+        // this callback is intended for users who prefer to process messages themselves
+        ioT3Mobility.setRawMessageCallback(message -> System.out.println("Raw message received: " + message));
 
         // let's set a Region of Interest for each object type (IoT3Mobility will handle the subscriptions)
         LatLng roiPosition = new LatLng(48.625218, 2.243448); // UTAC TEQMO test track coordinates

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -50,6 +50,8 @@ public class IoT3Mobility {
     private final String context;
     private final int stationId;
 
+    private IoT3RawMessageCallback ioT3RawMessageCallback;
+
     /**
      * Instantiate the IoT3.0 Mobility SDK.
      *
@@ -243,7 +245,17 @@ public class IoT3Mobility {
         RoadSensorManager.init(ioT3RoadSensorCallback);
     }
 
+    /**
+     * Set up the raw message callback to be informed of any message being received.
+     *
+     * @param ioT3RawMessageCallback the callback to be informed upon message reception, before treatment.
+     */
+    public void setRawMessageCallback(IoT3RawMessageCallback ioT3RawMessageCallback) {
+        this.ioT3RawMessageCallback = ioT3RawMessageCallback;
+    }
+
     private void processMessage(String topic, String message) {
+        if(ioT3RawMessageCallback != null) ioT3RawMessageCallback.messageArrived(message);
         if(topic.contains("/cam/")) RoadUserManager.processCam(message);
         else if(topic.contains("/cpm/")) RoadSensorManager.processCpm(message);
         else if(topic.contains("/denm/")) RoadHazardManager.processDenm(message);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3RawMessageCallback.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3RawMessageCallback.java
@@ -1,0 +1,14 @@
+/*
+ Copyright 2016-2024 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ */
+package com.orange.iot3mobility;
+
+public interface IoT3RawMessageCallback {
+
+    void messageArrived(String message);
+
+}


### PR DESCRIPTION
**Feature**

A new "raw message callback" allows the host application to retrieve raw messages before they are being treated by the SDK.

Closes #312 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityBootstrapExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context";
// Bootstrap parameters
private static final String BOOTSTRAP_ID = "bootstrap_id";
private static final String BOOTSTRAP_LOGIN = "boostrap_login";
private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
private static final boolean ENABLE_TELEMETRY = false;
```
4. Run ```Iot3MobilityBootstrapExample```.

---
**Expected results:**

1. On the console, you should see the following:
```
Bootstrap success
IoT3 ID: <id>
LOGIN: <login>
PASSWORD: <password>
MQTT URI: <mqtt_uri>
TELEMETRY URI: <open_telemetry_uri>
```
2. On the console, you should then see that the MQTT connection has been established successfully and that mobility messages are being published and received periodically (CAM, CPM and DENM).
3. For each message received, verify that you get a `Raw message received: <message>` log **before** the corresponding `<mobility_message_type> received: <message>` log.