### PR TITLE
swift: manage transient states and synchronize ROI subscriptions

### DIFF
--- a/swift/.swiftlint.yml
+++ b/swift/.swiftlint.yml
@@ -164,8 +164,8 @@ function_body_length:
     error: 80
     
 function_parameter_count:
-    warning: 6
-    error: 8
+    warning: 8
+    error: 10
 
 implicit_getter:
     severity: error

--- a/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
+++ b/swift/ITSClient/Sources/ITSMobility/MobilityError.swift
@@ -13,7 +13,7 @@ import Foundation
 import ITSCore
 
 /// The errors thrown by the mobility.
-public enum MobilityError: Error {
+public enum MobilityError: Error, Equatable {
     /// The mobilty start failed.
     case startFailed(CoreError)
     /// The mobility must be started before performing this action.

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterest.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterest.swift
@@ -11,11 +11,18 @@
 
 import Foundation
 
-struct RegionOfInterest {
-    let quadkey: String
-    let neighborQuadkeys: [String]
+struct RegionOfInterest: Equatable {
+    private(set)var quadkeys: [String]
 
-    var allQuadkeys: [String] {
-        [quadkey] + neighborQuadkeys
+    mutating func addQuadkey(_ quadkey: String) {
+        if !quadkeys.contains(quadkey) {
+            quadkeys.append(quadkey)
+        }
+    }
+
+    mutating func removeQuadkey(_ quadkey: String) {
+        if let index = quadkeys.firstIndex(where: { quadkey == $0 }) {
+            quadkeys.remove(at: index)
+        }
     }
 }

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestCoordinator.swift
@@ -11,12 +11,7 @@
 
 import Foundation
 
-final class RegionOfInterestCoordinator {
-    struct TopicUpdateRequest {
-        let subscriptions: [String]
-        let unsubscriptions: [String]
-    }
-
+actor RegionOfInterestCoordinator {
     private let quadkeyBuilder = QuadkeyBuilder()
     private var currentDENMRegionOfInterest: RegionOfInterest?
     private var currentCAMRegionOfInterest: RegionOfInterest?
@@ -25,28 +20,38 @@ final class RegionOfInterestCoordinator {
         latitude: Double,
         longitude: Double,
         zoomLevel: Int,
-        namespace: String
-    ) -> TopicUpdateRequest? {
-        updateRegionOfInterest(for: .denm,
-                               latitude: latitude,
-                               longitude: longitude,
-                               zoomLevel: zoomLevel,
-                               namespace: namespace,
-                               currentRegionOfInterest: &currentDENMRegionOfInterest)
+        namespace: String,
+        subscriber: RegionOfInterestSubscriber
+    ) async {
+        let regionOfInterest = await updateRegionOfInterest(for: .denm,
+                                                            latitude: latitude,
+                                                            longitude: longitude,
+                                                            zoomLevel: zoomLevel,
+                                                            namespace: namespace,
+                                                            currentRegionOfInterest: currentDENMRegionOfInterest,
+                                                            subscriber: subscriber)
+        if currentDENMRegionOfInterest != regionOfInterest {
+            currentDENMRegionOfInterest = regionOfInterest
+        }
     }
 
     func updateRoadUserRegionOfInterest(
         latitude: Double,
         longitude: Double,
         zoomLevel: Int,
-        namespace: String
-    ) -> TopicUpdateRequest? {
-        updateRegionOfInterest(for: .cam,
-                               latitude: latitude,
-                               longitude: longitude,
-                               zoomLevel: zoomLevel,
-                               namespace: namespace,
-                               currentRegionOfInterest: &currentCAMRegionOfInterest)
+        namespace: String,
+        subscriber: RegionOfInterestSubscriber
+    ) async {
+        let regionOfInterest = await updateRegionOfInterest(for: .cam,
+                                                            latitude: latitude,
+                                                            longitude: longitude,
+                                                            zoomLevel: zoomLevel,
+                                                            namespace: namespace,
+                                                            currentRegionOfInterest: currentCAMRegionOfInterest,
+                                                            subscriber: subscriber)
+        if currentCAMRegionOfInterest != regionOfInterest {
+            currentCAMRegionOfInterest = regionOfInterest
+        }
     }
 
     func reset() {
@@ -60,57 +65,32 @@ final class RegionOfInterestCoordinator {
         longitude: Double,
         zoomLevel: Int,
         namespace: String,
-        currentRegionOfInterest: inout RegionOfInterest?) -> TopicUpdateRequest? {
+        currentRegionOfInterest: RegionOfInterest?,
+        subscriber: RegionOfInterestSubscriber) async -> RegionOfInterest
+    {
         let separator = "/"
         let quadkey = quadkeyBuilder.quadkeyFrom(latitude: latitude,
                                                  longitude: longitude,
                                                  zoomLevel: zoomLevel,
                                                  separator: separator)
 
-        guard quadkey != currentRegionOfInterest?.quadkey else {
-            return nil
-        }
-
         let neighborQuadkeys = quadkeyBuilder.neighborQuadkeys(for: quadkey, separator: separator)
-        let regionOfInterest = RegionOfInterest(quadkey: quadkey,
-                                                neighborQuadkeys: neighborQuadkeys)
-        let topicUpdate = updateTopicSubscriptions(newRegionOfInterest: regionOfInterest,
-                                                   currentRegionOfInterest: currentRegionOfInterest,
-                                                   for: messageType,
-                                                   namespace: namespace)
-        currentRegionOfInterest = regionOfInterest
+        var regionOfInterest = RegionOfInterest(quadkeys: [quadkey] + neighborQuadkeys)
+        let topicUpdate = RegionOfInterestTopicBuilder.buildTopicSubscriptions(
+            newRegionOfInterest: regionOfInterest,
+            currentRegionOfInterest: currentRegionOfInterest,
+            for: messageType,
+            namespace: namespace
+        )
 
-        return topicUpdate
-    }
-
-    private func updateTopicSubscriptions(
-        newRegionOfInterest: RegionOfInterest,
-        currentRegionOfInterest: RegionOfInterest?,
-        for messageType: MessageType,
-        namespace: String
-    ) -> TopicUpdateRequest {
-        var subscriptions = [String]()
-        var unsubscriptions = [String]()
-
-        let newQuadkeys = newRegionOfInterest.allQuadkeys
-        let currentQuadkeys = currentRegionOfInterest?.allQuadkeys ?? []
-
-        newQuadkeys.forEach { newQuadkey in
-            if !currentQuadkeys.contains(newQuadkey) {
-                subscriptions.append(topic(for: messageType, in: newQuadkey, namespace: namespace))
-            }
+        for updateItem in topicUpdate.subscriptions where await !subscriber.subscribe(topic: updateItem.topic) {
+            regionOfInterest.removeQuadkey(updateItem.quadkey)
         }
 
-        currentQuadkeys.forEach { currentQuadkey in
-            if !newQuadkeys.contains(currentQuadkey) {
-                unsubscriptions.append(topic(for: messageType, in: currentQuadkey, namespace: namespace))
-            }
+        for updateItem in topicUpdate.unsubscriptions where await !subscriber.unsubscribe(topic: updateItem.topic) {
+            regionOfInterest.addQuadkey(updateItem.quadkey)
         }
 
-        return TopicUpdateRequest(subscriptions: subscriptions, unsubscriptions: unsubscriptions)
-    }
-
-    private func topic(for messageType: MessageType, in quadkey: String, namespace: String) -> String {
-        "\(namespace)/outQueue/v2x/\(messageType)/+/\(quadkey)/#"
+        return regionOfInterest
     }
 }

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestSubscriber.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestSubscriber.swift
@@ -1,0 +1,17 @@
+//
+// Software Name: SWRMobility
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+//
+// This software is confidential and proprietary information of Orange SA.
+// You shall not disclose such Confidential Information and shall not copy,
+// use or distribute it in whole or in part without the prior written
+// consent of Orange SA.
+//
+// Software description: SWRMobility is a V2X collision prevention solution.
+
+import Foundation
+
+protocol RegionOfInterestSubscriber: Actor {
+    func subscribe(topic: String) async -> Bool
+    func unsubscribe(topic: String) async -> Bool
+}

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestTopicBuilder.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/RegionOfInterestTopicBuilder.swift
@@ -1,0 +1,48 @@
+//
+// Software Name: SWRMobility
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+//
+// This software is confidential and proprietary information of Orange SA.
+// You shall not disclose such Confidential Information and shall not copy,
+// use or distribute it in whole or in part without the prior written
+// consent of Orange SA.
+//
+// Software description: SWRMobility is a V2X collision prevention solution.
+
+enum RegionOfInterestTopicBuilder {
+    static func buildTopicSubscriptions(
+        newRegionOfInterest: RegionOfInterest,
+        currentRegionOfInterest: RegionOfInterest?,
+        for messageType: MessageType,
+        namespace: String
+    ) -> TopicUpdateRequest {
+        var subscriptions = [TopicUpdateItem]()
+        var unsubscriptions = [TopicUpdateItem]()
+
+        let newQuadkeys = newRegionOfInterest.quadkeys
+        let currentQuadkeys = currentRegionOfInterest?.quadkeys ?? []
+
+        newQuadkeys.forEach { newQuadkey in
+            if !currentQuadkeys.contains(newQuadkey) {
+                let updateItem = TopicUpdateItem(topic: topic(for: messageType, in: newQuadkey, namespace: namespace),
+                                                 quadkey: newQuadkey)
+                subscriptions.append(updateItem)
+            }
+        }
+
+        currentQuadkeys.forEach { currentQuadkey in
+            if !newQuadkeys.contains(currentQuadkey) {
+                let topic = topic(for: messageType, in: currentQuadkey, namespace: namespace)
+                let updateItem = TopicUpdateItem(topic: topic,
+                                                 quadkey: currentQuadkey)
+                unsubscriptions.append(updateItem)
+            }
+        }
+
+        return TopicUpdateRequest(subscriptions: subscriptions, unsubscriptions: unsubscriptions)
+    }
+
+    private static func topic(for messageType: MessageType, in quadkey: String, namespace: String) -> String {
+        "\(namespace)/outQueue/v2x/\(messageType)/+/\(quadkey)/#"
+    }
+}

--- a/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/TopicUpdateRequest.swift
+++ b/swift/ITSClient/Sources/ITSMobility/RegionOfInterest/TopicUpdateRequest.swift
@@ -1,0 +1,22 @@
+//
+// Software Name: SWRMobility
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+//
+// This software is confidential and proprietary information of Orange SA.
+// You shall not disclose such Confidential Information and shall not copy,
+// use or distribute it in whole or in part without the prior written
+// consent of Orange SA.
+//
+// Software description: SWRMobility is a V2X collision prevention solution.
+
+import Foundation
+
+struct TopicUpdateRequest {
+        let subscriptions: [TopicUpdateItem]
+        let unsubscriptions: [TopicUpdateItem]
+}
+
+struct TopicUpdateItem {
+    let topic: String
+    let quadkey: String
+}

--- a/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/MobilityTests.swift
@@ -34,7 +34,7 @@ struct MobilityTests {
     }
 
     @Test("Send user position should send a payload on a topic computed from coordinates")
-    func send_position_should_send_payload_on_topic_computed_from_coordinates() async throws {
+    func send_user_position_should_send_payload_on_topic_computed_from_coordinates() async throws {
         try await mobility.start(mobilityConfiguration: mobilityConfiguration)
         try await mobility.sendUserPosition(stationType: .pedestrian,
                                             latitude: 43.63516355648167,
@@ -58,5 +58,46 @@ struct MobilityTests {
         await mobility.stop()
         // Wait a bit for the spans flush
         try await Task.sleep(seconds: 0.5)
+    }
+
+    @Test("Send user position when stopping should throw a not started error")
+    func send_user_position_when_stopping_should_throw_not_started_error() async throws {
+        try await mobility.start(mobilityConfiguration: mobilityConfiguration)
+        Task {
+            await mobility.stop()
+        }
+        Task {
+            do {
+                try await mobility.sendUserPosition(stationType: .pedestrian,
+                                                    latitude: 43.63516355648167,
+                                                    longitude: 1.3744570239910097,
+                                                    altitude: 155,
+                                                    heading: 45,
+                                                    speed: 8.1)
+                Issue.record("An not started error must be thrown")
+            } catch {
+                // Then
+                #expect((error as? MobilityError) == .notStarted)
+            }
+        }
+    }
+
+    @Test("Update road user ROI when stopping should throw a not started error")
+    func update_road_user_ROI_when_stopping_should_throw_not_started_error() async throws {
+        try await mobility.start(mobilityConfiguration: mobilityConfiguration)
+        Task {
+            await mobility.stop()
+        }
+        Task {
+            do {
+                try await mobility.updateRoadUserRegionOfInterest(latitude: 43.63516355648167,
+                                                                  longitude: 1.3744570239910097,
+                                                                  zoomLevel: 15)
+                Issue.record("An not started error must be thrown")
+            } catch {
+                // Then
+                #expect((error as? MobilityError) == .notStarted)
+            }
+        }
     }
 }

--- a/swift/ITSClient/Tests/ITSMobilityTests/MockRegionOfInterestSubscriber.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/MockRegionOfInterestSubscriber.swift
@@ -1,0 +1,29 @@
+//
+// Software Name: SWRMobility
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+//
+// This software is confidential and proprietary information of Orange SA.
+// You shall not disclose such Confidential Information and shall not copy,
+// use or distribute it in whole or in part without the prior written
+// consent of Orange SA.
+//
+// Software description: SWRMobility is a V2X collision prevention solution.
+
+import Foundation
+@testable import ITSMobility
+import Testing
+
+actor MockRegionOfInterestSubscriber: RegionOfInterestSubscriber {
+    private(set)var numberOfSubscriptionsCalled = 0
+    private(set)var numberOfUnsubscriptionsCalled = 0
+
+    func subscribe(topic: String) async -> Bool {
+        numberOfSubscriptionsCalled += 1
+        return true
+    }
+
+    func unsubscribe(topic: String) async -> Bool {
+        numberOfUnsubscriptionsCalled += 1
+        return true
+    }
+}

--- a/swift/ITSClient/Tests/ITSMobilityTests/RegionOfInterestCoordinatorTests.swift
+++ b/swift/ITSClient/Tests/ITSMobilityTests/RegionOfInterestCoordinatorTests.swift
@@ -16,86 +16,111 @@ import Testing
 struct RegionOfInterestCoordinatorTests {
     private let namespace = "default"
 
-    @Test("Updating road alarm ROI should return 9 subscriptions and 0 unsubscription the first time")
-    func updating_road_alarm_roi_should_return_9_subscriptions_and_0_unsubscription_first_time() throws {
+    @Test("Updating road alarm ROI should make 9 subscriptions and 0 unsubscription the first time")
+    func updating_road_alarm_roi_should_make_9_subscriptions_and_0_unsubscription_first_time() async throws {
         // Given
         let regionOfInterestCoordinator = RegionOfInterestCoordinator()
 
         // When
-        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+        let mockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
             latitude: 43.63516355648167,
             longitude: 1.3744570239910097,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: mockSubscriber
+        )
 
         // Then
-        let unwrapRequestUpdate = try #require(requestUpdate)
-        #expect(unwrapRequestUpdate.subscriptions.count == 9)
-        #expect(unwrapRequestUpdate.unsubscriptions.isEmpty)
+        #expect(await mockSubscriber.numberOfSubscriptionsCalled == 9)
+        #expect(await mockSubscriber.numberOfUnsubscriptionsCalled == 0)
     }
 
-    @Test("Updating road alarm ROI should return 9 subscriptions and 9 unsubscriptions when moving")
-    func updating_road_alarm_roi_should_return_9_subscriptions_and_9_unsubscriptions_when_moving() throws {
+    @Test("Updating road alarm ROI should make 9 subscriptions and 9 unsubscriptions when moving")
+    func updating_road_alarm_roi_should_make_9_subscriptions_and_9_unsubscriptions_when_moving() async throws {
         // Given
         let regionOfInterestCoordinator = RegionOfInterestCoordinator()
-        _ = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+        let firstMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
             latitude: 43.63516355648167,
             longitude: 1.3744570239910097,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: firstMockSubscriber
+        )
 
         // When
-        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+        let secondMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
             latitude: 43.64516355648167,
             longitude: 1.3844570239910097,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: secondMockSubscriber
+        )
 
         // Then
-        let unwrapRequestUpdate = try #require(requestUpdate)
-        #expect(unwrapRequestUpdate.subscriptions.count == 9)
-        #expect(unwrapRequestUpdate.unsubscriptions.count == 9)
+        #expect(await firstMockSubscriber.numberOfSubscriptionsCalled == 9)
+        #expect(await firstMockSubscriber.numberOfUnsubscriptionsCalled == 0)
+        #expect(await secondMockSubscriber.numberOfSubscriptionsCalled == 9)
+        #expect(await secondMockSubscriber.numberOfUnsubscriptionsCalled == 9)
     }
 
-    @Test("Updating road alarm ROI should return nil when no update")
-    func updating_road_alarm_roi_should_return_nil_when_no_update() throws {
+    @Test("Updating road alarm ROI should make 0 subscription when no update")
+    func updating_road_alarm_roi_should_make_0_subscription_when_no_update() async throws {
         // Given
         let regionOfInterestCoordinator = RegionOfInterestCoordinator()
-        _ = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+        let firstMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
             latitude: 43.63516355648167,
             longitude: 1.3744570239910097,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: firstMockSubscriber
+        )
 
         // When
-        let requestUpdate = regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
+        let secondMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadAlarmRegionOfInterest(
             latitude: 43.63516355648101,
             longitude: 1.3744570239910001,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: secondMockSubscriber)
 
         // Then
-        #expect(requestUpdate == nil)
+        #expect(await firstMockSubscriber.numberOfSubscriptionsCalled == 9)
+        #expect(await firstMockSubscriber.numberOfUnsubscriptionsCalled == 0)
+        #expect(await secondMockSubscriber.numberOfSubscriptionsCalled == 0)
+        #expect(await secondMockSubscriber.numberOfUnsubscriptionsCalled == 0)
     }
 
-    @Test("Updating road user ROI should return nil when no update")
-    func updating_road_position_roi_should_return_nil_when_no_update() throws {
+    @Test("Updating road user ROI should make 0 subscription when no update")
+    func updating_road_position_roi_should_make_0_subscription_when_no_update() async throws {
         // Given
         let regionOfInterestCoordinator = RegionOfInterestCoordinator()
-        _ = regionOfInterestCoordinator.updateRoadUserRegionOfInterest(
+        let firstMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadUserRegionOfInterest(
             latitude: 43.63516355648167,
             longitude: 1.3744570239910097,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: firstMockSubscriber
+        )
 
         // When
-        let requestUpdate = regionOfInterestCoordinator.updateRoadUserRegionOfInterest(
+        let secondMockSubscriber = MockRegionOfInterestSubscriber()
+        await regionOfInterestCoordinator.updateRoadUserRegionOfInterest(
             latitude: 43.63516355648101,
             longitude: 1.3744570239910001,
             zoomLevel: 22,
-            namespace: namespace)
+            namespace: namespace,
+            subscriber: secondMockSubscriber)
 
         // Then
-        #expect(requestUpdate == nil)
+        #expect(await firstMockSubscriber.numberOfSubscriptionsCalled == 9)
+        #expect(await firstMockSubscriber.numberOfUnsubscriptionsCalled == 0)
+        #expect(await secondMockSubscriber.numberOfSubscriptionsCalled == 0)
+        #expect(await secondMockSubscriber.numberOfUnsubscriptionsCalled == 0)
     }
 }


### PR DESCRIPTION
# Changes

- ITSClient SDK:
  - Synchronize MQTT quad keys subscriptions and ROI managing subscription errors.
  - Mobility: avoid sending messages or subscribing when the mobility is not started.

Close #447

# Test

## How to test

1. Prepare a test environment:
   1. Be sure to have unrestricted access to _test.mosquitto.org_ (IPv4 and IPv6)
   2. In a terminal, prepare a collector implementing
      the OpenTelemetry API, on localhost. If you don't have one,
      you may use an existing one, like:
      ```
      $ docker container run \
          --rm \
          -p 16686:16686 \
          -p 4318:4318 \
          jaegertracing/all-in-one:1.58
      ```
      then open a browser on the Jaegger UI
      (or that of your own collector if you have one):
      ```
      http://localhost:16686/
      ```
2. Run tests
   1. Run unit tests using ITSClient-UnitTests test plan in Xcode.
   2. Run integration tests using ITSClient-UnitTests test plan in Xcode.
   3. Test the sample application running it on a simulator or a physical device.
