### PR TITLE
Feature/hazard category

### DIFF
--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityBootstrapExample.java
@@ -8,7 +8,7 @@ import com.orange.iot3mobility.IoT3MobilityCallback;
 import com.orange.iot3mobility.TrueTime;
 import com.orange.iot3mobility.Utils;
 import com.orange.iot3mobility.its.EtsiUtils;
-import com.orange.iot3mobility.its.HazardType;
+import com.orange.iot3mobility.roadobjects.HazardType;
 import com.orange.iot3mobility.its.StationType;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.Position;

--- a/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Iot3MobilityExample.java
@@ -8,7 +8,7 @@ import com.orange.iot3mobility.IoT3MobilityCallback;
 import com.orange.iot3mobility.TrueTime;
 import com.orange.iot3mobility.Utils;
 import com.orange.iot3mobility.its.EtsiUtils;
-import com.orange.iot3mobility.its.HazardType;
+import com.orange.iot3mobility.roadobjects.HazardType;
 import com.orange.iot3mobility.its.StationType;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.Position;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/IoT3Mobility.java
@@ -15,7 +15,7 @@ import com.orange.iot3core.IoT3CoreCallback;
 import com.orange.iot3core.bootstrap.BootstrapConfig;
 import com.orange.iot3core.clients.lwm2m.model.*;
 import com.orange.iot3mobility.its.EtsiUtils;
-import com.orange.iot3mobility.its.HazardType;
+import com.orange.iot3mobility.roadobjects.HazardType;
 import com.orange.iot3mobility.its.StationType;
 import com.orange.iot3mobility.its.json.JsonValue;
 import com.orange.iot3mobility.its.json.Position;

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/HazardCategory.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/HazardCategory.java
@@ -1,0 +1,54 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ */
+package com.orange.iot3mobility.its;
+
+public enum HazardCategory {
+
+    UNDEFINED ("undefined", 0),
+    TRAFFIC_CONDITION ("trafficCondition", 1),
+    ACCIDENT ("accident", 2),
+    ROADWORKS ("roadworks", 3),
+    ADVERSE_WEATHER_CONDITION_ADHESION ("adverseWeatherCondition-Adhesion", 6),
+    HAZARDOUS_LOCATION_SURFACE_CONDITION ("hazardousLocation-SurfaceCondition", 9),
+    HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD ("hazardousLocation-ObstacleOnTheRoad", 10),
+    HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD ("hazardousLocation-AnimalOnTheRoad", 11),
+    HUMAN_PRESENCE_ON_THE_ROAD ("humanPresenceOnTheRoad", 12),
+    WRONG_WAY_OF_DRIVING ("wrongWayDriving", 14),
+    RESCUE_AND_RECOVERY_WORK_IN_PROGRESS ("rescueAndRecoveryWorkInProgress", 15),
+    ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION ("adverseWeatherCondition-ExtremeWeatherCondition", 17),
+    ADVERSE_WEATHER_CONDITION_VISIBILITY ("adverseWeatherCondition-Visibility", 18),
+    ADVERSE_WEATHER_CONDITION_PRECIPITATION ("adverseWeatherCondition-Precipitation", 19),
+    SLOW_VEHICLE ("slowVehicle", 26),
+    DANGEROUS_END_OF_QUEUE ("dangerousEndOfQueue", 27),
+    VEHICLE_BREAKDOWN ("vehicleBreakdown", 91),
+    POST_CRASH ("postCrash", 92),
+    HUMAN_PROBLEM ("humanProblem", 93),
+    STATIONARY_VEHICLE ("stationaryVehicle", 94),
+    EMERGENCY_VEHICLE_APPROACHING ("emergencyVehicleApproaching", 95),
+    HAZARDOUS_LOCATION_DANGEROUS_CURVE ("hazardousLocation-DangerousCurve", 96),
+    COLLISION_RISK ("collisionRisk", 97),
+    SIGNAL_VIOLATION ("signalViolation", 98),
+    DANGEROUS_SITUATION ("dangerousSituation", 99);
+
+    final String name;
+    final int cause;
+
+    HazardCategory(String name, int cause){
+        this.name = name;
+        this.cause = cause;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getCause() {
+        return cause;
+    }
+
+}

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/HazardType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/its/HazardType.java
@@ -1,5 +1,5 @@
 /*
- Copyright 2016-2024 Orange
+ Copyright 2016-2025 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
@@ -9,206 +9,212 @@ package com.orange.iot3mobility.its;
 
 public enum HazardType {
 	
-    UNDEFINED("roadHazard", 0, 0),
+    UNDEFINED("roadHazard", 0, HazardCategory.UNDEFINED),
 
-    TRAFFIC_CONDITION_NO_SUBCAUSE ("trafficJam", 0, 1),
-    INCREASED_VOLUME_OF_TRAFFIC ("increasedVolumeOfTraffic", 1, 1),
-    TRAFFIC_JAM_SLOWLY_INCREASING ("trafficJamSlowlyIncreasing", 2, 1),
-    TRAFFIC_JAM_INCREASING ("trafficJamIncreasing", 3, 1),
-    TRAFFIC_JAM_STRONGLY_INCREASING("trafficJamStronglyIncreasing", 4, 1),
-    TRAFFIC_STATIONARY ("trafficStationary", 5, 1),
-    TRAFFIC_JAM_SLIGHTLY_DECREASING ("trafficJamSlightlyDecreasing", 6, 1),
-    TRAFFIC_JAM_DECREASING ("trafficJamDecreasing", 7, 1),
-    TRAFFIC_JAM_STRONGLY_DECREASING ("trafficJamStronglyDecreasing", 8, 1),
+    TRAFFIC_CONDITION_NO_SUBCAUSE ("trafficJam", 0, HazardCategory.TRAFFIC_CONDITION),
+    INCREASED_VOLUME_OF_TRAFFIC ("increasedVolumeOfTraffic", 1, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_SLOWLY_INCREASING ("trafficJamSlowlyIncreasing", 2, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_INCREASING ("trafficJamIncreasing", 3, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_STRONGLY_INCREASING("trafficJamStronglyIncreasing", 4, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_STATIONARY ("trafficStationary", 5, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_SLIGHTLY_DECREASING ("trafficJamSlightlyDecreasing", 6, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_DECREASING ("trafficJamDecreasing", 7, HazardCategory.TRAFFIC_CONDITION),
+    TRAFFIC_JAM_STRONGLY_DECREASING ("trafficJamStronglyDecreasing", 8, HazardCategory.TRAFFIC_CONDITION),
 
-    ACCIDENT_NO_SUBCAUSE ("accident", 0, 2),
-    MULTI_VEHICLE_ACCIDENT ("multiVehicleAccident", 1, 2),
-    HEAVY_ACCIDENT ("heavyAccident", 2, 2),
-    ACCIDENT_INVOLVING_LORRY ("accidentInvolvingLorry", 3, 2),
-    ACCIDENT_INVOLVING_BUS ("accidentInvolvingBus", 4, 2),
-    ACCIDENT_INVOLVING_HAZARDOUS_MATERIALS ("accidentInvolvingHazardousMaterials", 5, 2),
-    ACCIDENT_ON_OPPOSITE_LANE ("accidentOnOppositeLane", 6, 2),
-    UNSECURED_ACCIDENT ("unsecuredAccident", 7, 2),
-    ASSISTANCE_REQUESTED ("assistanceRequested", 8, 2),
+    ACCIDENT_NO_SUBCAUSE ("accident", 0, HazardCategory.ACCIDENT),
+    MULTI_VEHICLE_ACCIDENT ("multiVehicleAccident", 1, HazardCategory.ACCIDENT),
+    HEAVY_ACCIDENT ("heavyAccident", 2, HazardCategory.ACCIDENT),
+    ACCIDENT_INVOLVING_LORRY ("accidentInvolvingLorry", 3, HazardCategory.ACCIDENT),
+    ACCIDENT_INVOLVING_BUS ("accidentInvolvingBus", 4, HazardCategory.ACCIDENT),
+    ACCIDENT_INVOLVING_HAZARDOUS_MATERIALS ("accidentInvolvingHazardousMaterials", 5, HazardCategory.ACCIDENT),
+    ACCIDENT_ON_OPPOSITE_LANE ("accidentOnOppositeLane", 6, HazardCategory.ACCIDENT),
+    UNSECURED_ACCIDENT ("unsecuredAccident", 7, HazardCategory.ACCIDENT),
+    ASSISTANCE_REQUESTED ("assistanceRequested", 8, HazardCategory.ACCIDENT),
 
-    ROADWORKS_NO_SUBCAUSE ("roadworks", 0, 3),
-    MAJOR_ROADWORKS ("majorRoadworks", 1, 3),
-    ROAD_MARKING_WORK ("roadMarkingWork", 2, 3),
-    SLOW_MOVING_ROAD_MAINTENANCE ("slowMovingRoadMaintenance", 3, 3),
-    SHORT_TERM_STATIONARY_ROADWORKS ("shortTermStationaryRoadworks", 4, 3),
-    STREET_CLEANING ("streetCleaning", 5, 3),
-    WINTER_SERVICE ("winterService", 6, 3),
+    ROADWORKS_NO_SUBCAUSE ("roadworks", 0, HazardCategory.ROADWORKS),
+    MAJOR_ROADWORKS ("majorRoadworks", 1, HazardCategory.ROADWORKS),
+    ROAD_MARKING_WORK ("roadMarkingWork", 2, HazardCategory.ROADWORKS),
+    SLOW_MOVING_ROAD_MAINTENANCE ("slowMovingRoadMaintenance", 3, HazardCategory.ROADWORKS),
+    SHORT_TERM_STATIONARY_ROADWORKS ("shortTermStationaryRoadworks", 4, HazardCategory.ROADWORKS),
+    STREET_CLEANING ("streetCleaning", 5, HazardCategory.ROADWORKS),
+    WINTER_SERVICE ("winterService", 6, HazardCategory.ROADWORKS),
     
-    ADVERSE_WEATHER_CONDITION_ADHESION_NO_SUBCAUSE ("slipperyRoad", 0, 6),
-    HEAVY_FROST_ON_ROAD ("heavyFrostOnRoad", 1, 6),
-    FUEL_ON_ROAD ("fuelOnRoad", 2, 6),
-    MUD_ON_ROAD ("mudOnRoad", 3, 6),
-    SNOW_ON_ROAD ("snowOnRoad", 4, 6),
-    ICE_ON_ROAD ("iceOnRoad", 5, 6),
-    BLACK_ICE_ON_ROAD ("blackIceOnRoad", 6, 6),
-    OIL_ON_ROAD ("oilOnRoad", 7, 6),
-    LOOSE_CHIPPINGS ("looseChippings", 8, 6),
-    INSTANT_BLACK_ICE ("instantBlackIce", 9, 6),
-    ROADS_SALTED ("roadsSalted", 10, 6),
+    ADVERSE_WEATHER_CONDITION_ADHESION_NO_SUBCAUSE ("slipperyRoad", 0, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    HEAVY_FROST_ON_ROAD ("heavyFrostOnRoad", 1, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    FUEL_ON_ROAD ("fuelOnRoad", 2, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    MUD_ON_ROAD ("mudOnRoad", 3, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    SNOW_ON_ROAD ("snowOnRoad", 4, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    ICE_ON_ROAD ("iceOnRoad", 5, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    BLACK_ICE_ON_ROAD ("blackIceOnRoad", 6, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    OIL_ON_ROAD ("oilOnRoad", 7, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    LOOSE_CHIPPINGS ("looseChippings", 8, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    INSTANT_BLACK_ICE ("instantBlackIce", 9, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
+    ROADS_SALTED ("roadsSalted", 10, HazardCategory.ADVERSE_WEATHER_CONDITION_ADHESION),
     
-    HAZARDOUS_LOCATION_SURFACE_CONDITION_NO_SUBCAUSE ("hazardousSurfaceCondition", 0, 9),
-    ROCKFALLS ("rockfalls", 1, 9),
-    EARTHQUAKE_DAMAGE ("earthquakeDamage", 2, 9),
-    SEWER_COLLAPSE ("sewerCollapse", 3, 9),
-    SUBSIDENCE ("subsidence", 4, 9),
-    SNOW_DRIFTS ("snowDrifts", 5, 9),
-    STORM_DAMAGE ("stormDamage", 6, 9),
-    BURST_PIPE ("burstPipe", 7, 9),
-    VOLCANO_ERUPTION ("volcanoEruption", 8, 9),
-    FALLING_ICE ("fallingIce", 9, 9),
+    HAZARDOUS_LOCATION_SURFACE_CONDITION_NO_SUBCAUSE ("hazardousSurfaceCondition", 0, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    ROCKFALLS ("rockfalls", 1, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    EARTHQUAKE_DAMAGE ("earthquakeDamage", 2, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    SEWER_COLLAPSE ("sewerCollapse", 3, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    SUBSIDENCE ("subsidence", 4, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    SNOW_DRIFTS ("snowDrifts", 5, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    STORM_DAMAGE ("stormDamage", 6, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    BURST_PIPE ("burstPipe", 7, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    VOLCANO_ERUPTION ("volcanoEruption", 8, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
+    FALLING_ICE ("fallingIce", 9, HazardCategory.HAZARDOUS_LOCATION_SURFACE_CONDITION),
 
-    HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD_NO_SUBCAUSE ("hazardousObstacleOnTheRoad", 0, 10),
-    SHED_LOAD ("shedLoad", 1, 10),
-    PARTS_OF_VEHICLES ("partsOfVehicles", 2, 10),
-    PARTS_OF_TYRES ("partsOfTyres", 3, 10),
-    BIG_OBJECTS ("bigObjects", 4, 10),
-    FALLEN_TREES ("fallenTrees", 5, 10),
-    HUB_CAPS ("hubCaps", 6, 10),
-    WAITING_VEHICLES ("waitingVehicles", 7, 10),
+    HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD_NO_SUBCAUSE ("hazardousObstacleOnTheRoad", 0, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    SHED_LOAD ("shedLoad", 1, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    PARTS_OF_VEHICLES ("partsOfVehicles", 2, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    PARTS_OF_TYRES ("partsOfTyres", 3, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    BIG_OBJECTS ("bigObjects", 4, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    FALLEN_TREES ("fallenTrees", 5, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    HUB_CAPS ("hubCaps", 6, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
+    WAITING_VEHICLES ("waitingVehicles", 7, HazardCategory.HAZARDOUS_LOCATION_OBSTACLE_ON_THE_ROAD),
 
-    HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD_NO_SUBCAUSE ("animalOnTheRoad", 0, 11),
-    WILD_ANIMALS ("wildAnimals", 1, 11),
-    HERD_OF_ANIMALS ("herdOfAnimals", 2, 11),
-    SMALL_ANIMALS ("smallAnimals", 3, 11),
-    LARGE_ANIMALS ("largeAnimals", 4, 11),
+    HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD_NO_SUBCAUSE ("animalOnTheRoad", 0, HazardCategory.HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD),
+    WILD_ANIMALS ("wildAnimals", 1, HazardCategory.HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD),
+    HERD_OF_ANIMALS ("herdOfAnimals", 2, HazardCategory.HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD),
+    SMALL_ANIMALS ("smallAnimals", 3, HazardCategory.HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD),
+    LARGE_ANIMALS ("largeAnimals", 4, HazardCategory.HAZARDOUS_LOCATION_ANIMAL_ON_THE_ROAD),
 
-    HUMAN_PRESENCE_ON_THE_ROAD_NO_SUBCAUSE ("humanPresenceOnTheRoad", 0, 12),
-    CHILDREN_ON_ROADWAY ("childrenOnRoadway", 1, 12),
-    CYCLIST_ON_ROADWAY ("cyclistOnRoadway", 2, 12),
-    MOTORCYCLIST_ON_ROADWAY ("motorcyclistOnRoadway", 3, 12),
-    SCOOTER_ON_ROADWAY ("scooterOnRoadway", 4, 12),
+    HUMAN_PRESENCE_ON_THE_ROAD_NO_SUBCAUSE ("humanPresenceOnTheRoad", 0, HazardCategory.HUMAN_PRESENCE_ON_THE_ROAD),
+    CHILDREN_ON_ROADWAY ("childrenOnRoadway", 1, HazardCategory.HUMAN_PRESENCE_ON_THE_ROAD),
+    CYCLIST_ON_ROADWAY ("cyclistOnRoadway", 2, HazardCategory.HUMAN_PRESENCE_ON_THE_ROAD),
+    MOTORCYCLIST_ON_ROADWAY ("motorcyclistOnRoadway", 3, HazardCategory.HUMAN_PRESENCE_ON_THE_ROAD),
+    SCOOTER_ON_ROADWAY ("scooterOnRoadway", 4, HazardCategory.HUMAN_PRESENCE_ON_THE_ROAD),
 
-    WRONG_WAY_OF_DRIVING_NO_SUBCAUSE ("wrongWayOfDriving", 0, 14),
-    WRONG_LANE ("wrongLane", 1, 14),
-    WRONG_DIRECTION ("wrongDirection", 2, 14),
+    WRONG_WAY_OF_DRIVING_NO_SUBCAUSE ("wrongWayOfDriving", 0, HazardCategory.WRONG_WAY_OF_DRIVING),
+    WRONG_LANE ("wrongLane", 1, HazardCategory.WRONG_WAY_OF_DRIVING),
+    WRONG_DIRECTION ("wrongDirection", 2, HazardCategory.WRONG_WAY_OF_DRIVING),
     
-    RESCUE_AND_RECOVERY_WORK_IN_PROGRESS_NO_SUBCAUSE ("rescueAndRecoveryWorkInProgress", 0, 15),
-    EMERGENCY_VEHICLES ("emergencyVehicles", 1, 15),
-    RESCUE_HELICOPTER_LANDING ("rescueHelicopterLanding", 2, 15),
-    POLICE_ACTIVITY_ONGOING ("policeActivityOngoing", 3, 15),
-    MEDICAL_EMERGENCY_ONGOING ("medicalEmergencyOngoing", 4, 15),
-    CHILD_ABDUCTION_IN_PROGRESS ("childAbductionInProgress", 5, 15),
+    RESCUE_AND_RECOVERY_WORK_IN_PROGRESS_NO_SUBCAUSE ("rescueAndRecoveryWorkInProgress", 0, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
+    EMERGENCY_VEHICLES ("emergencyVehicles", 1, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
+    RESCUE_HELICOPTER_LANDING ("rescueHelicopterLanding", 2, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
+    POLICE_ACTIVITY_ONGOING ("policeActivityOngoing", 3, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
+    MEDICAL_EMERGENCY_ONGOING ("medicalEmergencyOngoing", 4, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
+    CHILD_ABDUCTION_IN_PROGRESS ("childAbductionInProgress", 5, HazardCategory.RESCUE_AND_RECOVERY_WORK_IN_PROGRESS),
 
-    ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION_NO_SUBCAUSE ("extremeWeatherCondition", 0, 17),
-    STRONG_WINDS ("strongWinds", 1, 17),
-    DAMAGING_HAIL ("damagingHail", 2, 17),
-    HURRICANE ("hurricane", 3, 17),
-    THUNDERSTORM ("thunderstorm", 4, 17),
-    TORNADO ("tornado", 5, 17),
-    BLIZZARD ("blizzard", 6, 17),
+    ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION_NO_SUBCAUSE ("extremeWeatherCondition", 0, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    STRONG_WINDS ("strongWinds", 1, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    DAMAGING_HAIL ("damagingHail", 2, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    HURRICANE ("hurricane", 3, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    THUNDERSTORM ("thunderstorm", 4, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    TORNADO ("tornado", 5, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
+    BLIZZARD ("blizzard", 6, HazardCategory.ADVERSE_WEATHER_CONDITION_EXTREME_WEATHER_CONDITION),
 
-    ADVERSE_WEATHER_CONDITION_VISIBILITY_NO_SUBCAUSE ("badVisibility", 0, 18),
-    FOG ("fog", 1, 18),
-    SMOKE ("smoke", 2, 18),
-    HEAVY_SNOWFALL ("heavySnowfall", 3, 18),
-    HEAVY_RAIN ("heavyRain", 4, 18),
-    HEAVY_HAIL ("heavyHail", 5, 18),
-    LOW_SUN_GLARE ("lowSunGlare", 6, 18),
-    SANDSTORMS ("sandstorms", 7, 18),
-    SWARMS_OF_INSECTS ("swarmsOfInsects", 8, 18),
+    ADVERSE_WEATHER_CONDITION_VISIBILITY_NO_SUBCAUSE ("badVisibility", 0, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    FOG ("fog", 1, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    SMOKE ("smoke", 2, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    HEAVY_SNOWFALL ("heavySnowfall", 3, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    HEAVY_RAIN ("heavyRain", 4, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    HEAVY_HAIL ("heavyHail", 5, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    LOW_SUN_GLARE ("lowSunGlare", 6, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    SANDSTORMS ("sandstorms", 7, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
+    SWARMS_OF_INSECTS ("swarmsOfInsects", 8, HazardCategory.ADVERSE_WEATHER_CONDITION_VISIBILITY),
 
-    HEAVY_RAIN_PRECIPITATION_NO_SUBCAUSE ("heavyPrecipitation", 0, 19),
-    HEAVY_RAIN_PRECIPITATION ("heavyRain", 1, 19),
-    HEAVY_SNOWFALL_PRECIPITATION ("heavySnowfall", 2, 19),
-    SOFT_HAIL ("softHail", 3, 19),
+    HEAVY_RAIN_PRECIPITATION_NO_SUBCAUSE ("heavyPrecipitation", 0, HazardCategory.ADVERSE_WEATHER_CONDITION_PRECIPITATION),
+    HEAVY_RAIN_PRECIPITATION ("heavyRain", 1, HazardCategory.ADVERSE_WEATHER_CONDITION_PRECIPITATION),
+    HEAVY_SNOWFALL_PRECIPITATION ("heavySnowfall", 2, HazardCategory.ADVERSE_WEATHER_CONDITION_PRECIPITATION),
+    SOFT_HAIL ("softHail", 3, HazardCategory.ADVERSE_WEATHER_CONDITION_PRECIPITATION),
 
-    SLOW_VEHICLE_NO_SUBCAUSE ("slowVehicle", 0, 26),
-    MAINTENANCE_VEHICLE ("maintenanceVehicle", 1, 26),
-    VEHICLES_SLOWING_TO_LOOK_AT_ACCIDENT ("vehiclesSlowingToLookAtAccident", 2, 26),
-    ABNORMAL_LOAD ("abnormalLoad", 3, 26),
-    ABNORMAL_WIDE_LOAD ("abnormalWideLoad", 4, 26),
-    CONVOY ("convoy", 5, 26),
-    SNOWPLOUGH ("snowplough", 6, 26),
-    DEICING ("deicing", 7, 26),
-    SALTING_VEHICLES ("saltingVehicles", 8, 26),
+    SLOW_VEHICLE_NO_SUBCAUSE ("slowVehicle", 0, HazardCategory.SLOW_VEHICLE),
+    MAINTENANCE_VEHICLE ("maintenanceVehicle", 1, HazardCategory.SLOW_VEHICLE),
+    VEHICLES_SLOWING_TO_LOOK_AT_ACCIDENT ("vehiclesSlowingToLookAtAccident", 2, HazardCategory.SLOW_VEHICLE),
+    ABNORMAL_LOAD ("abnormalLoad", 3, HazardCategory.SLOW_VEHICLE),
+    ABNORMAL_WIDE_LOAD ("abnormalWideLoad", 4, HazardCategory.SLOW_VEHICLE),
+    CONVOY ("convoy", 5, HazardCategory.SLOW_VEHICLE),
+    SNOWPLOUGH ("snowplough", 6, HazardCategory.SLOW_VEHICLE),
+    DEICING ("deicing", 7, HazardCategory.SLOW_VEHICLE),
+    SALTING_VEHICLES ("saltingVehicles", 8, HazardCategory.SLOW_VEHICLE),
     
-    DANGEROUS_END_OF_QUEUE_NO_SUBCAUSE ("dangerousEndOfQueue", 0, 27),
-    SUDDEN_END_OF_QUEUE ("suddenEndOfQueue", 1, 27),
-    QUEUE_OVER_HILL ("queueOverHill", 2, 27),
-    QUEUE_AROUND_BEND ("queueAroundBend", 3, 27),
-    QUEUE_IN_TUNNEL ("queueInTunnel", 4, 27),
+    DANGEROUS_END_OF_QUEUE_NO_SUBCAUSE ("dangerousEndOfQueue", 0, HazardCategory.DANGEROUS_END_OF_QUEUE),
+    SUDDEN_END_OF_QUEUE ("suddenEndOfQueue", 1, HazardCategory.DANGEROUS_END_OF_QUEUE),
+    QUEUE_OVER_HILL ("queueOverHill", 2, HazardCategory.DANGEROUS_END_OF_QUEUE),
+    QUEUE_AROUND_BEND ("queueAroundBend", 3, HazardCategory.DANGEROUS_END_OF_QUEUE),
+    QUEUE_IN_TUNNEL ("queueInTunnel", 4, HazardCategory.DANGEROUS_END_OF_QUEUE),
+
+    VEHICLE_BREAKDOWN_NO_SUBCAUSE("vehicleBreakdown", 0, HazardCategory.VEHICLE_BREAKDOWN),
+    LACK_OF_FUEL ("lackOfFuel", 1, HazardCategory.VEHICLE_BREAKDOWN),
+    LACK_OF_BATTERY_POWER ("lackOfBatteryPower", 2, HazardCategory.VEHICLE_BREAKDOWN),
+    ENGINE_PROBLEM ("engineProblem", 3, HazardCategory.VEHICLE_BREAKDOWN),
+    TRANSMISSION_PROBLEM ("transmissionProblem", 4, HazardCategory.VEHICLE_BREAKDOWN),
+    ENGINE_COOLING_PROBLEM ("engineCoolingProblem", 5, HazardCategory.VEHICLE_BREAKDOWN),
+    BRAKING_SYSTEM_PROBLEM ("brakingSystemProblem", 6, HazardCategory.VEHICLE_BREAKDOWN),
+    STEERING_PROBLEM ("steeringProblem", 7, HazardCategory.VEHICLE_BREAKDOWN),
+    TYRE_PUNCTURE ("tyrePuncture", 8, HazardCategory.VEHICLE_BREAKDOWN),
     
-    POST_CRASH_NO_SUBCAUSE ("postCrash", 0, 92),
-    LACK_OF_FUEL ("lackOfFuel", 1, 92),
-    LACK_OF_BATTERY_POWER ("lackOfBatteryPower", 2, 92),
-    ENGINE_PROBLEM ("engineProblem", 3, 92),
-    TRANSMISSION_PROBLEM ("transmissionProblem", 4, 92),
-    ENGINE_COOLING_PROBLEM ("engineCoolingProblem", 5, 92),
-    BRAKING_SYSTEM_PROBLEM ("brakingSystemProblem", 6, 92),
-    STEERING_PROBLEM ("steeringProblem", 7, 92),
-    TYRE_PUNCTURE ("tyrePuncture", 8, 92),
-    ACCIDENT_WITHOUT_E_CALL_TRIGGERED ("accidentWithoutECallTriggered", 1, 92),
-    ACCIDENT_WITH_E_CALL_MANUALLY_TRIGGERED ("accidentWithECallManuallyTriggered", 2, 92),
-    ACCIDENT_WITH_E_CALL_AUTOMATICALLY_TRIGGERED ("accidentWithECallAutomaticallyTriggered", 3, 92),
-    ACCIDENT_WITH_E_CALL_TRIGGERED_WITHOUT_ACCESS_TO_CELLULAR_NETWORK ("accidentWithECallTriggeredWithoutAccessToCellularNetwork", 4, 92),
+    POST_CRASH_NO_SUBCAUSE ("postCrash", 0, HazardCategory.POST_CRASH),
+    ACCIDENT_WITHOUT_E_CALL_TRIGGERED ("accidentWithoutECallTriggered", 1, HazardCategory.POST_CRASH),
+    ACCIDENT_WITH_E_CALL_MANUALLY_TRIGGERED ("accidentWithECallManuallyTriggered", 2, HazardCategory.POST_CRASH),
+    ACCIDENT_WITH_E_CALL_AUTOMATICALLY_TRIGGERED ("accidentWithECallAutomaticallyTriggered", 3, HazardCategory.POST_CRASH),
+    ACCIDENT_WITH_E_CALL_TRIGGERED_WITHOUT_ACCESS_TO_CELLULAR_NETWORK ("accidentWithECallTriggeredWithoutAccessToCellularNetwork", 4, HazardCategory.POST_CRASH),
 
-    STATIONARY_VEHICLE_NO_SUBCAUSE ("stationaryVehicle", 0, 94),
-    HUMAN_PROBLEM ("humanProblem", 1, 94),
-    VEHICLE_BREAKDOWN ("vehicleBreakdown", 2, 94),
-    POST_CRASH ("postCrash", 3, 94),
-    PUBLIC_TRANSPORT_STOP ("publicTransportStop", 4, 94),
-    CARRYING_DANGEROUS_GOODS ("carryingDangerousGoods", 5, 94),
+    HUMAN_PROBLEM_NO_SUBCAUSE ("humanProblem", 0, HazardCategory.HUMAN_PROBLEM),
+    GLYCEMIA_PROBLEM ("glycemiaProblem", 1, HazardCategory.HUMAN_PROBLEM),
+    HEART_PROBLEM ("heartProblem", 2, HazardCategory.HUMAN_PROBLEM),
+    
+    STATIONARY_VEHICLE_NO_SUBCAUSE ("stationaryVehicle", 0, HazardCategory.STATIONARY_VEHICLE),
+    HUMAN_PROBLEM ("humanProblem", 1, HazardCategory.STATIONARY_VEHICLE),
+    VEHICLE_BREAKDOWN ("vehicleBreakdown", 2, HazardCategory.STATIONARY_VEHICLE),
+    POST_CRASH ("postCrash", 3, HazardCategory.STATIONARY_VEHICLE),
+    PUBLIC_TRANSPORT_STOP ("publicTransportStop", 4, HazardCategory.STATIONARY_VEHICLE),
+    CARRYING_DANGEROUS_GOODS ("carryingDangerousGoods", 5, HazardCategory.STATIONARY_VEHICLE),
 
-    HUMAN_PROBLEM_NO_SUBCAUSE ("humanProblem", 0, 93),
-    GLYCEMIA_PROBLEM ("glycemiaProblem", 1, 93),
-    HEART_PROBLEM ("heartProblem", 2, 93),
+    EMERGENCY_VEHICLE_APPROACHING_NO_SUBCAUSE ("emergencyVehicleApproaching", 0, HazardCategory.EMERGENCY_VEHICLE_APPROACHING),
+    EMERGENCY_VEHICLE_APPROACHING ("emergencyVehicleApproaching", 1, HazardCategory.EMERGENCY_VEHICLE_APPROACHING),
+    PRIORITIZED_VEHICLE_APPROACHING ("prioritizedVehicleApproaching", 2, HazardCategory.EMERGENCY_VEHICLE_APPROACHING),
 
-    EMERGENCY_VEHICLE_APPROACHING_NO_SUBCAUSE ("emergencyVehicleApproaching", 0, 95),
-    EMERGENCY_VEHICLE_APPROACHING ("emergencyVehicleApproaching", 1, 95),
-    PRIORITIZED_VEHICLE_APPROACHING ("prioritizedVehicleApproaching", 2, 95),
+    HAZARDOUS_LOCATION_DANGEROUS_CURVE_NO_SUBCAUSE ("dangerousCurve", 0, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
+    DANGEROUS_LEFT_TURN_CURVE ("dangerousLeftTurnCurve", 1, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
+    DANGEROUS_RIGHT_TURN_CURVE ("dangerousRightTurnCurve", 2, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
+    MULTIPLE_CURVES_STARTING_WITH_UNKNOWN_TURNING_DIRECTION ("multipleCurvesStartingWithUnknownTurningDirection", 3, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
+    MULTIPLE_CURVES_STARTING_WITH_LEFT_TURN ("multipleCurvesStartingWithLeftTurn", 4, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
+    MULTIPLE_CURVES_STARTING_WITH_RIGHT_TURN ("multipleCurvesStartingWithRightTurn", 5, HazardCategory.HAZARDOUS_LOCATION_DANGEROUS_CURVE),
 
-    HAZARDOUS_LOCATION_DANGEROUS_CURVE_NO_SUBCAUSE ("dangerousCurve", 0, 96),
-    DANGEROUS_LEFT_TURN_CURVE ("dangerousLeftTurnCurve", 1, 96),
-    DANGEROUS_RIGHT_TURN_CURVE ("dangerousRightTurnCurve", 2, 96),
-    MULTIPLE_CURVES_STARTING_WITH_UNKNOWN_TURNING_DIRECTION ("multipleCurvesStartingWithUnknownTurningDirection", 3, 96),
-    MULTIPLE_CURVES_STARTING_WITH_LEFT_TURN ("multipleCurvesStartingWithLeftTurn", 4, 96),
-    MULTIPLE_CURVES_STARTING_WITH_RIGHT_TURN ("multipleCurvesStartingWithRightTurn", 5, 96),
+    COLLISION_RISK_NO_SUBCAUSE ("collisionRisk", 0, HazardCategory.COLLISION_RISK),
+    LONGITUDINAL_COLLISION_RISK ("longitudinalCollisionRisk", 1, HazardCategory.COLLISION_RISK),
+    CROSSING_COLLISION_RISK ("crossingCollisionRisk", 2, HazardCategory.COLLISION_RISK),
+    LATERAL_COLLISION_RISK ("lateralCollisionRisk", 3, HazardCategory.COLLISION_RISK),
+    VULNERABLE_ROAD_USER ("vulnerableRoadUser", 4, HazardCategory.COLLISION_RISK),
 
-    COLLISION_RISK_NO_SUBCAUSE ("collisionRisk", 0, 97),
-    LONGITUDINAL_COLLISION_RISK ("longitudinalCollisionRisk", 1, 97),
-    CROSSING_COLLISION_RISK ("crossingCollisionRisk", 2, 97),
-    LATERAL_COLLISION_RISK ("lateralCollisionRisk", 3, 97),
-    VULNERABLE_ROAD_USER ("vulnerableRoadUser", 4, 97),
+    STOP_SIGN_VIOLATION_NO_SUBCAUSE ("stopSignViolation", 0, HazardCategory.SIGNAL_VIOLATION),
+    STOP_SIGN_VIOLATION ("stopSignViolation", 1, HazardCategory.SIGNAL_VIOLATION),
+    TRAFFIC_LIGHT_VIOLATION ("trafficLightViolation", 2, HazardCategory.SIGNAL_VIOLATION),
+    TURNING_REGULATION_VIOLATION ("turningRegulationViolation", 3, HazardCategory.SIGNAL_VIOLATION),
 
-    STOP_SIGN_VIOLATION_NO_SUBCAUSE ("stopSignViolation", 0, 98),
-    STOP_SIGN_VIOLATION ("stopSignViolation", 1, 98),
-    TRAFFIC_LIGHT_VIOLATION ("trafficLightViolation", 2, 98),
-    TURNING_REGULATION_VIOLATION ("turningRegulationViolation", 3, 98),
+    DANGEROUS_SITUATION_NO_SUBCAUSE ("dangerousSituation", 0, HazardCategory.DANGEROUS_SITUATION),
+    EMERGENCY_ELECTRONIC_BRAKE_ENGAGED ("emergencyElectronicBrakeEngaged", 1, HazardCategory.DANGEROUS_SITUATION),
+    PRE_CRASH_SYSTEM_ENGAGED ("preCrashSystemEngaged", 2, HazardCategory.DANGEROUS_SITUATION),
+    ESP_ENGAGED ("espEngaged", 3, HazardCategory.DANGEROUS_SITUATION),
+    ABS_ENGAGED ("absEngaged", 4, HazardCategory.DANGEROUS_SITUATION),
+    AEB_ENGAGED ("aebEngaged", 5, HazardCategory.DANGEROUS_SITUATION),
+    BRAKE_WARNING_ENGAGED ("brakeWarningEngaged", 6, HazardCategory.DANGEROUS_SITUATION),
+    COLLISION_RISK_WARNING_ENGAGED ("collisionRiskWarningEngaged", 7, HazardCategory.DANGEROUS_SITUATION);
 
-    DANGEROUS_SITUATION_NO_SUBCAUSE ("dangerousSituation", 0, 99),
-    EMERGENCY_ELECTRONIC_BRAKE_ENGAGED ("emergencyElectronicBrakeEngaged", 1, 99),
-    PRE_CRASH_SYSTEM_ENGAGED ("preCrashSystemEngaged", 2, 99),
-    ESP_ENGAGED ("espEngaged", 3, 99),
-    ABS_ENGAGED ("absEngaged", 4, 99),
-    AEB_ENGAGED ("aebEngaged", 5, 99),
-    BRAKE_WARNING_ENGAGED ("brakeWarningEngaged", 6, 99),
-    COLLISION_RISK_WARNING_ENGAGED ("collisionRiskWarningEngaged", 7, 99);
-	
-	final String name;
-	final int cause;
-	final int subcause;
+    final String name;
+    final HazardCategory hazardCategory;
+    final int subcause;
 
-	private HazardType(String name, int subcause, int cause) {
-		this.name = name;
-		this.cause = cause;
-		this.subcause = subcause;
-	}
-	
-	public String getName() {
-		return name;
-	}
+    HazardType(String name, int subcause, HazardCategory hazardCategory) {
+        this.name = name;
+        this.hazardCategory = hazardCategory;
+        this.subcause = subcause;
+    }
 
-	public int getCause() {
-		return cause;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public int getSubcause() {
-		return subcause;
-	}
+    public HazardCategory getCategory() {
+        return hazardCategory;
+    }
+
+    public int getCause() {
+        return hazardCategory.getCause();
+    }
+
+    public int getSubcause() {
+        return subcause;
+    }
 
 }

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/HazardCategory.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/HazardCategory.java
@@ -5,7 +5,7 @@
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
-package com.orange.iot3mobility.its;
+package com.orange.iot3mobility.roadobjects;
 
 public enum HazardCategory {
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/HazardType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/HazardType.java
@@ -5,7 +5,7 @@
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
-package com.orange.iot3mobility.its;
+package com.orange.iot3mobility.roadobjects;
 
 public enum HazardType {
 	

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadHazard.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadHazard.java
@@ -8,7 +8,6 @@
 package com.orange.iot3mobility.roadobjects;
 
 import com.orange.iot3mobility.TrueTime;
-import com.orange.iot3mobility.its.HazardType;
 import com.orange.iot3mobility.its.json.denm.DENM;
 import com.orange.iot3mobility.quadkey.LatLng;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadHazard.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadHazard.java
@@ -14,22 +14,12 @@ import com.orange.iot3mobility.quadkey.LatLng;
 public class RoadHazard {
 
     private final String uuid;
-    private final int cause;
-    private final int subcause;
-    private LatLng position;
-    private long timestamp;
-    private int lifetime;
     private HazardType hazardType;
     private DENM denm;
 
-    public RoadHazard(String uuid, int cause, int subcause, LatLng position, int lifetime, long timestamp, DENM denm) {
+    public RoadHazard(String uuid, DENM denm) {
         this.uuid = uuid;
-        this.cause = cause;
-        this.subcause = subcause;
-        this.position = position;
-        this.lifetime = lifetime;
         this.denm = denm;
-        this.timestamp = timestamp;
         findHazardType();
     }
 
@@ -38,30 +28,19 @@ public class RoadHazard {
     }
 
     public LatLng getPosition() {
-        return position;
-    }
-
-    public void setPosition(LatLng position) {
-        this.position = position;
+        return new LatLng(denm.getManagementContainer().getEventPosition().getLatitudeDegree(),
+                denm.getManagementContainer().getEventPosition().getLongitudeDegree());
     }
 
     public long getTimestamp() {
-        return timestamp;
-    }
-
-    public void updateTimestamp(long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    public void setLifetime(int lifetime) {
-        this.lifetime = lifetime;
+        return denm.getTimestamp();
     }
 
     public boolean stillLiving() {
-        return TrueTime.getAccurateTime() - timestamp < lifetime;
+        return TrueTime.getAccurateTime() - getTimestamp() < denm.getManagementContainer().getValidityDuration() * 1000L;
     }
 
-    public HazardType getHazardType() {
+    public HazardType getType() {
         return hazardType;
     }
 
@@ -74,6 +53,8 @@ public class RoadHazard {
     }
 
     private void findHazardType() {
+        int cause = denm.getSituationContainer().getEventType().getCause();
+        int subcause = denm.getSituationContainer().getEventType().getSubcause();
         for(HazardType hazard: HazardType.values()) {
             if(hazard.getCause() == cause && hazard.getSubcause() == subcause) {
                 hazardType = hazard;


### PR DESCRIPTION
Changes
=======

* IoT3 Mobility SDK:
    * A new `HazardCategory` object has been added to complement the existing `HazardType`. E.g. `roadHazard.getType().getCategory()`. The categories represent the different DENM cause codes.
    * The `RoadHazard` object has been cleaned up with the removal of unecessary constructor parameters and setters.

Close #411 

Test
====

How to test
-------

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Iot3MobilityExample``` class in the ```examples``` module, and set appropriate values for the following fields:
```
    private static final String EXAMPLE_UUID = "uuid";
    private static final String EXAMPLE_CONTEXT = "context";
    // MQTT parameters
    private static final String EXAMPLE_MQTT_HOST = "mqtt_host";
    private static final int EXAMPLE_MQTT_PORT = 1883;
    private static final String EXAMPLE_MQTT_USERNAME = "mqtt_username";
    private static final String EXAMPLE_MQTT_PASSWORD = "mqtt_password";
    private static final boolean EXAMPLE_MQTT_USE_TLS = true;
```
4. In the RoadHazardCallback, add some code to check that you can access the HazardCategory of the received RoadHazard objects (Like `System.out.println("Road Hazard category: " + roadHazard.getType().getCategory());`).
5. Run ```Iot3MobilityExample```.

Expected results:
-------

On the console, you should see that the received RoadHazards are from the `ACCIDENT` category.
