### PR TITLE
swift: start Core should throw an error each time when the connection fails

### DIFF
--- a/swift/ITSClient/Sources/ITSCore/Core.swift
+++ b/swift/ITSClient/Sources/ITSCore/Core.swift
@@ -135,11 +135,12 @@ public actor Core {
 
         do {
             try await self.mqttClient?.connect()
+            await self.telemetryClient?.start()
         } catch {
+            self.mqttClient = nil
+            self.telemetryClient = nil
             throw .mqttError(EquatableError(wrappedError: error))
         }
-
-        await self.telemetryClient?.start()
     }
 
     private func startReceivedMessageSpan(_ message: MQTTMessage) async -> String? {

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -95,6 +95,32 @@ struct CoreTests {
         try await Task.sleep(for: .seconds(0.5))
     }
 
+    @Test(.bug("https://github.com/Orange-OpenSource/its-client/issues/387",
+               "Start Core twice should throw an error each time"))
+    func start_core_twice_should_throw_an_error_each_time() async {
+        // Given
+        let core = Core()
+
+        // When
+        let mqttClientConfiguration = MQTTClientConfiguration(host: "badmqtthost.com",
+                                                              port: 1883,
+                                                              clientIdentifier: UUID().uuidString,
+                                                              useSSL: false)
+        let coreConfiguration = CoreConfiguration(mqttClientConfiguration: mqttClientConfiguration)
+
+        for _ in 0..<2 {
+            do {
+                try await core.start(coreConfiguration: coreConfiguration)
+                Issue.record("start should throw an error")
+            } catch {
+                // Then
+                if case .mqttError(let wrappedError) = error {
+                    #expect(wrappedError == EquatableError(wrappedError: MQTTClientError.connectionFailed))
+                }
+            }
+        }
+    }
+
 #if os(macOS)
 
     @Test("MQTT connection should be resumed after a network disconnection")

--- a/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
+++ b/swift/ITSClient/Tests/ITSCoreTests/CoreTests.swift
@@ -54,7 +54,7 @@ struct CoreTests {
                 // Wait a bit to simulate a task that takes time
                 Thread.sleep(forTimeInterval: 0.25)
             })
-            try await Task.sleep(for: .seconds(1.0))
+            try await Task.sleep(for: .seconds(3.0))
         }
 
         // Wait a bit for the spans flush


### PR DESCRIPTION
**What's new**

Calling several times the Core start method when the broker or the connection is down will throw a connection failed error each time.

---
**How to test**

Run the test called `start_core_twice_should_throw_an_error_each_time`

Closes #387 