### PR TITLE
swift: region of interest

### DIFF
--- a/swift/ITSClient/Sources/ITSMobility/Mobility.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Mobility.swift
@@ -149,6 +149,25 @@ public actor Mobility {
         await updateSubscriptions(topicUpdateRequest: topicUpdateRequest)
     }
 
+    /// Updates the road position region of interest according the coordinates and the zoom level.
+    /// - Parameters:
+    ///   - latitude: The latitude in decimal degrees.
+    ///   - longitude: The longitude in decimal degrees.
+    ///   - zoomLevel: The zoom level.
+    public func updateRoadPositionRegionOfInterest(
+        latitude: Double,
+        longitude: Double,
+        zoomLevel: Int) async throws(MobilityError) {
+        guard let mobilityConfiguration else { throw .notStarted }
+
+        let topicUpdateRequest = regionOfInterestCoordinator.updateRoadPositionRegionOfInterest(
+            latitude: latitude,
+            longitude: longitude,
+            zoomLevel: zoomLevel,
+            namespace: mobilityConfiguration.namespace)
+        await updateSubscriptions(topicUpdateRequest: topicUpdateRequest)
+    }
+
     private func publish<T: Codable>(_ payload: T, topic: String) async throws(MobilityError) {
         do {
             let coreMQTTMessage = CoreMQTTMessage(payload: try JSONEncoder().encode(payload),

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterest.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterest.swift
@@ -1,0 +1,21 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+struct RegionOfInterest {
+    let quadkey: String
+    let neighborQuadkeys: [String]
+
+    var allQuadkeys: [String] {
+        [quadkey] + neighborQuadkeys
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
@@ -1,0 +1,110 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+
+final class RegionOfInterestCoordinator {
+    struct TopicUpdateRequest {
+        let subscriptions: [String]
+        let unsubscriptions: [String]
+    }
+
+    private let quadkeyBuilder = QuadkeyBuilder()
+    private var currentDENMRegionOfInterest: RegionOfInterest?
+    private var currentCAMRegionOfInterest: RegionOfInterest?
+
+    func updateRoadAlarmRegionOfInterest(
+        latitude: Double,
+        longitude: Double,
+        zoomLevel: Int,
+        namespace: String
+    ) -> TopicUpdateRequest? {
+        updateRegionOfInterest(for: .denm,
+                               latitude: latitude,
+                               longitude: longitude,
+                               zoomLevel: zoomLevel,
+                               namespace: namespace,
+                               currentRegionOfInterest: &currentDENMRegionOfInterest)
+    }
+
+    func updateRoadPositionRegionOfInterest(
+        latitude: Double,
+        longitude: Double,
+        zoomLevel: Int,
+        namespace: String
+    ) -> TopicUpdateRequest? {
+        updateRegionOfInterest(for: .cam,
+                               latitude: latitude,
+                               longitude: longitude,
+                               zoomLevel: zoomLevel,
+                               namespace: namespace,
+                               currentRegionOfInterest: &currentCAMRegionOfInterest)
+    }
+
+    private func updateRegionOfInterest(
+        for messageType: MessageType,
+        latitude: Double,
+        longitude: Double,
+        zoomLevel: Int,
+        namespace: String,
+        currentRegionOfInterest: inout RegionOfInterest?) -> TopicUpdateRequest? {
+        let quadkey = quadkeyBuilder.quadkeyFrom(latitude: latitude,
+                                                 longitude: longitude,
+                                                 zoomLevel: zoomLevel,
+                                                 separator: "/")
+
+        guard quadkey != currentRegionOfInterest?.quadkey else {
+            return nil
+        }
+
+        let neighborQuadkeys = quadkeyBuilder.neighborQuadkeys(for: quadkey)
+        let regionOfInterest = RegionOfInterest(quadkey: quadkey,
+                                                neighborQuadkeys: neighborQuadkeys)
+        let topicUpdate = updateTopicSubscriptions(newRegionOfInterest: regionOfInterest,
+                                                   currentRegionOfInterest: currentRegionOfInterest,
+                                                   for: messageType,
+                                                   namespace: namespace)
+        currentRegionOfInterest = regionOfInterest
+
+        return topicUpdate
+    }
+
+    private func updateTopicSubscriptions(
+        newRegionOfInterest: RegionOfInterest,
+        currentRegionOfInterest: RegionOfInterest?,
+        for messageType: MessageType,
+        namespace: String
+    ) -> TopicUpdateRequest {
+        var subscriptions = [String]()
+        var unsubscriptions = [String]()
+
+        let newQuadkeys = newRegionOfInterest.allQuadkeys
+        let currentQuadkeys = currentRegionOfInterest?.allQuadkeys ?? []
+
+        newQuadkeys.forEach { newQuadkey in
+            if !currentQuadkeys.contains(newQuadkey) {
+                subscriptions.append(topic(for: messageType, in: newQuadkey, namespace: namespace))
+            }
+        }
+
+        currentQuadkeys.forEach { currentQuadkey in
+            if !newQuadkeys.contains(currentQuadkey) {
+                unsubscriptions.append(topic(for: messageType, in: currentQuadkey, namespace: namespace))
+            }
+        }
+
+        return TopicUpdateRequest(subscriptions: subscriptions, unsubscriptions: unsubscriptions)
+    }
+
+    private func topic(for messageType: MessageType, in quadkey: String, namespace: String) -> String {
+        "\(namespace)/outQueue/v2x/\(messageType)/+/\(quadkey)/#"
+    }
+}

--- a/swift/ITSClient/Tests/ITSClient-IntegrationTests.xctestplan
+++ b/swift/ITSClient/Tests/ITSClient-IntegrationTests.xctestplan
@@ -38,6 +38,9 @@
           },
           {
             "name" : "QuadkeyBuilderTests"
+          },
+          {
+            "name" : "RegionOfInterestCoordinatorTests"
           }
         ]
       },

--- a/swift/ITSClient/Tests/ITSMobilityTests/RegionOfInterestCoordinatorTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/RegionOfInterestCoordinatorTests.swift
@@ -1,0 +1,102 @@
+/*
+ * Software Name : ITSClient
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Software description: Swift ITS client.
+ */
+
+import Foundation
+import Testing
+@testable import ITSMobility
+
+struct RegionOfInterestCoordinatorTests {
+    private let namespace = "default"
+
+    @Test("Updating road alarm ROI should return 9 subscriptions and 0 unsubscription the first time")
+    func updating_road_alarm_roi_should_return_9_subscriptions_and_0_unsubscription_first_time() throws {
+        // Given
+        let regionOfInterestCoordinator = RegionOfInterestCoordinator()
+
+        // When
+        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+            latitude: 43.63516355648167,
+            longitude: 1.3744570239910097,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // Then
+        let unwrapRequestUpdate = try #require(requestUpdate)
+        #expect(unwrapRequestUpdate.subscriptions.count == 9)
+        #expect(unwrapRequestUpdate.unsubscriptions.isEmpty)
+    }
+
+    @Test("Updating road alarm ROI should return 9 subscriptions and 9 unsubscriptions when moving")
+    func updating_road_alarm_roi_should_return_9_subscriptions_and_9_unsubscriptions_when_moving() throws {
+        // Given
+        let regionOfInterestCoordinator = RegionOfInterestCoordinator()
+        _ = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+            latitude: 43.63516355648167,
+            longitude: 1.3744570239910097,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // When
+        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+            latitude: 43.64516355648167,
+            longitude: 1.3844570239910097,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // Then
+        let unwrapRequestUpdate = try #require(requestUpdate)
+        #expect(unwrapRequestUpdate.subscriptions.count == 9)
+        #expect(unwrapRequestUpdate.unsubscriptions.count == 9)
+    }
+
+    @Test("Updating road alarm ROI should return nil when no update")
+    func updating_road_alarm_roi_should_return_nil_when_no_update() throws {
+        // Given
+        let regionOfInterestCoordinator = RegionOfInterestCoordinator()
+        _ = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+            latitude: 43.63516355648167,
+            longitude: 1.3744570239910097,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // When
+        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+            latitude: 43.63516355648101,
+            longitude: 1.3744570239910001,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // Then
+        #expect(requestUpdate == nil)
+    }
+
+    @Test("Updating road position ROI should return nil when no update")
+    func updating_road_position_roi_should_return_nil_when_no_update() throws {
+        // Given
+        let regionOfInterestCoordinator = RegionOfInterestCoordinator()
+        _ = regionOfInterestCoordinator.updateRoadPositionRegionOfInterest(
+            latitude: 43.63516355648167,
+            longitude: 1.3744570239910097,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // When
+        let requestUpdate = regionOfInterestCoordinator.updateRoadPositionRegionOfInterest(
+            latitude: 43.63516355648101,
+            longitude: 1.3744570239910001,
+            zoomLevel: 22,
+            namespace: namespace)
+
+        // Then
+        #expect(requestUpdate == nil)
+    }
+}
+


### PR DESCRIPTION
**What's new**

Add the region of interest which allows to manage MQTT subscriptions depending the coordinates and the zoom level.
Add a method to update the road alarm region of interest
Add a method to update the road position region of interest

---
**How to test**

Just check the code and the unit tests.

Closes #363
