### PR TITLE
rust: add mobile_id in Exchange::PathElement

### DIFF
--- a/rust/src/exchange.rs
+++ b/rust/src/exchange.rs
@@ -40,6 +40,7 @@ pub struct Exchange {
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PathElement {
+    pub mobile_id: u32,
     pub position: Position,
     pub message_type: String,
 }


### PR DESCRIPTION
What's new
---------------

- Add `mobile_id` a `Exchange::PathElement` member

How to test
---------------

1. Check that no pipelines failed
