### PR TITLE
Feature/java bootstrap2 0 0

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
@@ -8,6 +8,7 @@
 package com.orange.iot3core.bootstrap;
 
 import okhttp3.*;
+import org.json.JSONException;
 import org.json.JSONObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -75,8 +76,13 @@ public class BootstrapHelper {
                     bootstrapCallback.boostrapError(new Throwable("Error: " + statusCode + " - " + responseBody));
                 } else {
                     JSONObject jsonResponse = new JSONObject(responseBody);
-                    BootstrapConfig bootstrapConfig = new BootstrapConfig(jsonResponse);
-                    bootstrapCallback.boostrapSuccess(bootstrapConfig);
+                    try {
+                        BootstrapConfig bootstrapConfig = new BootstrapConfig(jsonResponse);
+                        bootstrapCallback.boostrapSuccess(bootstrapConfig);
+                    }
+                    catch (Exception exception) {
+                        bootstrapCallback.boostrapError(exception);
+                    }
                 }
             }
         } catch (IllegalArgumentException | IOException exception) {
@@ -88,7 +94,9 @@ public class BootstrapHelper {
         EXTERNAL_APP("external-app"),
         INTERNAL_APP("internal-app"),
         NEIGHBOUR("neighbour"),
-        USER_EQUIPMENT("user-equipment");
+        INTERQUEUE_APP("interqueue-app"),
+        USER_EQUIPMENT("user-equipment"),
+        MONITORING_APP("monitoring-app");
 
         private final String jsonValue;
 


### PR DESCRIPTION
The format of the responses of the new bootstrap is different.
Among differences, it uses jsonarray.

**How to test:**
*Be not connected to the Orange SI.
*Adapt the IoT3CoreBootstrapExample Strings (credentials, uris, role). We can use the mail from Yann (mar. 03/06/2025 11:23) to provide such things.
*You should see 'Bootstrap success'

**Clarifications needed:**
*Do we have a exhaustive list of role? 
*Despite the facts that Yann tells that the given URI (in mail) are OK, I got an mqtt disconnection.

Close #392 
