### PR TITLE
Java/iot3mobility: expose ITS objects lists

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -29,8 +29,12 @@ import com.orange.iot3mobility.managers.RoadSensorManager;
 import com.orange.iot3mobility.managers.RoadUserManager;
 import com.orange.iot3mobility.quadkey.LatLng;
 import com.orange.iot3mobility.quadkey.QuadTileHelper;
+import com.orange.iot3mobility.roadobjects.RoadHazard;
+import com.orange.iot3mobility.roadobjects.RoadSensor;
+import com.orange.iot3mobility.roadobjects.RoadUser;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * Mobility SDK based on the Orange IoT3.0 platform.
@@ -420,6 +424,33 @@ public class IoT3Mobility {
 
         // send the message only if the client is connected
         if(isConnected()) ioT3Core.mqttPublish(topic, cpm.getJson().toString());
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Users in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadUser} objects
+     */
+    public static List<RoadUser> getRoadUsers() {
+        return RoadUserManager.getRoadUsers();
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Hazards in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadHazard} objects
+     */
+    public static List<RoadHazard> getRoadHazards() {
+        return RoadHazardManager.getRoadHazards();
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Sensors in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadSensor} objects
+     */
+    public static List<RoadSensor> getRoadSensors() {
+        return RoadSensorManager.getRoadSensors();
     }
 
     /**

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
@@ -64,6 +64,9 @@ public class RoadHazardManager {
                         if(roadHazard != null) {
                             if(terminate) {
                                 ROAD_HAZARD_MAP.values().remove(roadHazard);
+                                synchronized (ROAD_HAZARDS) {
+                                    ROAD_HAZARDS.remove(roadHazard);
+                                }
                                 ioT3RoadHazardCallback.roadHazardExpired(roadHazard);
                             } else {
                                 roadHazard.updateTimestamp(timestamp);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
@@ -16,9 +16,7 @@ import com.orange.iot3mobility.roadobjects.RoadHazard;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -119,6 +117,15 @@ public class RoadHazardManager {
             scheduler.scheduleWithFixedDelay(RoadHazardManager::checkAndRemoveExpiredObjects,
                     1, 1, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Hazards in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadHazard} objects
+     */
+    public static List<RoadHazard> getRoadHazards() {
+        return Collections.unmodifiableList(ROAD_HAZARDS);
     }
 
 }

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadSensorManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadSensorManager.java
@@ -14,9 +14,7 @@ import com.orange.iot3mobility.roadobjects.RoadSensor;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +105,15 @@ public class RoadSensorManager {
             scheduler.scheduleWithFixedDelay(RoadSensorManager::checkAndRemoveExpiredObjects,
                     1, 1, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Sensors in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadSensor} objects
+     */
+    public static List<RoadSensor> getRoadSensors() {
+        return Collections.unmodifiableList(ROAD_SENSORS);
     }
 
 }

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadUserManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadUserManager.java
@@ -9,16 +9,13 @@ package com.orange.iot3mobility.managers;
 
 import com.orange.iot3mobility.its.StationType;
 import com.orange.iot3mobility.its.json.cam.CAM;
-import com.orange.iot3mobility.its.json.cpm.CPM;
 import com.orange.iot3mobility.quadkey.LatLng;
 import com.orange.iot3mobility.roadobjects.RoadUser;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -112,6 +109,15 @@ public class RoadUserManager {
             scheduler.scheduleWithFixedDelay(RoadUserManager::checkAndRemoveExpiredObjects,
                     1, 1, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * Retrieve a read-only list of the Road Users in the vicinity.
+     *
+     * @return the read-only list of {@link com.orange.iot3mobility.roadobjects.RoadUser} objects
+     */
+    public static List<RoadUser> getRoadUsers() {
+        return Collections.unmodifiableList(ROAD_USERS);
     }
 
 }


### PR DESCRIPTION
**Feature**

The IoT3 Mobility SDK is now exposing its lists of `RoadUser`, `RoadHazard` and `RoadSensor` objects.

The lists are read-only to avoid modification by the host app.

Closes #332  

---
**How to test**

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityBootstrapExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
private static final String EXAMPLE_UUID = "uuid";
private static final String EXAMPLE_CONTEXT = "context";
// Bootstrap parameters
private static final String BOOTSTRAP_ID = "bootstrap_id";
private static final String BOOTSTRAP_LOGIN = "boostrap_login";
private static final String BOOTSTRAP_PASSWORD = "bootstrap_password";
private static final BootstrapHelper.Role BOOTSTRAP_ROLE = BootstrapHelper.Role.EXTERNAL_APP;
private static final String BOOTSTRAP_URI = "bootstrap.uri.com";
private static final boolean ENABLE_TELEMETRY = false;
```
4. Add the line `System.out.println("Number of Road Hazards in the vicinity: " + IoT3Mobility.getRoadHazards().size());` in the following callback:
 ```
@Override
public void newRoadHazard(RoadHazard roadHazard) {
      System.out.println("New Road Hazard: " + roadHazard.getUuid());
}

@Override
public void roadHazardExpired(RoadHazard roadHazard) {
   System.out.println("Road Hazard has expired: " + roadHazard.getUuid());
}
```
5. Increase the frequency of DENM sending rate to 1Hz: `messageScheduler.scheduleWithFixedDelay(Iot3MobilityBootstrapExample::sendTestDenm, 1, 1, TimeUnit.SECONDS);`

6. Run ```Iot3MobilityBootstrapExample``` for at least 15 seconds and stop it after you have checked that the results are as expected (see below).
7. Add the line `IoT3Mobility.getRoadUsers().clear();` in the following callback:
 ```
@Override
public void roadUserUpdate(RoadUser roadUser) {
   System.out.println("Road User update: " + roadUser.getUuid()
      + " | Position: " + roadUser.getPosition()
      + " | Speed: " + roadUser.getSpeedKmh() + " km/h");
}
```
8. Run ```Iot3MobilityBootstrapExample``` again.
---
**Expected results:**

1. On the console, you should see the following:
```
Bootstrap success
IoT3 ID: <id>
LOGIN: <login>
PASSWORD: <password>
MQTT URI: <mqtt_uri>
TELEMETRY URI: <open_telemetry_uri>
```
2. On the console, you should then see that the MQTT connection has been established successfully and that mobility messages are being published and received periodically (CAM, CPM and DENM).
3. Upon DENM receptions, you should have the following log: `Number of Road Hazards in the vicinity: <increasing_number>`.
4. You should then start having Road Hazard expirations, with the logs stabilizing at 10 to 11 Road Hazards in the vicinity.
5. In the second test, you should see the following error at the second CAM reception: `java.lang.UnsupportedOperationException`.