### PR TITLE
swift: stop Core properly when an error occurs

### DIFF
--- a/swift/ITSClient/Sources/ITSCore/Core.swift
+++ b/swift/ITSClient/Sources/ITSCore/Core.swift
@@ -102,13 +102,10 @@ public actor Core {
     }
 
     /// Stops the `Core` disconnecting the MQTT client and stopping the telemetry client.
-    /// - Throws: A `CoreError` if the MQTT unsubscriptions or disconnection fails.
-    public func stop() async throws(CoreError) {
+    public func stop() async {
         do {
             try await mqttClient?.disconnect()
-        } catch {
-            throw .mqttError(EquatableError(wrappedError: error))
-        }
+        } catch {}
         mqttClient = nil
 
         await telemetryClient?.stop()

--- a/swift/ITSClient/Sources/ITSMobility/Mobility.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Mobility.swift
@@ -46,13 +46,8 @@ public actor Mobility {
     }
 
     /// Stops the `Mobility` disconnecting the MQTT client and stopping the telemetry client.
-    /// - Throws: A `MobilityError` if the MQTT unsubscriptions or disconnection fails.
-    public func stop() async throws(MobilityError) {
-        do {
-            try await core.stop()
-        } catch {
-            throw .stopFailed(error)
-        }
+    public func stop() async {
+        await core.stop()
     }
 
     /// Sets an observer to observe changes on road alarms.

--- a/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
+++ b/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
@@ -16,8 +16,6 @@ import ITSCore
 public enum MobilityError: Error {
     /// The mobilty start failed.
     case startFailed(CoreError)
-    /// The mobility stop failed.
-    case stopFailed(CoreError)
     /// The mobility must be started before performing this action.
     case notStarted
     /// The payload encoding failed.

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -42,7 +42,7 @@ struct CoreTests {
             try await Task.sleep(for: .seconds(0.5))
             try await core.publish(message: incomingMessage)
             try await Task.sleep(for: .seconds(0.5))
-            try await core.stop() // Stop to flush spans
+            await core.stop() // Stop to flush spans
         }
 
         try await confirmation(expectedCount: 1) { confirmation in
@@ -73,7 +73,7 @@ struct CoreTests {
         do {
             try await core.publish(message: message)
         } catch {
-            try await core.stop() // Stop to flush spans
+            await core.stop() // Stop to flush spans
             // Wait a bit for the spans flush
             try await Task.sleep(for: .seconds(0.5))
         }
@@ -90,7 +90,7 @@ struct CoreTests {
         try await core.start(coreConfiguration: coreConfiguration)
         let message = CoreMQTTMessage(payload: Data(), topic: topic)
         try await core.publish(message: message)
-        try await core.stop() // Stop as you want to flush spans
+        await core.stop() // Stop as you want to flush spans
         // Wait a bit for the spans flush
         try await Task.sleep(for: .seconds(0.5))
     }
@@ -154,7 +154,7 @@ struct CoreTests {
         // Expect that one message is received
         #expect(messagesReceivedCount == 1)
 
-        try await core.stop()
+        await core.stop()
     }
 #endif
 }

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreUnitTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreUnitTests.swift
@@ -52,7 +52,7 @@ struct CoreUnitTests {
         // When
         try await core.start(mqttClient: mockMQTTClient, telemetryClient: mockTelemetryClient)
         try await Task.sleep(for: .seconds(0.5))
-        try await core.stop()
+        await core.stop()
 
         // Then
         #expect(await !mockMQTTClient.isConnected)

--- a/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
@@ -41,7 +41,7 @@ struct MobilityTests {
                                         altitude: 155,
                                         heading: 45,
                                         speed: 8.1)
-        try await mobility.stop()
+        await mobility.stop()
         // Wait a bit for the spans flush
         try await Task.sleep(for: .seconds(0.5))
     }
@@ -53,7 +53,7 @@ struct MobilityTests {
                                      longitude: 1.3744570239910097,
                                      altitude: 155,
                                      cause: .trafficCondition())
-        try await mobility.stop()
+        await mobility.stop()
         // Wait a bit for the spans flush
         try await Task.sleep(for: .seconds(0.5))
     }

--- a/swift/SampleApp/SampleApp/Mobility/Data/ITSMobilityService.swift
+++ b/swift/SampleApp/SampleApp/Mobility/Data/ITSMobilityService.swift
@@ -54,14 +54,10 @@ actor ITSMobilityService: MobilityService {
         startSendingPosition()
     }
 
-    func stop() async throws(MobilityError) {
+    func stop() async {
         stopSendingPosition()
         roadAlarmChangeObserver = nil
-        do {
-            try await mobility.stop()
-        } catch {
-            throw .stopFailed
-        }
+        await mobility.stop()
     }
 
     func startSendingPosition() {

--- a/swift/SampleApp/SampleApp/Mobility/Domain/MobilityError.swift
+++ b/swift/SampleApp/SampleApp/Mobility/Domain/MobilityError.swift
@@ -13,5 +13,4 @@ import Foundation
 
 enum MobilityError: Error {
     case startFailed
-    case stopFailed
 }

--- a/swift/SampleApp/SampleApp/Mobility/Domain/MobilityService.swift
+++ b/swift/SampleApp/SampleApp/Mobility/Domain/MobilityService.swift
@@ -13,5 +13,5 @@ import Foundation
 
 protocol MobilityService {
     func start() async throws(MobilityError)
-    func stop() async throws(MobilityError)
+    func stop() async
 }

--- a/swift/SampleApp/SampleApp/Mobility/UI/MobilityView.swift
+++ b/swift/SampleApp/SampleApp/Mobility/UI/MobilityView.swift
@@ -26,30 +26,15 @@ struct MobilityView: View {
                     if viewModel.isStarted {
                         await viewModel.stop()
                     } else {
-                        await viewModel.start()
+                        showAlert = await !viewModel.start()
                     }
                 }
             }
             .buttonStyle(.borderedProminent)
         }
-        .onChange(of: viewModel.error) { newValue in
-            showAlert = newValue != nil
-        }
         .alert("Error", isPresented: $showAlert, actions: {}, message: {
-            errorView
-        })
-    }
-
-    @ViewBuilder
-    private var errorView: some View {
-        switch viewModel.error {
-        case .startFailed:
             Text("Start mobility failed")
-        case .stopFailed:
-            Text("Stop mobility failed")
-        default:
-            EmptyView()
-        }
+        })
     }
 }
 

--- a/swift/SampleApp/SampleApp/Mobility/UI/MobilityViewModel.swift
+++ b/swift/SampleApp/SampleApp/Mobility/UI/MobilityViewModel.swift
@@ -14,30 +14,24 @@ import SwiftUI
 @MainActor
 final class MobilityViewModel: ObservableObject {
     @Published var isStarted = false
-    @Published var error: MobilityError?
     private let mobilityService: MobilityService
 
     init(mobilityService: MobilityService) {
         self.mobilityService = mobilityService
     }
 
-    func start() async {
+    func start() async -> Bool {
         do {
             try await mobilityService.start()
             isStarted = true
-            error = nil
+            return true
         } catch {
-            self.error = error
+            return false
         }
     }
 
     func stop() async {
-        do {
-            try await mobilityService.stop()
-            isStarted = false
-            error = nil
-        } catch {
-            self.error = error
-        }
+        await mobilityService.stop()
+        isStarted = false
     }
 }


### PR DESCRIPTION
**What's new**

The stop action never fails. The MQTT instance is destroyed even if a MQTT disconnect error occurs.

Closes #385 
