### PR TITLE
github: make PR templates somewhat usable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/README
+++ b/.github/PULL_REQUEST_TEMPLATE/README
@@ -1,0 +1,2 @@
+When adding a new template here, be sure to update the list in the
+generic template: .github/pull_request_template.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+Go to the `Preview`, right above, and select the appropriate template in the list:
+
+* [Python](?expand=1&template=python.md)
+
+If no template matches your changes, remove this whole text, and enter your own description with the following information:
+
+* In the title text:
+    * the main impacted component
+    * a short summary of the changes
+* In the description:
+    * a human-readable summary of the changes, with a focus on semantics rather than technical details (unless that's really important)
+    * a list of issues this PR closes
+    * the sequence of steps to test the changes
+    * the expected result for each steps in 3, above


### PR DESCRIPTION
**Changes:**

* github: add a generic PR template

* Closes: #345 

Note: it is not possible to test this until it has landed in the master branch, as GitHub only takes templates from there.