### PR TITLE
java: add MQTT auto reconnect to IoT3 Core

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/IoT3Core.java
@@ -206,11 +206,18 @@ public class IoT3Core {
     }
 
     /**
+     * Check that the MQTT connection is established
+     */
+    public boolean isMqttConnected() {
+        if(mqttClient != null) return mqttClient.isConnected();
+        else return false;
+    }
+
+    /**
      * Check that the MQTT connection is secured with TLS
      */
     public boolean isMqttConnectionSecured() {
-        if(mqttClient != null) return mqttClient.isConnected() && mqttClient.isConnectionSecured();
-        else return false;
+        return isMqttConnected() && mqttClient.isConnectionSecured();
     }
 
     /**

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -57,6 +57,7 @@ public class MqttClient {
                 .identifier(clientId)
                 .serverHost(serverHost)
                 .serverPort(serverPort)
+                .automaticReconnectWithDefaultConfig()
                 .addDisconnectedListener(context1 -> {
                     LOGGER.log(Level.INFO, "Disconnected from MQTT broker " + serverHost);
                     callback.connectionLost(context1.getCause());

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -9,6 +9,8 @@ package com.orange.iot3core.clients;
 
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.lifecycle.MqttClientAutoReconnect;
+import com.hivemq.client.mqtt.lifecycle.MqttClientAutoReconnectBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.datatypes.Mqtt5UserProperties;
@@ -26,6 +28,7 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,7 +60,10 @@ public class MqttClient {
                 .identifier(clientId)
                 .serverHost(serverHost)
                 .serverPort(serverPort)
-                .automaticReconnectWithDefaultConfig()
+                .automaticReconnect()
+                        .initialDelay(500, TimeUnit.MILLISECONDS)
+                        .maxDelay(5, TimeUnit.SECONDS)
+                        .applyAutomaticReconnect()
                 .addDisconnectedListener(context1 -> {
                     LOGGER.log(Level.INFO, "Disconnected from MQTT broker " + serverHost);
                     callback.connectionLost(context1.getCause());

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -332,8 +332,8 @@ public class IoT3Mobility {
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
         String topic = context + "/inQueue/v2x/cam/" + uuid + geoExtension;
 
-        // send the message
-        if(ioT3Core != null) ioT3Core.mqttPublish(topic, cam.getJsonCAM().toString());
+        // send the message only if the client is connected
+        if(isConnected()) ioT3Core.mqttPublish(topic, cam.getJsonCAM().toString());
     }
 
     /**
@@ -400,7 +400,7 @@ public class IoT3Mobility {
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
         String topic = context + "/inQueue/v2x/denm/" + uuid + geoExtension;
 
-        // send the message
+        // send the message even if the client is disconnected, so it will be queued
         if(ioT3Core != null) ioT3Core.mqttPublish(topic, denm.getJsonDENM().toString());
     }
 
@@ -418,8 +418,8 @@ public class IoT3Mobility {
         String geoExtension = QuadTileHelper.quadKeyToQuadTopic(quadkey);
         String topic = context + "/inQueue/v2x/cpm/" + uuid + geoExtension;
 
-        // send the message
-        if(ioT3Core != null) ioT3Core.mqttPublish(topic, cpm.getJson().toString());
+        // send the message only if the client is connected
+        if(isConnected()) ioT3Core.mqttPublish(topic, cpm.getJson().toString());
     }
 
     /**

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -147,6 +147,14 @@ public class IoT3Mobility {
     }
 
     /**
+     * Check that the connection is established.
+     */
+    public boolean isConnected() {
+        if(ioT3Core != null) return ioT3Core.isMqttConnected();
+        else return false;
+    }
+
+    /**
      * Retrieve the IoT3Core instance powering IoT3Mobility.
      */
     public IoT3Core getIoT3Core() {


### PR DESCRIPTION
**Feature**

The IoT3 Core MQTT client now has an automatic reconnection policy: reconnection will automatically be tried 500 ms after a connection loss the retry delay will gradually increase up to every 5 seconds.

The IoT3 Core and Mobility also expose respectively an isMqttConnected() and isConnected() method.

Closes #323 

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityBootstrapExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context";
// Bootstrap parameters
private static final String BOOTSTRAP_ID = "bootstrap_id";
private static final String BOOTSTRAP_LOGIN = "boostrap_login";
private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
private static final boolean ENABLE_TELEMETRY = false;
```
4. Run ```Iot3MobilityBootstrapExample```.
5. After a few seconds, disconnect your computer from the Internet (turn WiFi off or disconnect your Ethernet cable).
6. After another few seconds, reconnect your computer to the Internet.

---
**Expected results:**

1. On the console, you should see the following:
```
Bootstrap success
IoT3 ID: <id>
LOGIN: <login>
PASSWORD: <password>
MQTT URI: <mqtt_uri>
TELEMETRY URI: <open_telemetry_uri>
```
2. On the console, you should then see that the MQTT connection has been established successfully and that mobility messages are being published and received periodically (CAM, CPM and DENM).
3. After disconnection, you should not receive the messages anymore.
4. After reconnection, you should start receiving messages again.