### PR TITLE
swift: fix mobility stop

### DIFF
--- a/swift/ITSClient/Sources/ITSMobility/Mobility.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Mobility.swift
@@ -79,6 +79,8 @@ public actor Mobility {
     public func stop() async {
         await core.stop()
         regionOfInterestCoordinator.reset()
+        await roadAlarmCoordinator.reset()
+        await roadUserCoordinator.reset()
     }
 
     /// Sets an observer to observe changes on road alarms.

--- a/swift/ITSClient/Sources/ITSMobility/Mobility.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Mobility.swift
@@ -78,6 +78,7 @@ public actor Mobility {
     /// Stops the `Mobility` disconnecting the MQTT client and stopping the telemetry client.
     public func stop() async {
         await core.stop()
+        regionOfInterestCoordinator.reset()
     }
 
     /// Sets an observer to observe changes on road alarms.

--- a/swift/ITSClient/Sources/ITSMobility/Observers/Cache.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Observers/Cache.swift
@@ -44,8 +44,10 @@ actor Cache<K: Hashable, V: Sendable> {
         cache.removeValue(forKey: key)
     }
 
-    func clear() {
+    func clear() -> [Entry] {
+        let entriesRemoved = Array(cache.values)
         cache.removeAll()
+        return entriesRemoved
     }
 
     private func startRemovingExpiredEntries() {

--- a/swift/ITSClient/Sources/ITSMobility/Observers/RoadAlarm/RoadAlarmCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Observers/RoadAlarm/RoadAlarmCoordinator.swift
@@ -31,6 +31,13 @@ actor RoadAlarmCoordinator {
         self.observer = observer
     }
 
+    func reset() async {
+        let entriesRemoved = await cache.clear()
+        for entryRemoved in entriesRemoved {
+            await observer?.didDelete(entryRemoved.value)
+        }
+    }
+
     func handleRoadAlarm(withPayload payload: Data) async {
         guard let observer,
               let denm = try? JSONDecoder().decode(DENM.self, from: payload) else { return }

--- a/swift/ITSClient/Sources/ITSMobility/Observers/RoadUser/RoadUserCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/Observers/RoadUser/RoadUserCoordinator.swift
@@ -31,6 +31,13 @@ actor RoadUserCoordinator {
         self.observer = observer
     }
 
+    func reset() async {
+        let entriesRemoved = await cache.clear()
+        for entryRemoved in entriesRemoved {
+            await observer?.didDelete(entryRemoved.value)
+        }
+    }
+
     func handleRoadUser(withPayload payload: Data) async {
         guard let observer,
               let cam = try? JSONDecoder().decode(CAM.self, from: payload) else { return }

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
@@ -49,6 +49,11 @@ final class RegionOfInterestCoordinator {
                                currentRegionOfInterest: &currentCAMRegionOfInterest)
     }
 
+    func reset() {
+        currentDENMRegionOfInterest = nil
+        currentCAMRegionOfInterest = nil
+    }
+
     private func updateRegionOfInterest(
         for messageType: MessageType,
         latitude: Double,


### PR DESCRIPTION
**What's new**

When the mobility stack is stopped, the subscriptions are reset. The road object caches are also reset and the client will be notified with delete events to clean the objects on its side.

Closes #422 