### PR TITLE
python/iqm: fix error when filter defines no pattern

### DIFF
--- a/python/its-interqueuemanager/src/its_iqm/filters.py
+++ b/python/its-interqueuemanager/src/its_iqm/filters.py
@@ -56,7 +56,7 @@ class Filter:
             self._type = filter_type
             self._kind = filter_kind
 
-        if patterns is None:
+        if self._patterns is None:
             raise ValueError(f"Filter '{name}' does not define patterns")
 
         self._drop = "drop" in filter_cfg


### PR DESCRIPTION
**Changes:**

* InterQueueManager:
    * fix parsing filters

Closes #313

---
**How to test:**

_**Note:** in the folowing: lines starting with `$` are to be executed on your machine, as a non-root user; lines starting with `(docker)$` are to be executed in the Docker container; lines starting with `(docker)🐍 $` are to be executed in the Docker container, in the python `venv`._

1. Prepare an environment
    1. ensure a mosquitto broker is listening on `localhost:1883`, without any ACL; if not, start one (no need to be root):
        ```sh
        $ mosquitto
        ```
       then in another terminal, run an MQTT client that dumps mesages going through the broker:
        ```sh
        $ mosquitto_sub --retain-as-published -t '#' -V 5 -F %J
        ```
    2. in another terminal, start a container with python 3.11 and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            ${DOCKER_PROXY}python:3.11.9-slim-bookworm \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential socat
        $ docker container exec -d iot3 socat UNIX-LISTEN:/tmp/mqtt.socket,fork TCP4:localhost:1883

        $ docker container attach iot3
        ```
       Note: the socat command exposes the MQTT broker, listening on `localhost:1883`, inside the container, listening on the UNIX socket `/tmp/mqtt.socket`.
    3. prepare a configuration file for the IQM:
        ```sh
        (docker)$ cat >/tmp/its-iqm.cfg <<_EOF_
        [general]
        instance-id = ora_geo_1234
        prefix = default
        suffix =
        
        [local]
        socket-path = /tmp/mqtt.socket
        
        [authority]
        reload = 1000000
        
        [filter.test]
        prefix = something/
        _EOF_
        ```
    4. prepare a Python 3.11 environment, and install the Python packages:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --no-cache-dir install ./python/iot3/
        (docker)🐍 $ pip --no-cache-dir install --no-deps ./python/its-interqueuemanager/
        ```
       Note: we use `--nop-deps` when installing the IQM, because it would try to install the IoT3 SDK from a set commit in git, rather than use the one we just installed the line before.
3. Start the IQM:
    ```sh
    (docker)🐍 $ its-iqm --debug -c /tmp/its-iqm.cfg
    ```
    The IQM fails with a `ValueError` traceback:
    ```
    Traceback (most recent call last):
      File "/usr/bin/its-iqm", line 8, in <module>
        sys.exit(main())
                 ^^^^^^
      File "/usr/lib/python3.12/site-packages/its_iqm/main.py", line 85, in main
        iqm = its_iqm.iqm.IQM(cfg)
              ^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.12/site-packages/its_iqm/iqm.py", line 73, in __init__
        new_filter = filters.Filter(
                     ^^^^^^^^^^^^^^^
      File "/usr/lib/python3.12/site-packages/its_iqm/filters.py", line 60, in __init__
        raise ValueError(f"Filter '{name}' does not define patterns")
    ValueError: Filter 'test' does not define patterns
    ```