### PR TITLE
python/iot3: fix MQTT subscriptions

### DIFF
--- a/python/iot3/src/iot3/core/mqtt.py
+++ b/python/iot3/src/iot3/core/mqtt.py
@@ -309,7 +309,7 @@ class MqttClient:
             retainAsPublished=True,
         )
         self.client.subscribe(
-            list(map(lambda t: (t, opts), self.subscriptions)),
+            list(map(lambda t: (t, opts), topics)),
         )
 
     # In theory, we would not need this method, as we could very well

--- a/python/iot3/tests/test-iot3-core
+++ b/python/iot3/tests/test-iot3-core
@@ -30,7 +30,7 @@ iot3.core.start(
 iot3.core.subscribe(f"{topic}/+")
 
 iot3.core.publish(f"{topic}/dropped", "dropped")
-time.sleep(1)
+time.sleep(2)
 
 iot3.core.publish(f"{topic}/passed", "passed")
 time.sleep(1)
@@ -52,7 +52,7 @@ iot3.core.start(
 iot3.core.subscribe(f"{topic}/+")
 
 iot3.core.publish(f"{topic}/dropped", "dropped")
-time.sleep(1)
+time.sleep(2)
 
 iot3.core.publish(f"{topic}/passed", "passed")
 time.sleep(1)

--- a/python/iot3/tests/test-iot3-core-all
+++ b/python/iot3/tests/test-iot3-core-all
@@ -6,7 +6,7 @@ import random
 import time
 
 
-def recv(data, topic, payload):
+def recv(data, topic, payload, retain):
     print(f"{data}: {topic[:16]}: {payload[:16]}")
 
 
@@ -32,7 +32,7 @@ c.start()
 c.subscribe(topics=[f"{topic}/+"])
 
 c.publish(topic=f'{topic}/dropped', payload="dropped")
-time.sleep(1)
+time.sleep(2)
 
 c.publish(topic=f'{topic}/passed', payload="passed")
 time.sleep(1)

--- a/python/iot3/tests/test-iot3-core-mqtt
+++ b/python/iot3/tests/test-iot3-core-mqtt
@@ -5,7 +5,7 @@ import random
 import time
 
 
-def recv(data, topic, payload):
+def recv(data, topic, payload, retain):
     print(f"{data}: {topic[:16]}: {payload.decode()[:32]}")
 
 


### PR DESCRIPTION
**Changes:**

* Bugfix:
    * fix MQTT subscriptions using the IoT3 Core SDK

Closes #317 

---
**How to test:**

1. Prepare a test environment:
    1. be sure to have unrestricted access to _test.mosquitto.org_ (IPv4 and IPv6)
    2. prepare an OpenTelemetry collector on localhost:
        ```
        $ docker container run \
            --rm \
            -p 16686:16686 \
            -p 4318:4318 \
            jaegertracing/all-in-one:1.58
        ```
        then open a browser on the Jaegger UI:
        ```
        http://localhost:16686/
        ```
    3. in another terminal, start a container with python 3.11 and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            ${DOCKER_PROXY}python:3.11.9-slim-bookworm \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git

        $ docker container attach iot3
        ```
    4. prepare a Python 3.11 environment, and install the Python packages:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --no-cache-dir install ./python/iot3/
        ```
2. Run the IoT3 Core SDK tests:
    ```sh
    (docker)🐍 $ ./python/iot3/tests/test-iot3-core
    (docker)🐍 $ ./python/iot3/tests/test-iot3-core-all
    (docker)🐍 $ ./python/iot3/tests/test-iot3-core-mqtt
    (docker)🐍 $ ./python/iot3/tests/test-iot3-core-otel
    ```

---
**Expected results:**

1. The test environment is ready
2. The tests all succeed:
    * `test-iot3-core`
        ```
        IoT3 Core SDK with MQTT and OTLP
        test/d3168f2005964f60257699b4b777f881/iot3/passed: b'passed'
        IoT3 Core SDK with MQTT and no OTLP
        test/49f5dd422caece411c22cef5e1eacc86/iot3/no-otlp/passed: b'passed'
        ```
    * `test-iot3-core-all`
        ```
        None: test/62bd0dd9f4a: b'passed'
        ```
    * `test-iot3-core-mqtt`
        ```
        clear: test/9054e3fce6c: clear message
        tls: test/9054e3fce6c: 3ИСЯЧРТЕD ПЕЅЅД̈GЕ
        ws: test/9054e3fce6c: clear message
        wss: test/9054e3fce6c: 3ИСЯЧРТЕD ПЕЅЅД̈GЕ
        ```
      Check the Jaeger UI: traces with spans were logged in OTLP
    * `test-iot3-core-otel`
      Check the Jaeger UI: traces with spans were logged in OTLP
