### PR TITLE
swift: fix Core start when telemetry client is set

### DIFF
--- a/swift/ITSClient/Sources/ITSCore/Core.swift
+++ b/swift/ITSClient/Sources/ITSCore/Core.swift
@@ -33,6 +33,7 @@ public actor Core {
     /// - Parameter coreConfiguration: The configuration used to start the MQTT client and the telemetry client.
     /// - Throws: A `CoreError` if the MQTT connection fails.
     public func start(coreConfiguration: CoreConfiguration) async throws(CoreError) {
+        var telemetryClient: TelemetryClient?
         if let telemetryClientConfiguration = coreConfiguration.telemetryClientConfiguration {
             telemetryClient = await OpenTelemetryClient(configuration: telemetryClientConfiguration)
         }


### PR DESCRIPTION
**What's new**

The Core is started properly when telemetry client is set.

---
**How to test**

Run the sample app with bootstrap configuration to check that the SDK is started.

Closes #408 