### PR TITLE
swift: add separator for neighbors quadkeys

### DIFF
--- a/swift/ITSClient/Sources/ITSMobility/QuadkeyBuilder.swift
+++ b/swift/ITSClient/Sources/ITSMobility/QuadkeyBuilder.swift
@@ -28,10 +28,11 @@ struct QuadkeyBuilder {
         return quadkey(from: Tile(x: x, y: y), zoomLevel: zoomLevel, separator: separator)
     }
 
-    func neighborQuadkeys(for quadkey: String) -> [String] {
+    func neighborQuadkeys(for quadkey: String, separator: String = "") -> [String] {
         var quadkeys = [String]()
-        let tile = tile(from: quadkey)
-        let zoomLevel = quadkey.count
+        let sanitizedQuadkey = quadkey.replacingOccurrences(of: separator, with: "")
+        let tile = tile(from: sanitizedQuadkey)
+        let zoomLevel = sanitizedQuadkey.count
         let maxTileValue = Int(pow(2.0, Double(zoomLevel))) - 1
         let westXValue = tile.x > 0 ? tile.x - 1 : maxTileValue
         let eastXValue = tile.x < maxTileValue ? tile.x + 1 : 0
@@ -39,38 +40,46 @@ struct QuadkeyBuilder {
         // North-west
         if tile.y > 0 {
             quadkeys.append(self.quadkey(from: Tile(x: westXValue, y: tile.y - 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
         // North
         if tile.y > 0 {
             quadkeys.append(self.quadkey(from: Tile(x: tile.x, y: tile.y - 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
         // North-east
         if tile.y > 0 {
             quadkeys.append(self.quadkey(from: Tile(x: eastXValue, y: tile.y - 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
         // West
         quadkeys.append(self.quadkey(from: Tile(x: westXValue, y: tile.y),
-                                     zoomLevel: zoomLevel))
+                                     zoomLevel: zoomLevel,
+                                     separator: separator))
         // East
         quadkeys.append(self.quadkey(from: Tile(x: eastXValue, y: tile.y),
-                                     zoomLevel: zoomLevel))
+                                     zoomLevel: zoomLevel,
+                                     separator: separator))
         // South-west
         if tile.y < maxTileValue {
             quadkeys.append(self.quadkey(from: Tile(x: westXValue, y: tile.y + 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
         // South
         if tile.y < maxTileValue {
             quadkeys.append(self.quadkey(from: Tile(x: tile.x, y: tile.y + 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
         // South-east
         if tile.y < maxTileValue {
             quadkeys.append(self.quadkey(from: Tile(x: eastXValue, y: tile.y + 1),
-                                         zoomLevel: zoomLevel))
+                                         zoomLevel: zoomLevel,
+                                         separator: separator))
         }
 
         return quadkeys

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
@@ -56,16 +56,17 @@ final class RegionOfInterestCoordinator {
         zoomLevel: Int,
         namespace: String,
         currentRegionOfInterest: inout RegionOfInterest?) -> TopicUpdateRequest? {
+        let separator = "/"
         let quadkey = quadkeyBuilder.quadkeyFrom(latitude: latitude,
                                                  longitude: longitude,
                                                  zoomLevel: zoomLevel,
-                                                 separator: "/")
+                                                 separator: separator)
 
         guard quadkey != currentRegionOfInterest?.quadkey else {
             return nil
         }
 
-        let neighborQuadkeys = quadkeyBuilder.neighborQuadkeys(for: quadkey)
+        let neighborQuadkeys = quadkeyBuilder.neighborQuadkeys(for: quadkey, separator: separator)
         let regionOfInterest = RegionOfInterest(quadkey: quadkey,
                                                 neighborQuadkeys: neighborQuadkeys)
         let topicUpdate = updateTopicSubscriptions(newRegionOfInterest: regionOfInterest,

--- a/swift/ITSClient/Tests/ITSMobilityTests/QuadkeyBuilderTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/QuadkeyBuilderTests.swift
@@ -170,4 +170,22 @@ struct QuadkeyBuilderTests {
         #expect(neighborQuadkeys.contains("22"))
         #expect(neighborQuadkeys.contains("20"))
     }
+
+    @Test("Quadkey must have 5 neighbors if it is at the bottom right edge with separator")
+    func quadkey_must_have_5_neighbors_if_bottom_right_edge_with_separator() {
+        // Given
+        let builder = QuadkeyBuilder()
+        let quadkey = "33"
+
+        // When
+        let neighborQuadkeys = builder.neighborQuadkeys(for: quadkey, separator: "/")
+
+        // Then
+        #expect(neighborQuadkeys.count == 5)
+        #expect(neighborQuadkeys.contains("3/0"))
+        #expect(neighborQuadkeys.contains("3/1"))
+        #expect(neighborQuadkeys.contains("3/2"))
+        #expect(neighborQuadkeys.contains("2/2"))
+        #expect(neighborQuadkeys.contains("2/0"))
+    }
 }


### PR DESCRIPTION
**What's new**

Add the separator when generation the quadkey for the neighbors.

---
**How to test**

Run the new test `quadkey_must_have_5_neighbors_if_bottom_right_edge_with_separator`

Closes #406 