### PR TITLE
swift: add ETSI entities

### DIFF
--- a/swift/ITSClient/Package.swift
+++ b/swift/ITSClient/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
         ),
         .testTarget(
             name: "ITSMobilityTests",
-            dependencies: ["ITSMobility"]
+            dependencies: ["ITSMobility"],
+            resources: [.copy("Data")]
         ),
     ]
 )

--- a/swift/ITSClient/Sources/ITSMobility/Models/CAM/BasicContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/CAM/BasicContainer.swift
@@ -1,0 +1,35 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The basic container.
+public struct BasicContainer: Codable {
+    public let confidence: Confidence?
+    public let referencePosition: Position
+    public let stationType: StationType?
+
+    enum CodingKeys: String, CodingKey {
+        case stationType = "station_type"
+        case referencePosition = "reference_position"
+        case confidence
+    }
+
+    init(
+        stationType: StationType? = .unknown,
+        referencePosition: Position,
+        confidence: Confidence? = nil
+    ) {
+        self.stationType = stationType
+        self.referencePosition = referencePosition
+        self.confidence = confidence
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/CAM/CAM.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/CAM/CAM.swift
@@ -1,0 +1,50 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+typealias CAM = CooperativeAwarenessMessage
+
+/// The CAM representation.
+public struct CooperativeAwarenessMessage: Codable {
+    /// The CAM message.
+    public let message: CAMMessage
+    /// The entity responsible for this message.
+    public let origin: Origin
+    /// The identifier of the entity responsible for emitting the message.
+    public let sourceUUID: String
+    /// The timestamp when the message was generated since Unix Epoch in milliseconds.
+    public let millisecondsTimestamp: Int
+    /// The message type.
+    public let type: MessageType = .cam
+    /// The message format version.
+    public let version: String = "1.1.3"
+    /// The timestamp when the message was generated since Unix Epoch in seconds.
+    public var timestamp: TimeInterval { Double(millisecondsTimestamp) / 1000 }
+
+    enum CodingKeys: String, CodingKey {
+        case message, origin, type, version
+        case sourceUUID = "source_uuid"
+        case millisecondsTimestamp = "timestamp"
+    }
+
+    init(
+        message: CAMMessage,
+        origin: Origin = .originSelf,
+        sourceUUID: String,
+        timestamp: TimeInterval
+    ) {
+        self.message = message
+        self.origin = origin
+        self.sourceUUID = sourceUUID
+        self.millisecondsTimestamp = Int(timestamp * 1000)
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/CAM/CAMMessage.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/CAM/CAMMessage.swift
@@ -1,0 +1,59 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The CAM message.
+public struct CAMMessage: Codable {
+    /// The version of the ITS message and/or communication protocol.
+    public let protocolVersion: UInt8
+    /// The identifier for an ITS-S.
+    public let stationID: UInt32
+    /// The time of the reference position in the CAM, considered as time of the CAM generation.
+    /// TimestampIts mod 65 536. TimestampIts represents an integer value in milliseconds since 2004-01-01T00:00:00:000Z.
+    public let etsiGenerationDeltaTime: Int
+    /// The basic container.
+    public let basicContainer: BasicContainer
+    /// The high frequency container.
+    public let highFrequencyContainer: HighFrequencyContainer?
+    /// The low frequency container.
+    public let lowFrequencyContainer: LowFrequencyContainer?
+
+    private static let generationDeltaTimeModulo = 65_536
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "protocol_version"
+        case stationID = "station_id"
+        case etsiGenerationDeltaTime = "generation_delta_time"
+        case basicContainer = "basic_container"
+        case highFrequencyContainer = "high_frequency_container"
+        case lowFrequencyContainer = "low_frequency_container"
+    }
+
+    init(
+        protocolVersion: UInt8 = 1,
+        stationID: UInt32,
+        generationDeltaTime: TimeInterval,
+        basicContainer: BasicContainer,
+        highFrequencyContainer: HighFrequencyContainer?,
+        lowFrequencyContainer: LowFrequencyContainer? = nil
+        )
+    {
+        self.protocolVersion = protocolVersion
+        self.stationID = stationID
+        self.etsiGenerationDeltaTime = ETSI.epochTimestampToETSIMilliseconds(
+            generationDeltaTime
+        ) % Self.generationDeltaTimeModulo
+        self.basicContainer = basicContainer
+        self.highFrequencyContainer = highFrequencyContainer
+        self.lowFrequencyContainer = lowFrequencyContainer
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/CAM/HighFrequencyContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/CAM/HighFrequencyContainer.swift
@@ -1,0 +1,379 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The high frequency container.
+public struct HighFrequencyContainer: Codable {
+    /// The heading in 0.1 degree.
+    public let etsiHeading: Int?
+    /// The  speed in 0.01 m/s.
+    public let etsiSpeed: Int?
+    /// The drive direction.
+    public let driveDirection: DriveDirection?
+    /// The vehicule length in decimeters.
+    public let etsiVehicleLength: Int?
+    /// The vehicule width in decimeters.
+    public let etsiVehicleWidth: Int?
+    /// The curvature.
+    public let curvature: Int?
+    /// The curvature calculation mode.
+    public let curvatureCalculationMode: CurvatureCalculationMode?
+    /// The longitudinal acceleration in 0.1 m/s2
+    public let etsiLongitudinalAcceleration: Int?
+    /// The yaw rate in 0.01 degrees/s
+    public let etsiYawRate: Int?
+    /// The acceleration control with a bit representation in a string.
+    public let etsiAccelerationControl: String?
+    /// The lane position.
+    public let lanePosition: LanePosition?
+    /// The lateral acceleration in 0.1 m/s2.
+    public let etsiLateralAcceleration: Int?
+    /// The vertical acceleration in 0.1 m/s2.
+    public let etsiVerticalAcceleration: Int?
+    /// The high frequency confidence.
+    public let confidence: HighFrequencyContainerConfidence?
+    /// The heading in degree.
+    public var heading: Double? {
+        etsiHeading.map({ ETSI.deciDegreesToDegrees($0) })
+    }
+    // The speed in m/s.
+    public var speed: Double? {
+        etsiSpeed.map({ ETSI.centimetersPerSecondToMetersPerSecond($0) })
+    }
+    /// The vehicule length in meters.
+    public var vehicleLength: Double? {
+        etsiVehicleLength.map({ ETSI.decimetersToMeters($0) })
+    }
+    /// The vehicule width in meters.
+    public var vehicleWidth: Double? {
+        etsiVehicleWidth.map({ ETSI.decimetersToMeters($0) })
+    }
+    /// The longitudinal acceleration in m/s2.
+    public var longitudinalAcceleration: Double? {
+        etsiLongitudinalAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+    /// The yaw rate in degrees/s
+    public var yawRate: Double? {
+        etsiYawRate.map({ ETSI.centiDegreesPerSecondToDegreesPerSecond($0) })
+    }
+    /// The acceleration control.
+    public var accelerationControl: AccelerationControl? {
+        etsiAccelerationControl.map({ AccelerationControl(rawValue: strtoul($0, nil, 2)) })
+    }
+    /// The lateral acceleration in m/s2.
+    public var lateralAcceleration: Double? {
+        etsiLateralAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+    /// The vertical acceleration in m/s2.
+    public var verticalAcceleration: Double? {
+        etsiVerticalAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+
+    private static let minHeading = 0
+    private static let maxHeading = 3601
+    private static let minSpeed = 0
+    private static let maxSpeed = 16383
+    private static let minVehiculeLength = 1
+    private static let maxVehiculeLength = 1023
+    private static let minVehiculeWidth = 1
+    private static let maxVehiculeWidth = 62
+    private static let minCurvature = -1023
+    private static let maxCurvature = 1023
+    private static let minAcceleration = -160
+    private static let maxAcceleration = 161
+    private static let minYawRate = -32766
+    private static let maxYawRate = 32766
+    static let unavailableYawRate = 32767
+    static let unavailableHeading = ETSI.deciDegreesToDegrees(Self.maxHeading)
+    static let unavailableSpeed = ETSI.centimetersPerSecondToMetersPerSecond(Self.maxSpeed)
+    static let unavailableVehiculeLength = ETSI.decimetersToMeters(Self.maxVehiculeLength)
+    static let unavailableVehiculeWidth = ETSI.decimetersToMeters(Self.maxVehiculeWidth)
+    static let unavailableCurvature = 1023
+    static let unavailableAcceleration = ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond(Self.maxAcceleration)
+
+
+    enum CodingKeys: String, CodingKey {
+        case etsiHeading = "heading"
+        case etsiSpeed = "speed"
+        case driveDirection = "drive_direction"
+        case etsiVehicleLength = "vehicle_length"
+        case etsiVehicleWidth = "vehicle_width"
+        case confidence, curvature
+        case curvatureCalculationMode = "curvature_calculation_mode"
+        case etsiLongitudinalAcceleration = "longitudinal_acceleration"
+        case etsiYawRate = "yaw_rate"
+        case etsiAccelerationControl = "acceleration_control"
+        case lanePosition = "lane_position"
+        case etsiLateralAcceleration = "lateral_acceleration"
+        case etsiVerticalAcceleration = "vertical_acceleration"
+    }
+
+    init(
+        heading: Double?,
+        speed: Double?,
+        driveDirection: DriveDirection? = nil,
+        vehicleLength: Double? = nil,
+        vehicleWidth: Double? = nil,
+        curvature: Int? = nil,
+        curvatureCalculationMode: CurvatureCalculationMode? = nil,
+        longitudinalAcceleration: Double? = nil,
+        yawRate: Double? = nil,
+        accelerationControl: AccelerationControl? = nil,
+        lanePosition: LanePosition? = nil,
+        lateralAcceleration: Double? = nil,
+        verticalAcceleration: Double? = nil,
+        confidence: HighFrequencyContainerConfidence? = nil
+    ) {
+        self.etsiHeading = heading.map({
+            clip(ETSI.degreesToDeciDegrees($0),
+                 Self.minHeading,
+                 Self.maxHeading)
+        })
+        self.etsiSpeed = speed.map({
+            clip(ETSI.metersPerSecondToCentimetersPerSecond($0),
+                 Self.minSpeed,
+                 Self.maxSpeed)
+        })
+        self.driveDirection = driveDirection
+        self.etsiVehicleLength = vehicleLength.map({
+            clip(ETSI.metersToDecimeters($0),
+                 Self.minVehiculeLength,
+                 Self.maxVehiculeLength)
+        })
+        self.etsiVehicleWidth = vehicleWidth.map({
+            clip(ETSI.metersToDecimeters($0),
+                 Self.minVehiculeWidth,
+                 Self.maxVehiculeWidth)
+        })
+        self.curvature = curvature.map({ clip($0, Self.minCurvature, Self.maxCurvature) })
+        self.curvatureCalculationMode = curvatureCalculationMode
+        self.etsiLongitudinalAcceleration = longitudinalAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+        self.etsiYawRate = yawRate.map({
+            clip(ETSI.degreesPerSecondToCentiDegreesPerSecond($0),
+                 Self.minYawRate,
+                 Self.maxYawRate)
+        })
+        self.etsiAccelerationControl = accelerationControl.map({ String($0.rawValue, radix: 2) })
+        self.lanePosition = lanePosition
+        self.etsiLateralAcceleration = lateralAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+        self.etsiVerticalAcceleration = verticalAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+        self.confidence = confidence
+    }
+}
+
+/// The drive direction.
+public enum DriveDirection: Int, Codable {
+    case forward = 0
+    case backward = 1
+    case unavailable
+}
+
+/// The curvature calculation mode.
+public enum CurvatureCalculationMode: Int, Codable {
+    case yawRateUsed = 0
+    case yawRateNotUsed = 1
+    case unavailable = 2
+}
+
+/// The acceleration control.
+public struct AccelerationControl: OptionSet, Sendable {
+    public let rawValue: UInt
+
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    static let brakePedalEngaged  = AccelerationControl(rawValue: 1 << 0)
+    static let gasPedalEngaged  = AccelerationControl(rawValue: 1 << 1)
+    static let emergencyBrakeEngaged   = AccelerationControl(rawValue: 1 << 2)
+    static let collisionWarningEngaged   = AccelerationControl(rawValue: 1 << 3)
+    static let accEngaged   = AccelerationControl(rawValue: 1 << 4)
+    static let cruiseControlEngaged   = AccelerationControl(rawValue: 1 << 5)
+    static let speedLimiterEngaged   = AccelerationControl(rawValue: 1 << 6)
+}
+
+/// The lane position.
+public enum LanePosition: Int, Codable {
+    case offTheRoad = -1
+    case innerHardShoulder = 0
+    case innermostDrivingLane = 1
+    case secondLaneFromInside = 2
+    case outterHardShoulder = 14
+}
+
+/// The high frequency confidence.
+public struct HighFrequencyContainerConfidence: Codable {
+    /// The heading in 0.1 degree.
+    public let etsiHeading: Int?
+    /// The  speed in 0.01 m/s.
+    public let etsiSpeed: Int?
+    /// The vehicule length.
+    public let vehicleLength: VehiculeLengthConfidence?
+    /// The yaw rate.
+    public let yawRate: YawRateConfidence?
+    /// The longitudinal acceleration in 0.1 m/s2
+    public let etsiLongitudinalAcceleration: Int?
+    /// The lateral acceleration in 0.1 m/s2.
+    public let etsiLateralAcceleration: Int?
+    /// The curvature.
+    public let curvature: CurvatureConfidence?
+    /// The vertical acceleration in 0.1 m/s2.
+    public let etsiVerticalAcceleration: Int?
+    /// The heading in degree.
+    public var heading: Double? {
+        etsiHeading.map({ ETSI.deciDegreesToDegrees($0) })
+    }
+    // The speed in m/s.
+    public var speed: Double? {
+        etsiSpeed.map({ ETSI.centimetersPerSecondToMetersPerSecond($0) })
+    }
+    /// The longitudinal acceleration in m/s2
+    public var longitudinalAcceleration: Double? {
+        etsiLongitudinalAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+    /// The lateral acceleration in m/s2
+    public var lateralAcceleration: Double? {
+        etsiLateralAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+    /// The vertical acceleration in m/s2
+    public var verticalAcceleration: Double? {
+        etsiVerticalAcceleration.map({ ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond($0) })
+    }
+
+    private static let minHeading = 1
+    private static let maxHeading = 127
+    private static let minSpeed = 1
+    private static let maxSpeed = 127
+    private static let minAcceleration = 0
+    private static let maxAcceleration = 102
+    static let unavailableHeading = ETSI.deciDegreesToDegrees(Self.maxHeading)
+    static let unavailableSpeed = ETSI.centimetersPerSecondToMetersPerSecond(Self.maxSpeed)
+    static let unavailableAcceleration = ETSI.decimetersPerSquaredSecondToMetersPerSquaredSecond(Self.maxAcceleration)
+
+    enum CodingKeys: String, CodingKey {
+        case etsiHeading = "heading"
+        case etsiSpeed = "speed"
+        case vehicleLength = "vehicle_length"
+        case yawRate = "yaw_rate"
+        case etsiLongitudinalAcceleration = "longitudinal_acceleration"
+        case etsiLateralAcceleration = "lateral_acceleration"
+        case curvature
+        case etsiVerticalAcceleration = "vertical_acceleration"
+    }
+
+    init(
+        heading: Double?,
+        speed: Double?,
+        vehicleLength: VehiculeLengthConfidence? = nil,
+        yawRate: YawRateConfidence? = nil,
+        longitudinalAcceleration: Double? = nil,
+        lateralAcceleration: Double? = nil,
+        curvature: CurvatureConfidence? = nil,
+        verticalAcceleration: Double? = nil
+    ) {
+        self.etsiHeading = heading.map({
+            clip(ETSI.degreesToDeciDegrees($0),
+                 Self.minHeading,
+                 Self.maxHeading)
+        })
+        self.etsiSpeed = speed.map({
+            clip(ETSI.metersPerSecondToCentimetersPerSecond($0),
+                 Self.minSpeed,
+                 Self.maxSpeed)
+        })
+        self.vehicleLength = vehicleLength
+        self.yawRate = yawRate
+        self.etsiLongitudinalAcceleration = longitudinalAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+        self.etsiLateralAcceleration = lateralAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+        self.curvature = curvature
+        self.etsiVerticalAcceleration = verticalAcceleration.map({
+            clip(ETSI.metersPerSquaredSecondToDecimetersPerSquaredSecond($0),
+                 Self.minAcceleration,
+                 Self.maxAcceleration)
+        })
+    }
+}
+
+/// The vehicule length confidence.
+public enum VehiculeLengthConfidence: Int, Codable {
+    case noTrailerPresent = 0
+    case trailerPresentWithKnownLength = 1
+    case trailerPresentWithUnknownLength = 2
+    case trailerPresenceIsUnknown = 3
+    case unavailable = 4
+}
+
+/// The yaw rate confidence.
+public enum YawRateConfidence: Int, Codable {
+    case degSec_000_01 = 0
+    case degSec_000_05 = 1
+    case degSec_000_10 = 2
+    case degSec_001_00 = 3
+    case degSec_005_00 = 4
+    case degSec_010_00 = 5
+    case degSec_100_00 = 6
+    case outOfRange = 7
+    case unavailable = 8
+    
+    enum CodingKeys: String, CodingKey {
+        case degSec_000_01 = "degSec-000-01"
+        case degSec_000_05 = "degSec-000-05"
+        case degSec_000_10 = "degSec-000-10"
+        case degSec_001_00 = "degSec-001-00"
+        case degSec_005_00 = "degSec-005-00"
+        case degSec_010_00 = "degSec-010-00"
+        case degSec_100_00 = "degSec-100-00"
+        case outOfRange, unavailable
+    }
+}
+
+/// The curvature confidence.
+public enum CurvatureConfidence: Int, Codable {
+    case onePerMeter_0_0002 = 0
+    case onePerMeter_0_0001 = 1
+    case onePerMeter_0_0005 = 2
+    case onePerMeter_0_02 = 3
+    case onePerMeter_0_01 = 4
+    case onePerMeter_01 = 5
+    case outOfRange = 6
+    case unavailable = 7
+
+    enum CodingKeys: String, CodingKey {
+        case onePerMeter_0_0002 = "onePerMeter-0-00002"
+        case onePerMeter_0_0001 = "onePerMeter-0-0001"
+        case onePerMeter_0_0005 = "onePerMeter-0-0005"
+        case onePerMeter_0_02 = "onePerMeter-0-002"
+        case onePerMeter_0_01 = "onePerMeter-0-01"
+        case onePerMeter_01 = "onePerMeter-0-1"
+        case outOfRange, unavailable
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/CAM/LowFrequencyContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/CAM/LowFrequencyContainer.swift
@@ -1,0 +1,78 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The low frequency container.
+public struct LowFrequencyContainer: Codable {
+    /// The vehicule role.
+    public let vehicleRole: VehiculeRole?
+    /// The exterior lights status with a bit representation in a string.
+    public let etsiExteriorLights: String
+    /// The path history, a path with a set of path points
+    public let pathHistory: [PathHistory]
+    /// The exterior lights status.
+    public var exteriorLights: ExteriorLightStatus {
+        ExteriorLightStatus(rawValue: strtoul(etsiExteriorLights, nil, 2))
+    }
+
+    private static let maxPathHistory = 40
+
+    enum CodingKeys: String, CodingKey {
+        case vehicleRole = "vehicle_role"
+        case etsiExteriorLights = "exterior_lights"
+        case pathHistory = "path_history"
+    }
+
+    init(vehicleRole: VehiculeRole?, exteriorLights: ExteriorLightStatus, pathHistory: [PathHistory]) {
+        self.vehicleRole = vehicleRole
+        self.etsiExteriorLights = String(exteriorLights.rawValue, radix: 2)
+        self.pathHistory = Array(pathHistory.prefix(Self.maxPathHistory))
+    }
+}
+
+/// The vehicule role
+public enum VehiculeRole: Int, Codable {
+    case `default` = 0
+    case publicTransport = 1
+    case specialTransport = 2
+    case dangerousGoods = 3
+    case roadWork = 4
+    case rescue = 5
+    case emergency = 6
+    case safetyCar = 7
+    case agriculture = 8
+    case commercial = 9
+    case military = 10
+    case roadOperator = 11
+    case taxi = 12
+    case reserved1 = 13
+    case reserved2 = 14
+    case reserved3 = 15
+}
+
+/// The exterior light status.
+public struct ExteriorLightStatus: OptionSet, Sendable {
+    public let rawValue: UInt
+
+    public init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+
+    static let lowBeamHeadlightsOn  = AccelerationControl(rawValue: 1 << 0)
+    static let highBeamHeadlightsOn  = AccelerationControl(rawValue: 1 << 1)
+    static let leftTurnSignalOn   = AccelerationControl(rawValue: 1 << 2)
+    static let rightTurnSignalOn   = AccelerationControl(rawValue: 1 << 3)
+    static let daytimeRunningLightsOn   = AccelerationControl(rawValue: 1 << 4)
+    static let reverseLightOn   = AccelerationControl(rawValue: 1 << 5)
+    static let fogLightOn   = AccelerationControl(rawValue: 1 << 6)
+    static let parkingLightsOn   = AccelerationControl(rawValue: 1 << 7)
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/Confidence.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/Confidence.swift
@@ -1,0 +1,104 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The confidence.
+public struct Confidence: Codable {
+    /// The altitude confidence.
+    public let altitude: AltitudeConfidence?
+    /// The position confidence ellipse.
+    public let positionConfidenceEllipse: PositionConfidenceEllipse?
+
+    enum CodingKeys: String, CodingKey {
+        case altitude
+        case positionConfidenceEllipse = "position_confidence_ellipse"
+    }
+
+    init(altitude: AltitudeConfidence? = nil, positionConfidenceEllipse: PositionConfidenceEllipse?) {
+        self.altitude = altitude
+        self.positionConfidenceEllipse = positionConfidenceEllipse
+    }
+}
+
+/// The altitude confidence.
+public enum AltitudeConfidence: Int, Codable {
+    case alt_000_01 = 0
+    case alt_000_02 = 1
+    case alt_000_05 = 2
+    case alt_000_10 = 3
+    case alt_000_20 = 4
+    case alt_000_50 = 5
+    case alt_001_00 = 6
+    case alt_002_00 = 7
+    case alt_005_00 = 8
+    case alt_010_00 = 9
+    case alt_020_00 = 10
+    case alt_050_00 = 11
+    case alt_100_00 = 12
+    case alt_200_00 = 13
+    case outOfRange = 14
+    case unavailable = 15
+
+    enum CodingKeys: String, CodingKey {
+        case alt_000_01 = "alt-000-01"
+        case alt_000_02 = "alt-000-02"
+        case alt_000_05 = "alt-000-05"
+        case alt_000_10 = "alt-000-10"
+        case alt_000_20 = "alt-000-20"
+        case alt_000_50 = "alt-000-50"
+        case alt_001_00 = "alt-001-00"
+        case alt_002_00 = "alt-002-00"
+        case alt_005_00 = "alt-005-00"
+        case alt_010_00 = "alt-010-00"
+        case alt_020_00 = "alt-020-00"
+        case alt_050_00 = "alt-050-00"
+        case alt_100_00 = "alt-100-00"
+        case outOfRange, unavailable
+    }
+}
+
+/// The position confidence ellipse.
+public struct PositionConfidenceEllipse: Codable {
+    /// The semi major confidence.
+    public let semiMajorConfidence: Int?
+    /// The semi minor confidence.
+    public let semiMinorConfidence: Int?
+    /// The semi major orientation.
+    public let semiMajorOrientation: Int?
+
+    private static let minConfidence: Int = 0
+    private static let minOrientation: Int = 0
+    private static let unavailableConfidence: Int = 4095
+    private static let unavailableOrientation: Int = 3601
+
+    enum CodingKeys: String, CodingKey {
+        case semiMajorConfidence = "semi_major_confidence"
+        case semiMajorOrientation = "semi_major_orientation"
+        case semiMinorConfidence = "semi_minor_confidence"
+    }
+
+    init(
+        semiMajorConfidence: Int? = Self.unavailableConfidence,
+        semiMajorOrientation: Int? = Self.unavailableOrientation,
+        semiMinorConfidence: Int? = Self.unavailableConfidence
+    ) {
+        self.semiMajorConfidence = semiMajorConfidence.map({
+            clip($0, Self.minConfidence, Self.unavailableConfidence)
+        })
+        self.semiMinorConfidence = semiMinorConfidence.map({
+            clip($0, Self.minConfidence, Self.unavailableConfidence)
+        })
+        self.semiMajorOrientation = semiMajorOrientation.map({
+            clip($0, Self.minOrientation, Self.unavailableOrientation)
+        })
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/AlacarteContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/AlacarteContainer.swift
@@ -1,0 +1,45 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The "à la carte" container.
+public struct AlacarteContainer: Codable {
+    /// The lane position.
+    public let lanePosition: Int8?
+    /// The positioning solution.
+    public let positioningSolution: PositioningSolution?
+
+    private static let minLanePosition: Int8 = -1
+    private static let maxLanePosition: Int8 = 14
+
+    enum CodingKeys: String, CodingKey {
+        case lanePosition = "lane_position"
+        case positioningSolution = "positioning_solution"
+    }
+
+    init(lanePosition: Int8?, positioningSolution: PositioningSolution?) {
+        self.lanePosition = lanePosition.map({
+            clip($0, Self.minLanePosition, Self.maxLanePosition)
+        })
+        self.positioningSolution = positioningSolution
+    }
+}
+
+/// The positioning solution.
+public enum PositioningSolution: Int, Codable {
+    case noPositioningSolution = 0
+    case sGNSS = 1
+    case dGNSS = 2
+    case sGNSSplusDR = 3
+    case dGNSSplusDR = 4
+    case dR = 5
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/DENM.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/DENM.swift
@@ -1,0 +1,73 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+typealias DENM = DecentralizedEnvironmentalNotificationMessage
+
+/// The DENM representation.
+public struct DecentralizedEnvironmentalNotificationMessage: Codable {
+    /// The DENM message.
+    public let message: DENMMessage
+    /// The entity responsible for this message.
+    public let origin: Origin
+    /// The identifier of the entity responsible for emitting the message.
+    public let sourceUUID: String
+    /// The timestamp when the message was generated since Unix Epoch in milliseconds.
+    public let millisecondsTimestamp: Int
+    /// The message type.
+    public let type: MessageType = .denm
+    /// The message format version.
+    public let version: String = "1.1.3"
+    /// The list of ordered elements root source of the message.
+    public let path: [Path]?
+    /// The timestamp when the message was generated since Unix Epoch in seconds.
+    public var timestamp: TimeInterval { Double(millisecondsTimestamp) / 1000 }
+
+    enum CodingKeys: String, CodingKey {
+        case message, origin, path, type, version
+        case sourceUUID = "source_uuid"
+        case millisecondsTimestamp = "timestamp"
+    }
+
+    init(
+        message: DENMMessage,
+        origin: Origin = .originSelf,
+        sourceUUID: String,
+        timestamp: TimeInterval,
+        path: [Path]? = nil
+    ) {
+        self.message = message
+        self.origin = origin
+        self.path = path
+        self.sourceUUID = sourceUUID
+        self.millisecondsTimestamp = Int(timestamp * 1000)
+    }
+}
+
+/// The path.
+public struct Path: Codable {
+    /// The root message type source of the element.
+    public let messageType: MessageType
+    /// The position.
+    public let position: Position
+
+    enum CodingKeys: String, CodingKey {
+        case messageType = "message_type"
+        case position
+    }
+
+    init(messageType: MessageType, position: Position) {
+        self.messageType = messageType
+        self.position = position
+    }
+}
+

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/DENMMessage.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/DENMMessage.swift
@@ -1,0 +1,54 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The DENM message.
+public struct DENMMessage: Codable {
+    /// The version of the ITS message and/or communication protocol.
+    public let protocolVersion: UInt8
+    /// The identifier for an ITS-S.
+    public let stationID: UInt32
+    /// Contains information related to the DENM management and the DENM protocol.
+    public let managementContainer: ManagementContainer
+    /// Contains information related to the type of the detected event.
+    public let situationContainer: SituationContainer?
+    /// Contains information specific to the use case which requires the transmission of
+    /// additional information that is not included in the three previous containers.
+    public let alacarteContainer: AlacarteContainer?
+    /// Contains information of the event location, and the location referencing.
+    public let locationContainer: LocationContainer?
+
+    enum CodingKeys: String, CodingKey {
+        case alacarteContainer = "alacarte_container"
+        case locationContainer = "location_container"
+        case managementContainer = "management_container"
+        case protocolVersion = "protocol_version"
+        case situationContainer = "situation_container"
+        case stationID = "station_id"
+    }
+
+    init(
+        protocolVersion: UInt8 = 1,
+        stationID: UInt32,
+        managementContainer: ManagementContainer,
+        situationContainer: SituationContainer,
+        locationContainer: LocationContainer? = nil,
+        alacarteContainer: AlacarteContainer? = nil
+    ) {
+        self.protocolVersion = protocolVersion
+        self.stationID = stationID
+        self.managementContainer = managementContainer
+        self.situationContainer = situationContainer
+        self.locationContainer = locationContainer
+        self.alacarteContainer = alacarteContainer
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/LocationContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/LocationContainer.swift
@@ -1,0 +1,123 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The location container.
+public struct LocationContainer: Codable {
+    /// The traces, 1 or more path history.
+    public let traces: [Trace]
+    /// The event speed in 0.01 m/s.
+    public let etsiEventSpeed: Int?
+    /// The event heading in 0.1 degrees.
+    public let etsiEventPositionHeading: Int?
+    /// The road type.
+    public let roadType: RoadType?
+    /// The location container confidence.
+    public let confidence: LocationContainerConfidence?
+    /// The event heading in degrees.
+    public var eventPositionHeading: Double? {
+        etsiEventPositionHeading.map({ ETSI.deciDegreesToDegrees($0) })
+    }
+    /// The event speed in m/s.
+    public var eventSpeed: Double? {
+        etsiEventSpeed.map({ ETSI.centimetersPerSecondToMetersPerSecond($0) })
+    }
+
+    private static let minEventSpeed = 0
+    private static let maxEventSpeed = 16383
+    private static let maxTraces = 7
+
+    enum CodingKeys: String, CodingKey {
+        case confidence
+        case etsiEventPositionHeading = "event_position_heading"
+        case etsiEventSpeed = "event_speed"
+        case roadType = "road_type"
+        case traces
+    }
+
+    init(
+        traces: [Trace] = [],
+        eventSpeed: Double? = nil,
+        eventPositionHeading: Double? = nil,
+        roadType: RoadType? = nil,
+        confidence: LocationContainerConfidence? = nil
+    ) {
+        self.traces = Array(traces.prefix(Self.maxTraces))
+        self.etsiEventSpeed = eventSpeed.map({
+            clip(ETSI.metersPerSecondToCentimetersPerSecond($0),
+                 Self.minEventSpeed,
+                 Self.maxEventSpeed)
+        })
+        self.etsiEventPositionHeading = eventPositionHeading.map({ ETSI.degreesToDeciDegrees($0) })
+        self.roadType = roadType
+        self.confidence = confidence
+    }
+}
+
+/// The trace.
+public struct Trace: Codable {
+    /// The path history, a path with a set of path points
+    public let pathHistory: [PathHistory]
+
+    private static let maxPathHistory = 40
+
+    enum CodingKeys: String, CodingKey {
+        case pathHistory = "path_history"
+    }
+
+    init(pathHistory: [PathHistory]) {
+        self.pathHistory = Array(pathHistory.prefix(Self.maxPathHistory))
+    }
+}
+
+/// The road type.
+public enum RoadType: Int, Codable {
+    case urban_NoStructuralSeparationToOppositeLanes = 0
+    case urban_WithStructuralSeparationToOppositeLanes = 1
+    case nonUrban_NoStructuralSeparationToOppositeLanes = 2
+    case nonUrban_WithStructuralSeparationToOppositeLanes = 3
+
+    enum CodingKeys: String, CodingKey {
+        case urban_NoStructuralSeparationToOppositeLanes = "urban-NoStructuralSeparationToOppositeLanes"
+        case urban_WithStructuralSeparationToOppositeLanes = "urban-WithStructuralSeparationToOppositeLanes"
+        case nonUrban_NoStructuralSeparationToOppositeLanes = "nonUrban-NoStructuralSeparationToOppositeLanes"
+        case nonUrban_WithStructuralSeparationToOppositeLanes = "nonUrban-WithStructuralSeparationToOppositeLanes"
+    }
+}
+
+/// The location container confidence.
+public struct LocationContainerConfidence: Codable {
+    /// The event speed in  0.01 m/s.
+    public let etsiEventSpeed: Int?
+    /// The event position heading in 0.1 degrees.
+    public let etsiEventPositionHeading: Int?
+    public var eventSpeed: Double? {
+        etsiEventSpeed.map({ ETSI.centimetersPerSecondToMetersPerSecond($0)})
+    }
+    public var eventPositionHeading: Double? {
+        etsiEventPositionHeading.map({ ETSI.deciDegreesToDegrees($0)})
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case etsiEventSpeed = "event_speed"
+        case etsiEventPositionHeading = "event_position_heading"
+    }
+
+    init(eventSpeed: Double?, eventPositionHeading: Double?) {
+        self.etsiEventSpeed = eventSpeed.map({
+            ETSI.metersPerSecondToCentimetersPerSecond($0)
+        })
+        self.etsiEventPositionHeading = eventPositionHeading.map({
+            ETSI.degreesToDeciDegrees($0)
+        })
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/ManagementContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/ManagementContainer.swift
@@ -1,0 +1,144 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The management container.
+public struct ManagementContainer: Codable {
+    /// The action identifier.
+    public let actionID: ActionID
+    /// The time at which the event is detected by the originating ITS-S. For the DENM repetition, this DE shall remain.
+    /// Unit: millisecond since ETSI epoch (2004/01/01, so 1072915200000). 
+    public let etsiDetectionTime: Int
+    /// The time at which a new DENM, an update DENM or a cancellation DENM is generated.
+    /// Unit: millisecond since ETSI epoch (2004/01/01, so 1072915200000).
+    public let etsiReferenceTime: Int
+    /// The event position.
+    public let eventPosition: Position
+    /// The termination.
+    public let termination: Termination?
+    /// The relevance distance.
+    public let relevanceDistance: RelevanceDistance?
+    /// The relevance traffic direction
+    public let relevanceTrafficDirection: RelevanceTrafficDirection?
+    /// The validity duration in seconds.
+    public let validityDuration: Int?
+    /// The transmission interval in milliseconds.
+    public let etsiTransmissionInterval: Int?
+    /// The station type.
+    public let stationType: StationType?
+    /// The management container confidence.
+    public let confidence: Confidence?
+    /// The detection time since Unix Epoch in seconds.
+    public var detectionTime: TimeInterval {
+        ETSI.etsiMillisecondsToEpochTimestamp(etsiDetectionTime)
+    }
+    /// The reference time since Unix Epoch in seconds.
+    public var referenceTime: TimeInterval {
+        ETSI.etsiMillisecondsToEpochTimestamp(etsiReferenceTime)
+    }
+    /// The transmission interval in seconds.
+    public var transmissionInterval: TimeInterval? {
+        etsiTransmissionInterval.map({ Double($0) / 1000 })
+    }
+
+    private static let minValidityDuration: TimeInterval = 0
+    private static let maxValidityDuration: TimeInterval = 86400
+    public static let defaultValidityDuration: TimeInterval = 600
+
+    enum CodingKeys: String, CodingKey {
+        case actionID = "action_id"
+        case confidence
+        case etsiDetectionTime = "detection_time"
+        case eventPosition = "event_position"
+        case etsiReferenceTime = "reference_time"
+        case relevanceDistance = "relevance_distance"
+        case relevanceTrafficDirection = "relevance_traffic_direction"
+        case stationType = "station_type"
+        case termination
+        case etsiTransmissionInterval = "transmission_interval"
+        case validityDuration = "validity_duration"
+    }
+
+    init(
+        actionID: ActionID,
+        detectionTime: TimeInterval,
+        referenceTime: TimeInterval,
+        eventPosition: Position,
+        termination: Termination? = nil,
+        relevanceDistance: RelevanceDistance? = nil,
+        relevanceTrafficDirection: RelevanceTrafficDirection? = nil,
+        validityDuration: TimeInterval? = nil,
+        transmissionInterval: TimeInterval? = nil,
+        stationType: StationType? = .unknown,
+        confidence: Confidence? = nil
+    ) {
+        self.actionID = actionID
+        self.etsiDetectionTime = ETSI.epochTimestampToETSIMilliseconds(detectionTime)
+        self.etsiReferenceTime = ETSI.epochTimestampToETSIMilliseconds(referenceTime)
+        self.eventPosition = eventPosition
+        self.termination = termination
+        self.relevanceDistance = relevanceDistance
+        self.relevanceTrafficDirection = relevanceTrafficDirection
+        self.validityDuration = validityDuration.map({
+            Int(clip($0, Self.minValidityDuration, Self.maxValidityDuration))
+        })
+        self.etsiTransmissionInterval = transmissionInterval.map({ Int($0 * 1000) })
+        self.stationType = stationType
+        self.confidence = confidence
+    }
+}
+
+/// The action identifier.
+public struct ActionID: Codable {
+    /// The identifier of an its station.
+    public let originatingStationID: UInt32
+    /// The sequence number is set each time a new DENM is created. It is used to differentiate
+    /// from events detected by the same ITS-S.
+    public let sequenceNumber: UInt16
+
+    enum CodingKeys: String, CodingKey {
+        case originatingStationID = "originating_station_id"
+        case sequenceNumber = "sequence_number"
+    }
+
+    init(originatingStationID: UInt32) {
+        self.originatingStationID = originatingStationID
+        self.sequenceNumber = SequenceNumberGenerator.next()
+    }
+}
+
+/// The termination.
+public enum Termination: Int, Codable {
+    case isCancellation = 0
+    case isNegation = 1
+}
+
+/// The relevance distance.
+public enum RelevanceDistance: Int, Codable {
+    case lessThan50m = 0
+    case lessThan100m = 1
+    case lessThan200m = 2
+    case lessThan500m = 3
+    case lessThan1000m = 4
+    case lessThan5km = 5
+    case lessThan10km = 6
+    case over10km = 7
+}
+
+/// The relevance traffic direction.
+public enum RelevanceTrafficDirection: Int, Codable {
+    case allTrafficDirections = 0
+    case upstreamTraffic = 1
+    case downstreamTraffic = 2
+    case oppositeTraffic = 3
+}
+

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/Position.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/Position.swift
@@ -1,0 +1,40 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The position with coordinates and altitude.
+public struct Position: Codable {
+    /// The latitude in 0.1 microdegree.
+    public let etsiLatitude: Int
+    /// The longitude in 0.1 microdegree.
+    public let etsiLongitude: Int
+    /// The altitude in 0.01 meter.
+    public let etsiAltitude: Int
+    /// The latitiude in degrees.
+    public var latitude: Double { ETSI.deciMicroDegreesToDegrees(etsiLatitude) }
+    /// The longitude in degrees.
+    public var longitude: Double { ETSI.deciMicroDegreesToDegrees(etsiLongitude) }
+    /// The altitude in meters.
+    public var altitude: Double { ETSI.centimetersToMeters(etsiAltitude) }
+
+    enum CodingKeys: String, CodingKey {
+        case etsiLatitude = "latitude"
+        case etsiLongitude = "longitude"
+        case etsiAltitude = "altitude"
+    }
+
+    init(latitude: Double, longitude: Double, altitude: Double) {
+        self.etsiLatitude = ETSI.degreesToDeciMicroDegrees(latitude)
+        self.etsiLongitude = ETSI.degreesToDeciMicroDegrees(longitude)
+        self.etsiAltitude = ETSI.metersToCentimeters(altitude)
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/SituationContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/SituationContainer.swift
@@ -1,0 +1,86 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The situation container.
+public struct SituationContainer: Codable {
+    /// The event type.
+    public let eventType: Cause
+    /// The information quality.
+    public let informationQuality: Int?
+    /// The linked cause.
+    public let linkedCause: Cause?
+    private static let unavailableInformationQuality = 0
+    private static let maxInformationQuality = 7
+
+    enum CodingKeys: String, CodingKey {
+        case eventType = "event_type"
+        case informationQuality = "information_quality"
+        case linkedCause = "linked_cause"
+    }
+
+    init(
+        eventType: Cause,
+        informationQuality: Int? = nil,
+        linkedCause: Cause? = nil
+    ) {
+        self.eventType = eventType
+        self.informationQuality = informationQuality.map({
+            clip($0, Self.unavailableInformationQuality, Self.maxInformationQuality)
+        })
+        self.linkedCause = linkedCause
+    }
+}
+
+/// The cause.
+public struct Cause: Codable {
+    /// The cause.
+    public let cause: CauseType
+    /// The subcause
+    public let subcause: UInt8?
+
+    public init(cause: CauseType, subcause: UInt8? = nil) {
+        self.cause = cause
+        self.subcause = subcause
+    }
+}
+
+/// The cause type
+public enum CauseType: Int8, Codable {
+    case reserved = 0
+    case trafficCondition = 1
+    case accident = 2
+    case roadworks = 3
+    case adverseWeatherConditionAdhesion = 6
+    case hazardousLocationSurfaceCondition = 9
+    case hazardousLocationObstacleOnTheRoad = 10
+    case hazardousLocationAnimalOnTheRoad = 11
+    case humanPresenceOnTheRoad = 12
+    case wrongWayDriving = 14
+    case rescueAndRecoveryWorkInProgress = 15
+    case adverseWeatherConditionExtremeWeatherCondition = 17
+    case adverseWeatherConditionVisibility = 18
+    case adverseWeatherConditionPrecipitation = 19
+    case slowVehicle = 26
+    case dangerousEndOfQueue = 27
+    case vehicleBreakdown = 91
+    case postCrash = 92
+    case humanProblem = 93
+    case stationaryVehicle = 94
+    case emergencyVehicleApproaching = 95
+    case hazardousLocationDangerousCurve = 96
+    case collisionRisk = 97
+    case signalViolation = 98
+    case dangerousSituation = 99
+}
+
+

--- a/swift/ITSClient/Sources/ITSMobility/Models/ETSI.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/ETSI.swift
@@ -1,0 +1,105 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// A structure to make conversion for ESTI units.
+struct ETSI {
+    private static let deciMicroDegreesFactor: Double = 10_000_000
+    private static let etsiUnixEpochDifference = 1072915200
+    private static let centiSecondsFactor: Double = 100
+    private static let centimetersFactor: Double = 100
+    private static let decimetersFactor: Double = 10
+    private static let centimetersPerSecondFactor: Double = 100
+    private static let deciDegreesFactor: Double = 10
+    private static let centiDegreesPerSecondFactor: Double = 100
+    private static let decimetersPerSquaredSecondFactor: Double = 10
+
+    static func degreesToDeciMicroDegrees(_ degrees: Double) -> Int {
+        Int(degrees * deciMicroDegreesFactor)
+    }
+
+    static func deciMicroDegreesToDegrees(_ deciMicroDegrees: Int) -> Double {
+        Double(deciMicroDegrees) / deciMicroDegreesFactor
+    }
+
+    static func epochTimestampToETSIMilliseconds(_ epochTimestamp: TimeInterval) -> Int {
+        Int(Int(epochTimestamp * 1000) - (etsiUnixEpochDifference * 1000))
+    }
+
+    static func etsiMillisecondsToEpochTimestamp(_ etsiMilliseconds: Int) -> TimeInterval {
+        TimeInterval(etsiMilliseconds + etsiUnixEpochDifference * 1000) / 1000
+    }
+
+    static func epochTimestampToETSISeconds(_ epochTimestamp: TimeInterval) -> Int {
+        Int(epochTimestamp) - etsiUnixEpochDifference
+    }
+
+    static func secondsToCentiSeconds(_ seconds: TimeInterval) -> Int {
+        Int(seconds * centiSecondsFactor)
+    }
+
+    static func centiSecondsToSeconds(_ centiSeconds: Int) -> TimeInterval {
+        Double(centiSeconds) / centiSecondsFactor
+    }
+
+    static func metersToCentimeters(_ meters: Double) -> Int {
+        Int(meters * centimetersFactor)
+    }
+
+    static func centimetersToMeters(_ centimeters: Int) -> Double {
+        Double(centimeters) / centimetersFactor
+    }
+
+    static func metersToDecimeters(_ meters: Double) -> Int {
+        Int(meters * decimetersFactor)
+    }
+
+    static func decimetersToMeters(_ decimeters: Int) -> Double {
+        Double(decimeters) / decimetersFactor
+    }
+
+    static func metersPerSecondToCentimetersPerSecond(_ meters: Double) -> Int {
+        Int(meters * centimetersPerSecondFactor)
+    }
+
+    static func centimetersPerSecondToMetersPerSecond(_ centimetersPerSecond: Int) -> Double {
+        Double(centimetersPerSecond) / centimetersPerSecondFactor
+    }
+
+    static func degreesToDeciDegrees(_ degrees: Double) -> Int {
+        Int(degrees * deciDegreesFactor)
+    }
+
+    static func deciDegreesToDegrees(_ deciDegrees: Int) -> Double {
+        Double(deciDegrees) / deciDegreesFactor
+    }
+
+    static func degreesPerSecondToCentiDegreesPerSecond(_ degreesPerSecond: Double) -> Int {
+        Int(degreesPerSecond * centiDegreesPerSecondFactor)
+    }
+
+    static func centiDegreesPerSecondToDegreesPerSecond(_ centiDegreesPerSecond: Int) -> Double {
+        Double(centiDegreesPerSecond) / centiDegreesPerSecondFactor
+    }
+
+    static func metersPerSquaredSecondToDecimetersPerSquaredSecond(_ metersPerSquaredSecond: Double) -> Int {
+        Int(metersPerSquaredSecond * decimetersPerSquaredSecondFactor)
+    }
+
+    static func decimetersPerSquaredSecondToMetersPerSquaredSecond(_ decimetersPerSquaredSecond: Int) -> Double {
+        Double(decimetersPerSquaredSecond) / decimetersPerSquaredSecondFactor
+    }
+}
+
+@inlinable func clip<T>(_ value: T, _ minimum: T, _ maximum: T) -> T where T : Comparable {
+    min(max(minimum, value), maximum)
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/ETSI.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/ETSI.swift
@@ -14,6 +14,8 @@ import Foundation
 /// A structure to make conversion for ESTI units.
 struct ETSI {
     private static let deciMicroDegreesFactor: Double = 10_000_000
+    /// The ETSI reference date is the 2004-01-01 00:00:00 UTC.
+    /// This value is the number of seconds between the 1970-01-01T00:00:00Z and 2004-01-01T00:00:00Z.
     private static let etsiUnixEpochDifference = 1072915200
     private static let centiSecondsFactor: Double = 100
     private static let centimetersFactor: Double = 100

--- a/swift/ITSClient/Sources/ITSMobility/Models/MessageType.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/MessageType.swift
@@ -1,0 +1,20 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The message type.
+public enum MessageType: String, Codable {
+    case cam = "cam"
+    case cpm = "cpm"
+    case denm = "denm"
+    case po = "po"
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/Origin.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/Origin.swift
@@ -1,0 +1,20 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The entity responsible for this message.
+public enum Origin: String, Codable {
+    case globalApplication = "global_application"
+    case mecApplication = "mec_application"
+    case onBoardApplication = "on_board_application"
+    case originSelf = "self"
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/PathHistory.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/PathHistory.swift
@@ -1,0 +1,87 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The path history.
+public struct PathHistory: Codable {
+    /// The offset position of a detected event point with regards to the previous detected event point (event_position).
+    public let pathPosition: PathPosition
+    /// The time travelled by the detecting ITS-S since the previous detected event point (reference_time) in centiseconds.
+    public let etsiPathDeltaTime: Int16?
+    /// The time travelled by the detecting ITS-S since the previous detected event point (reference_time) in seconds.
+    public var pathDeltaTime: TimeInterval? {
+        etsiPathDeltaTime.map { ETSI.centiSecondsToSeconds(Int($0)) }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case etsiPathDeltaTime = "path_delta_time"
+        case pathPosition = "path_position"
+    }
+
+    init(pathPosition: PathPosition, pathDeltaTime: TimeInterval?) {
+        self.pathPosition = pathPosition
+        self.etsiPathDeltaTime = pathDeltaTime.map({ Int16(ETSI.secondsToCentiSeconds($0)) })
+    }
+}
+
+/// The path position.
+public struct PathPosition: Codable {
+    /// The delta latitude in 0.1 microdegree.
+    public let etsiDeltaLatitude: Int?
+    /// The delta longitude in 0.1 microdegree.
+    public let etsiDeltaLongitude: Int?
+    /// The delta altitude in 0.01 meter.
+    public let etsiDeltaAltitude: Int?
+    /// The delta latitiude in degrees.
+    public var deltaLatitude: Double? {
+        etsiDeltaLatitude.map({ ETSI.deciMicroDegreesToDegrees($0) })
+    }
+    /// The delta longitude in degrees.
+    public var deltaLongitude: Double? {
+        etsiDeltaLongitude.map({ ETSI.deciMicroDegreesToDegrees($0) })
+    }
+    /// The delta altitude in meters.
+    public var deltaAltitude: Double? {
+        etsiDeltaAltitude.map({ ETSI.centimetersToMeters($0) })
+    }
+
+    private static let minDeltaPosition = -131071
+    private static let maxDeltaPosition = 131072
+    private static let minDeltaAltitude = -12700
+    private static let maxDeltaAltitude = 12800
+    static let deltaPositionUnavailable = ETSI.deciMicroDegreesToDegrees(Self.maxDeltaPosition)
+    static let unavailableDeltaAltitude = ETSI.centimetersToMeters(Self.maxDeltaAltitude)
+
+    public enum CodingKeys: String, CodingKey {
+        case etsiDeltaAltitude = "delta_altitude"
+        case etsiDeltaLatitude = "delta_latitude"
+        case etsiDeltaLongitude = "delta_longitude"
+    }
+
+    init(deltaLatitude: Double?, deltaLongitude: Double?, deltaAltitude: Double?) {
+        self.etsiDeltaLatitude = deltaLatitude.map({
+            clip(ETSI.degreesToDeciMicroDegrees($0),
+                 Self.minDeltaPosition,
+                 Self.maxDeltaPosition)
+        })
+        self.etsiDeltaLongitude = deltaLongitude.map({
+            clip(ETSI.degreesToDeciMicroDegrees($0),
+                 Self.minDeltaPosition,
+                 Self.maxDeltaPosition)
+        })
+        self.etsiDeltaAltitude = deltaAltitude.map({
+            clip(ETSI.metersToCentimeters($0),
+                 Self.minDeltaAltitude,
+                 Self.maxDeltaAltitude)
+        })
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/SequenceNumberGenerator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/SequenceNumberGenerator.swift
@@ -1,0 +1,24 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// Generates an incremental sequence number.
+/// If the number overflows `maxSequenceNumber`, the sequence number sequence is started over.
+actor SequenceNumberGenerator {
+    private static var sequenceNumber: UInt16 = 0
+    private static let maxSequenceNumber = 65535
+
+    static func next() -> UInt16 {
+        sequenceNumber = UInt16((Int(sequenceNumber) + 1) % (maxSequenceNumber + 1))
+        return sequenceNumber
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/StationType.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/StationType.swift
@@ -1,0 +1,30 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+/// The station type.
+public enum StationType: Int, Codable {
+    case unknown = 0
+    case pedestrian = 1
+    case cyclist = 2
+    case moped = 3
+    case motorcycle = 4
+    case passengerCar = 5
+    case bus = 6
+    case lightTruck = 7
+    case heavyTruck = 8
+    case trailer = 9
+    case specialVehicles = 10
+    case tram = 11
+    case roadSideUnit = 15
+}
+

--- a/swift/ITSClient/Tests/ITSClient-UnitTests.xctestplan
+++ b/swift/ITSClient/Tests/ITSClient-UnitTests.xctestplan
@@ -32,6 +32,13 @@
         "identifier" : "ITSCoreTests",
         "name" : "ITSCoreTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ITSMobilityTests",
+        "name" : "ITSMobilityTests"
+      }
     }
   ],
   "version" : 2

--- a/swift/ITSClient/Tests/ITSMobilityTests/CAMTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/CAMTests.swift
@@ -1,0 +1,127 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import Testing
+@testable import ITSMobility
+
+struct CAMTests {
+    private let latitude = 44.7758076
+    private let longitude = -0.6528173
+    private let altitude = 81.44
+    private let semiMajorConfidence = 10
+    private let semiMajorOrientation = 1
+    private let semiMinorConfidence = 50
+    private let altitudeConfidence = AltitudeConfidence.alt_000_02
+    private let stationType = StationType.passengerCar
+    private let headingConfidence = 0.2
+    private let speedConfidence = 0.03
+    private let vehiculeLengthConfidence = VehiculeLengthConfidence.noTrailerPresent
+    private let heading = 303.7
+    private let speed = 0.21
+    private let driveDirection = DriveDirection.forward
+    private let vehicleLength = 4.0
+    private let vehicleWidth = 2.0
+    private let longitudinalAcceleration = HighFrequencyContainer.unavailableAcceleration
+    private let stationID: UInt32 = 123456
+    private let dateComponents = DateComponents(calendar: .init(identifier: .gregorian),
+                                                timeZone: TimeZone.gmt,
+                                                year: 2025,
+                                                month: 3,
+                                                day: 25,
+                                                hour: 8,
+                                                minute: 12,
+                                                second: 26,
+                                                nanosecond: 165 * 1_000_000) // Milliseconds
+    private let sourceUUID = "v2x_12345678"
+
+    @Test("CAM JSON should be decoded correctly")
+    func cam_json_should_be_decoded_correctly() throws {
+        // Given
+        let camData = try FileLoader.loadJSONFile("Cam")
+
+        // When
+        let cam = try JSONDecoder().decode(CAM.self, from: camData)
+
+        // Then
+        assertCAM(cam)
+    }
+
+    @Test("CAM JSON should be encoded correctly")
+    func cam_json_should_be_encoded_correctly() throws {
+        // Given
+        let position = Position(latitude: latitude, longitude: longitude, altitude: altitude)
+        let positionConfidence = PositionConfidenceEllipse(semiMajorConfidence: semiMajorConfidence,
+                                                           semiMajorOrientation: semiMajorOrientation,
+                                                           semiMinorConfidence: semiMinorConfidence)
+        let confidence = Confidence(altitude: altitudeConfidence,
+                                    positionConfidenceEllipse: positionConfidence)
+        let basicContainer = BasicContainer(stationType: stationType,
+                                            referencePosition: position,
+                                            confidence: confidence)
+        let highFrequencyConfidence = HighFrequencyContainerConfidence(heading: headingConfidence,
+                                                                       speed: speedConfidence,
+                                                                       vehicleLength: vehiculeLengthConfidence)
+        let highFrequencyContainer = HighFrequencyContainer(heading: heading,
+                                                            speed: speed,
+                                                            driveDirection: driveDirection,
+                                                            vehicleLength: vehicleLength,
+                                                            vehicleWidth: vehicleWidth,
+                                                            longitudinalAcceleration: longitudinalAcceleration,
+                                                            confidence: highFrequencyConfidence)
+        let camMessage = CAMMessage(stationID: stationID,
+                                    generationDeltaTime: 1742890411.638,
+                                    basicContainer: basicContainer,
+                                    highFrequencyContainer: highFrequencyContainer)
+        let date = try #require(dateComponents.date)
+        let cam = CAM(message: camMessage,
+                      sourceUUID: sourceUUID,
+                      timestamp: date.timeIntervalSince1970)
+        // When
+        let encodedData = try JSONEncoder().encode(cam)
+        let decodedCAM = try JSONDecoder().decode(CAM.self, from: encodedData)
+
+        // Then
+        assertCAM(decodedCAM)
+    }
+
+    private func assertCAM(_ cam: CAM) {
+        #expect(cam.origin == Origin.originSelf)
+        #expect(cam.version == "1.1.3")
+        #expect(cam.type == MessageType.cam)
+        #expect(cam.sourceUUID == sourceUUID)
+        #expect(Date(timeIntervalSince1970: cam.timestamp) == dateComponents.date)
+        #expect(cam.message.protocolVersion == 1)
+        #expect(cam.message.stationID == stationID)
+        #expect(cam.message.etsiGenerationDeltaTime == 28278)
+        let basicContainer = cam.message.basicContainer
+        #expect(basicContainer.stationType == stationType)
+        #expect(basicContainer.referencePosition.latitude == latitude)
+        #expect(basicContainer.referencePosition.longitude == longitude)
+        #expect(basicContainer.referencePosition.altitude == altitude)
+        #expect(basicContainer.confidence?.positionConfidenceEllipse?.semiMajorConfidence == semiMajorConfidence)
+        #expect(basicContainer.confidence?.positionConfidenceEllipse?.semiMinorConfidence == semiMinorConfidence)
+        #expect(basicContainer.confidence?.positionConfidenceEllipse?.semiMajorOrientation == semiMajorOrientation)
+        #expect(basicContainer.confidence?.altitude == altitudeConfidence)
+        let highFrequencyContainer = cam.message.highFrequencyContainer
+        #expect(highFrequencyContainer?.heading == heading)
+        #expect(highFrequencyContainer?.speed == speed)
+        #expect(highFrequencyContainer?.longitudinalAcceleration == longitudinalAcceleration)
+        #expect(highFrequencyContainer?.driveDirection == driveDirection)
+        #expect(highFrequencyContainer?.vehicleLength == vehicleLength)
+        #expect(highFrequencyContainer?.vehicleWidth == vehicleWidth)
+        #expect(highFrequencyContainer?.confidence?.heading == headingConfidence)
+        #expect(highFrequencyContainer?.confidence?.speed == speedConfidence)
+        #expect(highFrequencyContainer?.confidence?.vehicleLength == vehiculeLengthConfidence)
+        #expect(cam.message.lowFrequencyContainer == nil)
+    }
+}
+

--- a/swift/ITSClient/Tests/ITSMobilityTests/DENMTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/DENMTests.swift
@@ -1,0 +1,118 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import Testing
+@testable import ITSMobility
+
+struct DENMTests {
+    private let origin = Origin.mecApplication
+    private let latitude = 43.5657439
+    private let longitude = 1.4681494
+    private let altitude = 46.0
+    private let relevanceDistance = RelevanceDistance.lessThan50m
+    private let relevanceTrafficDirection = RelevanceTrafficDirection.upstreamTraffic
+    private let validityDuration = 10
+    private let transmissionInterval = 0.2
+    private let stationType = StationType.passengerCar
+    private let stationID: UInt32 = 654321
+    private let originatingStationID: UInt32 = 10000
+    private let dateComponents = DateComponents(calendar: .init(identifier: .gregorian),
+                                                timeZone: TimeZone.gmt,
+                                                year: 2025,
+                                                month: 3,
+                                                day: 26,
+                                                hour: 10,
+                                                minute: 21,
+                                                second: 43,
+                                                nanosecond: 586 * 1_000_000) // Milliseconds
+    // Wednesday 26 March 2025 10:21:43.586
+    private let sourceUUID = "v2x_87654321"
+    private let causeType = CauseType.slowVehicle
+    private let eventPositionHeading = 145.3
+    private let eventSpeed = 0.14
+
+    @Test("DENM JSON should be decoded correctly")
+    func denm_json_should_be_decoded_correctly() throws {
+        // Given
+        let denmData = try FileLoader.loadJSONFile("Denm")
+
+        // When
+        let denm = try JSONDecoder().decode(DENM.self, from: denmData)
+
+        // Then
+        assertDENM(denm)
+    }
+
+    @Test("DENM JSON should be encoded correctly")
+    func denm_json_should_be_encoded_correctly() throws {
+        // Given
+        let date = try #require(dateComponents.date)
+        let actionID = ActionID(originatingStationID: originatingStationID)
+        let position = Position(latitude: latitude, longitude: longitude, altitude: altitude)
+        let managementContainer = ManagementContainer(actionID: actionID,
+                                                      detectionTime: date.timeIntervalSince1970,
+                                                      referenceTime: date.timeIntervalSince1970,
+                                                      eventPosition: position,
+                                                      relevanceDistance: relevanceDistance,
+                                                      relevanceTrafficDirection: relevanceTrafficDirection,
+                                                      validityDuration: TimeInterval(validityDuration),
+                                                      transmissionInterval: transmissionInterval,
+                                                      stationType: stationType)
+        let situationContainer = SituationContainer(eventType: Cause(cause: causeType, subcause: 0))
+        let locationContainer = LocationContainer(eventSpeed: eventSpeed, eventPositionHeading: eventPositionHeading)
+        let demMessage = DENMMessage(stationID: stationID,
+                                     managementContainer: managementContainer,
+                                     situationContainer: situationContainer,
+                                     locationContainer: locationContainer)
+        let denm = DENM(message: demMessage,
+                        origin: origin,
+                        sourceUUID: sourceUUID,
+                        timestamp: date.timeIntervalSince1970)
+
+        // When
+        let encodedData = try JSONEncoder().encode(denm)
+        let decodedDENM = try JSONDecoder().decode(DENM.self, from: encodedData)
+
+        // Then
+        assertDENM(decodedDENM)
+    }
+
+    private func assertDENM(_ denm: DENM) {
+        #expect(denm.origin == origin)
+        #expect(denm.version == "1.1.3")
+        #expect(denm.type == MessageType.denm)
+        #expect(denm.sourceUUID == sourceUUID)
+        #expect(Date(timeIntervalSince1970: denm.timestamp) == dateComponents.date)
+        #expect(denm.message.protocolVersion == 1)
+        #expect(denm.message.stationID == stationID)
+        let managementContainer = denm.message.managementContainer
+        #expect(managementContainer.stationType == stationType)
+        #expect(managementContainer.actionID.originatingStationID == originatingStationID)
+        #expect(managementContainer.detectionTime == dateComponents.date?.timeIntervalSince1970)
+        #expect(managementContainer.referenceTime == dateComponents.date?.timeIntervalSince1970)
+        #expect(managementContainer.eventPosition.latitude == latitude)
+        #expect(managementContainer.eventPosition.longitude == longitude)
+        #expect(managementContainer.eventPosition.altitude == altitude)
+        #expect(managementContainer.transmissionInterval == transmissionInterval)
+        #expect(managementContainer.validityDuration == validityDuration)
+        #expect(managementContainer.relevanceDistance == relevanceDistance)
+        #expect(managementContainer.relevanceTrafficDirection == relevanceTrafficDirection)
+        let situationContainer = denm.message.situationContainer
+        #expect(situationContainer?.eventType.cause == causeType)
+        #expect(situationContainer?.eventType.subcause == 0)
+        let locationContainer = denm.message.locationContainer
+        #expect(locationContainer?.eventPositionHeading == eventPositionHeading)
+        #expect(locationContainer?.eventSpeed == eventSpeed)
+        #expect(locationContainer?.traces.isEmpty ?? false)
+        #expect(denm.message.alacarteContainer == nil)
+    }
+}

--- a/swift/ITSClient/Tests/ITSMobilityTests/Data/Cam.json
+++ b/swift/ITSClient/Tests/ITSMobilityTests/Data/Cam.json
@@ -1,0 +1,41 @@
+{
+    "type": "cam",
+    "origin": "self",
+    "version": "1.1.3",
+    "source_uuid": "v2x_12345678",
+    "timestamp": 1742890346165,
+    "message": {
+        "protocol_version": 1,
+        "station_id": 123456,
+        "generation_delta_time": 28278,
+        "basic_container": {
+            "station_type": 5,
+            "reference_position": {
+                "latitude": 447758076,
+                "longitude": -6528173,
+                "altitude": 8144
+            },
+            "confidence": {
+                "position_confidence_ellipse": {
+                    "semi_major_confidence": 10,
+                    "semi_minor_confidence": 50,
+                    "semi_major_orientation": 1
+                },
+                "altitude": 1
+            }
+        },
+        "high_frequency_container": {
+            "heading": 3037,
+            "speed": 21,
+            "longitudinal_acceleration": 161,
+            "drive_direction": 0,
+            "vehicle_length": 40,
+            "vehicle_width": 20,
+            "confidence": {
+                "heading": 2,
+                "speed": 3,
+                "vehicle_length": 0
+            }
+        }
+    }
+}

--- a/swift/ITSClient/Tests/ITSMobilityTests/Data/Denm.json
+++ b/swift/ITSClient/Tests/ITSMobilityTests/Data/Denm.json
@@ -1,0 +1,40 @@
+{
+    "type": "denm",
+    "origin": "mec_application",
+    "version": "1.1.1",
+    "source_uuid": "v2x_87654321",
+    "timestamp": 1742984503586,
+    "message": {
+        "protocol_version": 1,
+        "station_id": 654321,
+        "management_container": {
+            "action_id": {
+                "originating_station_id": 10000,
+                "sequence_number": 1
+            },
+            "detection_time": 670069303586,
+            "reference_time": 670069303586,
+            "event_position": {
+                "latitude": 435657439,
+                "longitude": 14681494,
+                "altitude": 4600
+            },
+            "relevance_distance": 0,
+            "relevance_traffic_direction": 1,
+            "validity_duration": 10,
+            "transmission_interval": 200,
+            "station_type": 5
+        },
+        "situation_container": {
+            "event_type": {
+                "cause": 26,
+                "subcause": 0
+            }
+        },
+        "location_container": {
+            "event_speed": 14,
+            "event_position_heading": 1453,
+            "traces": []
+        }
+    }
+}

--- a/swift/ITSClient/Tests/ITSMobilityTests/FileLoader.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/FileLoader.swift
@@ -1,0 +1,21 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+struct FileLoader {
+    static func loadJSONFile(_ filename: String) throws -> Data {
+        guard let fileURL = Bundle.module.url(forResource: "Data/\(filename)", withExtension: "json") else {
+            fatalError("File \(filename).json not found")
+        }
+        return try Data(contentsOf: fileURL)
+    }
+}


### PR DESCRIPTION
**What's new**

Add the CAM and DENM objects. Allow to encode or decode the objects in JSON.

---
**How to test**

Just check the code and the unit tests to be sure that the schemas are respected.

Closes #341