### PR TITLE
swift: send position and alert

### DIFF
--- a/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/CoreConfiguration.swift
@@ -11,8 +11,10 @@
 
 /// A structure to configure the core.
 public struct CoreConfiguration: Sendable {
-    let mqttClientConfiguration: MQTTClientConfiguration
-    let telemetryClientConfiguration: TelemetryClientConfiguration?
+    /// The MQTT client configuration.
+    public let mqttClientConfiguration: MQTTClientConfiguration
+    /// The telemetry client configuration.
+    public let telemetryClientConfiguration: TelemetryClientConfiguration?
 
     /// Initializes a `CoreConfiguration`.
     /// - Parameters:

--- a/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/MQTT/MQTTClientConfiguration.swift
@@ -11,13 +11,20 @@
 
 /// A structure to configure a MQTT client.
 public struct MQTTClientConfiguration: Sendable {
-    let host: String
-    let port: Int
-    let clientIdentifier: String
-    let userName: String?
-    let password: String?
-    let useSSL: Bool
-    let useWebSockets: Bool
+    /// The MQTT server host.
+    public let host: String
+    /// The MQTT server port.
+    public let port: Int
+    /// The MQTT client identifier.
+    public let clientIdentifier: String
+    /// The MQTT user name if authentication is enabled on the server.
+    public let userName: String?
+    /// The MQTT password if authentication is enabled on the server.
+    public let password: String?
+    /// `true` if an encrypted connection to the server is used.
+    public let useSSL: Bool
+    /// `true` if a websocket connection to the server is used.
+    public let useWebSockets: Bool
 
     /// Initializes a `MQTTClientConfiguration`.
     /// - Parameters:

--- a/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSCore/Telemetry/TelemetryClientConfiguration.swift
@@ -13,12 +13,18 @@ import Foundation
 
 /// A structure to configure a telemetry client.
 public struct TelemetryClientConfiguration: Sendable {
-    let url: URL
-    let user: String?
-    let password: String?
-    let serviceName: String
-    let scheduleDelay: TimeInterval
-    let batchSize: Int
+    /// The server url.
+    public let url: URL
+    /// The user name if authentication is enabled on the server.
+    public let user: String?
+    /// The password if authentication is enabled on the server.
+    public let password: String?
+    /// The service name to use.
+    public let serviceName: String
+    /// The delay to send spans (Default: 5 seconds).
+    public let scheduleDelay: TimeInterval
+    /// The maximum of spans to send in a batch (Default: 50).
+    public let batchSize: Int
 
     /// Initializes a `TelemetryClientConfiguration`.
     /// - Parameters:

--- a/swift/ITSClient/Sources/ITSMobility/Mobility.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Mobility.swift
@@ -15,22 +15,100 @@ import Foundation
 /// An object that manages a mobility client using the `Core`.
 public actor Mobility {
     private let core: Core
-
+    private var mobilityConfiguration: MobilityConfiguration?
+    
     /// Initializes a `Mobility`.
     public init() {
         core = Core()
     }
-
+    
     /// Starts the `Mobility` with a configuration to connect to a MQTT server and initialize the telemetry client.
-    /// - Parameter coreConfiguration: The configuration used to start the MQTT client and the telemetry client.
-    /// - Throws: A `CoreError` if the MQTT connection fails.
-    public func start(coreConfiguration: CoreConfiguration) async throws(CoreError) {
-        try await core.start(coreConfiguration: coreConfiguration)
+    /// - Parameter mobilityConfiguration: The configuration used to start the mobility including `CoreConfiguration`.
+    /// - Throws: A `MobilityError` if the MQTT connection fails.
+    public func start(mobilityConfiguration: MobilityConfiguration) async throws(MobilityError) {
+        self.mobilityConfiguration = mobilityConfiguration
+        do {
+            try await core.start(coreConfiguration: mobilityConfiguration.coreConfiguration)
+        } catch {
+            throw .startFailed(error)
+        }
     }
-
+    
     /// Stops the `Mobility` disconnecting the MQTT client and stopping the telemetry client.
-    /// - Throws: A `CoreError` if the MQTT unsubscriptions or disconnection fails.
-    public func stop() async throws(CoreError) {
-        try await core.stop()
+    /// - Throws: A `MobilityError` if the MQTT unsubscriptions or disconnection fails.
+    public func stop() async throws(MobilityError) {
+        do {
+            try await core.stop()
+        } catch {
+            throw .stopFailed(error)
+        }
+    }
+    
+    /// Sends a position to share it.
+    /// - Parameters:
+    ///   - latitude: The latitude in decimal degrees.
+    ///   - longitude: The longitude in decimal degrees.
+    ///   - altitude: The altitude in meters.
+    ///   - heading: The heading in degrees.
+    ///   - speed: The speed in meters per second.
+    ///   - acceleration: The longitudinal acceleration in meters per squared second.
+    ///   - yawRate: The rotational acceleration in degrees per squared second.
+    public func sendPosition(
+        latitude: Double,
+        longitude: Double,
+        altitude: Double,
+        heading: Double?,
+        speed: Double?,
+        acceleration: Double? = nil,
+        yawRate: Double? = nil
+    ) async throws(MobilityError) {
+        guard let mobilityConfiguration else { throw .notStarted }
+
+        // Build CAM
+        let now = Date().timeIntervalSince1970
+        let position = Position(latitude: latitude, longitude: longitude, altitude: altitude)
+        let basicContainer = BasicContainer(stationType: mobilityConfiguration.stationType,
+                                            referencePosition: position)
+        let highFrequencyContainer = HighFrequencyContainer(heading: heading,
+                                                            speed: speed,
+                                                            longitudinalAcceleration: acceleration,
+                                                            yawRate: yawRate)
+        let camMessage = CAMMessage(stationID: mobilityConfiguration.stationID,
+                                    generationDeltaTime: now,
+                                    basicContainer: basicContainer,
+                                    highFrequencyContainer: highFrequencyContainer)
+        let cam = CAM(message: camMessage,
+                      sourceUUID: mobilityConfiguration.userIdentifier,
+                      timestamp: now)
+        
+        // Publish CAM
+        let quadkey = QuadkeyBuilder().quadkeyFrom(latitude: latitude,
+                                                   longitude: longitude,
+                                                   zoomLevel: mobilityConfiguration.reportZoomLevel,
+                                                   separator: "/")
+        try await publish(cam, topic: try topic(for: .cam, in: quadkey))
+    }
+    
+    private func publish<T: Codable>(_ payload: T, topic: String) async throws(MobilityError) {
+        do {
+            let coreMQTTMessage = CoreMQTTMessage(payload: try JSONEncoder().encode(payload),
+                                                  topic: topic)
+            try await core.publish(message: coreMQTTMessage)
+        } catch let error as CoreError {
+            throw .payloadPublishingFailed(error)
+        } catch {
+            throw .payloadEncodingFailed
+        }
+    }
+    
+    private func topic(
+        for messageType: MessageType,
+        in quadkey: String
+    ) throws(MobilityError) -> String {
+        guard let mobilityConfiguration else { throw .notStarted }
+        
+        let namespace = mobilityConfiguration.namespace
+        let userIdentifier = mobilityConfiguration.userIdentifier
+        return "\(namespace)/inQueue/v2x/\(messageType.rawValue)/\(userIdentifier)/\(quadkey)"
     }
 }

--- a/swift/ITSClient/Sources/ITSMobility/MobilityConfiguration.swift
+++ b/swift/ITSClient/Sources/ITSMobility/MobilityConfiguration.swift
@@ -1,0 +1,53 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import ITSCore
+
+/// A structure to configure the mobility.
+public struct MobilityConfiguration: Sendable {
+    /// The `CoreConfiguration` which includes MQTT and telemetry configurations.
+    public let coreConfiguration: CoreConfiguration
+    /// The station identifier. Must be unique and the same each time on a same device.
+    public let stationID: UInt32
+    /// The `StationType` of the user.
+    public let stationType: StationType
+    /// The namespace used in the MQTT topic.
+    public let namespace: String
+    /// The zoom level used when a position or an alert is sent.
+    public let reportZoomLevel: Int
+
+    var userIdentifier: String {
+        coreConfiguration.mqttClientConfiguration.clientIdentifier
+    }
+
+    /// Initializes a `MobilityConfiguration`.
+    /// - Parameters:
+    ///   - coreConfiguration: The `CoreConfiguration` which includes MQTT and telemetry configurations.
+    ///   - stationID: The station identifier. Must be unique and the same each time on a same device.
+    ///   - stationType: The `StationType` of the user.
+    ///   - namespace: The namespace used in the MQTT topic.
+    ///   - reportZoomLevel: The zoom level used when a position or an alert is sent.
+    public init(
+        coreConfiguration: CoreConfiguration,
+        stationID: UInt32,
+        stationType: StationType = .unknown,
+        namespace: String = "default",
+        reportZoomLevel: Int = 22
+    ) {
+        self.coreConfiguration = coreConfiguration
+        self.stationID = stationID
+        self.stationType = stationType
+        self.namespace = namespace
+        self.reportZoomLevel = reportZoomLevel
+    }
+}
+

--- a/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
+++ b/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
@@ -1,0 +1,27 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import ITSCore
+
+/// The errors thrown by the mobility.
+public enum MobilityError: Error {
+    /// The mobilty start failed.
+    case startFailed(CoreError)
+    /// The mobility stop failed.
+    case stopFailed(CoreError)
+    /// The mobility must be started before performing this action.
+    case notStarted
+    /// The payload encoding failed.
+    case payloadEncodingFailed
+    /// The payload publishing failed.
+    case payloadPublishingFailed(CoreError)
+}

--- a/swift/ITSClient/Sources/ITSMobility/Models/DENM/SituationContainer.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/DENM/SituationContainer.swift
@@ -55,7 +55,7 @@ public struct Cause: Codable {
 }
 
 /// The cause type
-public enum CauseType: Int8, Codable {
+public enum CauseType: Int8, Codable, Sendable {
     case reserved = 0
     case trafficCondition = 1
     case accident = 2

--- a/swift/ITSClient/Sources/ITSMobility/Models/StationType.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Models/StationType.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 /// The station type.
-public enum StationType: Int, Codable {
+public enum StationType: Int, Codable, Sendable {
     case unknown = 0
     case pedestrian = 1
     case cyclist = 2

--- a/swift/ITSClient/Tests/ITSClient-IntegrationTests.xctestplan
+++ b/swift/ITSClient/Tests/ITSClient-IntegrationTests.xctestplan
@@ -26,6 +26,26 @@
         "identifier" : "ITSCoreTests",
         "name" : "ITSCoreTests"
       }
+    },
+    {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "CAMTests"
+          },
+          {
+            "name" : "DENMTests"
+          },
+          {
+            "name" : "QuadkeyBuilderTests"
+          }
+        ]
+      },
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ITSMobilityTests",
+        "name" : "ITSMobilityTests"
+      }
     }
   ],
   "version" : 2

--- a/swift/ITSClient/Tests/ITSClient-UnitTests.xctestplan
+++ b/swift/ITSClient/Tests/ITSClient-UnitTests.xctestplan
@@ -34,6 +34,13 @@
       }
     },
     {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "MobilityTests"
+          }
+        ]
+      },
       "target" : {
         "containerPath" : "container:",
         "identifier" : "ITSMobilityTests",

--- a/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
@@ -1,0 +1,50 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import ITSCore
+import Testing
+@testable import ITSMobility
+
+struct MobilityTests {
+    private let mobility: Mobility
+    private let mobilityConfiguration: MobilityConfiguration
+
+    init() throws {
+        mobility = Mobility()
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "test.mosquitto.org",
+                                                              port: 1883,
+                                                              clientIdentifier: UUID().uuidString,
+                                                              useSSL: false)
+        let url = try #require(URL(string: "http://localhost:4318"))
+        let telemetryClientConfiguration = TelemetryClientConfiguration(url: url,
+                                                                        serviceName: "its-tests-service")
+        let coreConfiguration = CoreConfiguration(mqttClientConfiguration: mqttClientConfiguration,
+                                                  telemetryClientConfiguration: telemetryClientConfiguration)
+        mobilityConfiguration = MobilityConfiguration(coreConfiguration: coreConfiguration,
+                                                      stationID: UInt32.random(in: 0..<UInt32.max))
+    }
+
+    @Test("Send position should send a payload on a topic computed from coordinates")
+    func send_position_should_send_payload_on_topic_computed_from_coordinates() async throws {
+        try await mobility.start(mobilityConfiguration: mobilityConfiguration)
+        try await mobility.sendPosition(latitude: 43.63516355648167,
+                                        longitude: 1.3744570239910097,
+                                        altitude: 155,
+                                        heading: 45,
+                                        speed: 8.1)
+        try await mobility.stop()
+        // Wait a bit for the spans flush
+        try await Task.sleep(for: .seconds(0.5))
+    }
+}
+
+

--- a/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
@@ -45,6 +45,18 @@ struct MobilityTests {
         // Wait a bit for the spans flush
         try await Task.sleep(for: .seconds(0.5))
     }
+
+    @Test("Send alert should send a payload on a topic computed from coordinates")
+    func send_alert_should_send_payload_on_topic_computed_from_coordinates() async throws {
+        try await mobility.start(mobilityConfiguration: mobilityConfiguration)
+        try await mobility.sendAlert(latitude: 43.63516355648167,
+                                     longitude: 1.3744570239910097,
+                                     altitude: 155,
+                                     cause: .trafficCondition)
+        try await mobility.stop()
+        // Wait a bit for the spans flush
+        try await Task.sleep(for: .seconds(0.5))
+    }
 }
 
 


### PR DESCRIPTION
**What's new**

Add a method to send a position : build a CAM and send the encoded json in the relevant MQTT topic.
Add a method to send an alarm : build a DENM and send the encoded json in the relevant MQTT topic.

---
**How to test**

1. Clone the its-client project and check out the branch under review
2. Run a local OpenTelemetry collector with a http endpoint on port 4318:
    ```sh
     $ docker container run \
          --rm \
          -p 16686:16686 \
          -p 4318:4318 \
          jaegertracing/all-in-one:1.58
     ```
3. Run the test MobilityTests.send_position_should_send_payload_on_topic_computed_from_coordinates:
    ```sh
    swift test --filter MobilityTests.send_position_should_send_payload_on_topic_computed_from_coordinates
    ```
   Expected result:  Check on the Jaeger UI (on http://localhost:16686/) that a producer span is created with the following iot3.core.mqtt.topic property value: default/inQueue/v2x/cam/X/1/2/0/2/2/2/0/2/1/3/3/3/1/0/3/0/0/0/3/3/2/1
(X is a random UDID)
4. Run the test MobilityTests.send_alert_should_send_payload_on_topic_computed_from_coordinates:
    ```sh
    swift test --filter MobilityTests.send_alert_should_send_payload_on_topic_computed_from_coordinates
    ```
   Expected result:  Check on the Jaeger UI (on http://localhost:16686/) that a producer span is created with the following iot3.core.mqtt.topic property value: default/inQueue/v2x/denm/X/1/2/0/2/2/2/0/2/1/3/3/3/1/0/3/0/0/0/3/3/2/1
(X is a random UDID)

Closes #357 