### PR TITLE
java: add error callbacks

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -110,6 +110,11 @@ public class IoT3Core {
                         public void unsubscriptionComplete(Throwable unsubscriptionFailure) {
                             ioT3CoreCallback.mqttUnsubscriptionComplete(unsubscriptionFailure);
                         }
+
+                        @Override
+                        public void onError(Throwable error) {
+                            ioT3CoreCallback.onError(error);
+                        }
                     },
                     openTelemetryClient);
         }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3CoreCallback.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3CoreCallback.java
@@ -21,4 +21,6 @@ public interface IoT3CoreCallback {
 
     void mqttUnsubscriptionComplete(Throwable unsubscriptionFailure);
 
+    void onError(Throwable error);
+
 }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttCallback.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttCallback.java
@@ -21,4 +21,6 @@ public interface MqttCallback {
 
     void unsubscriptionComplete(Throwable unsubscriptionFailure);
 
+    void onError(Throwable error);
+
 }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -90,6 +90,7 @@ public class MqttClient {
             mqttClient.disconnect().whenComplete((mqtt5DisconnectResult, throwable) -> {
                 if(throwable != null) {
                     LOGGER.log(Level.WARNING, "Error during disconnection: " + throwable.getMessage());
+                    callback.onError(throwable);
                 } else {
                     LOGGER.log(Level.INFO, "Disconnected");
                 }
@@ -104,6 +105,7 @@ public class MqttClient {
                 .whenComplete((connAck, throwable) -> {
                     if(throwable != null) {
                         LOGGER.log(Level.INFO, "Error during connection to the server: " + throwable.getMessage());
+                        callback.onError(throwable);
                     } else {
                         LOGGER.log(Level.INFO, "Success connecting to the server");
                     }

--- a/java/iot3/examples/src/main/java/com/orange/IoT3CoreBootstrapExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/IoT3CoreBootstrapExample.java
@@ -91,6 +91,11 @@ public class IoT3CoreBootstrapExample {
                         if(unsubscribeFailure == null) System.out.println("MQTT unsubscription successful");
                         else System.out.println("MQTT unsubscription failed");
                     }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        System.out.println("IoT3Core error: " + error.getMessage());
+                    }
                 })
                 .build();
     }

--- a/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3CoreExample.java
@@ -75,6 +75,11 @@ public class Iot3CoreExample {
                         if(unsubscribeFailure == null) System.out.println("MQTT unsubscription successful");
                         else System.out.println("MQTT unsubscription failed");
                     }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        System.out.println("IoT3Core error: " + error.getMessage());
+                    }
                 })
                 .build();
     }

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
@@ -91,6 +91,11 @@ public class Iot3MobilityBootstrapExample {
                     public void connectComplete(boolean reconnect, String serverURI) {
                         System.out.println("MQTT connection complete: " + serverURI);
                     }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        System.out.println("IoT3Mobility error: " + error.getMessage());
+                    }
                 })
                 .build();
 

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
@@ -69,6 +69,11 @@ public class Iot3MobilityExample {
                     public void connectComplete(boolean reconnect, String serverURI) {
                         System.out.println("MQTT connection complete: " + serverURI);
                     }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        System.out.println("IoT3Mobility error: " + error.getMessage());
+                    }
                 })
                 .build();
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -107,17 +107,22 @@ public class IoT3Mobility {
 
             @Override
             public void mqttMessagePublished(Throwable publishFailure) {
-
+                if(publishFailure != null) ioT3MobilityCallback.onError(publishFailure);
             }
 
             @Override
             public void mqttSubscriptionComplete(Throwable subscribeFailure) {
-
+                if(subscribeFailure != null) ioT3MobilityCallback.onError(subscribeFailure);
             }
 
             @Override
             public void mqttUnsubscriptionComplete(Throwable unsubscribeFailure) {
+                if(unsubscribeFailure != null) ioT3MobilityCallback.onError(unsubscribeFailure);
+            }
 
+            @Override
+            public void onError(Throwable error) {
+                ioT3MobilityCallback.onError(error);
             }
         };
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3MobilityCallback.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3MobilityCallback.java
@@ -13,4 +13,6 @@ public interface IoT3MobilityCallback {
 
     void connectComplete(boolean reconnect, String serverURI);
 
+    void onError(Throwable error);
+
 }


### PR DESCRIPTION
**Feature**

Error callbacks allow the host applications to be notified when the SDK encounters unexpected errors.

Closes #315  

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3CoreExample``` and ```Iot3MobilityExample``` classes in the ```examples``` module.
4. Run them without changing the placeholder parameters.

---
**Expected results:**

On the console, you should see the following for ```Iot3CoreExample```:
```
IoT3Core error: java.net.UnknownHostException: mqtt_host: Temporary failure in name resolution
```
And the following for ```Iot3MobilityExample```:
```
IoT3Mobility error: java.net.UnknownHostException: mqtt_host: Temporary failure in name resolution
IoT3Mobility error: MQTT client is not connected.
...
IoT3Mobility error: MQTT client is not connected.
```