### PR TITLE
python/iqm: add support for using MQTT shared subscriptions

### DIFF
--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -5,6 +5,13 @@ instance-id = ora_geo_1234
 #prefix = 5GCroCo
 # Suffix to queue names; default: v2x
 #suffix = v2x
+# Set if multiple instance of the IQM cooperate to distribute the MQTT load.
+# If set, then subscribing to the brokers (local and neighbours) will be made
+# using shared subscriptions, using the instance-id as the subscription share
+# name and adding a random string of hexdigits after the client-id; otherwise
+# (the default), subscribing to the brokers will be done with simple
+# subscriptions.
+#multi-instances
 
 [telemetry]
 # The OpenTelemetry endpoint (without the trailing /v1/traces)


### PR DESCRIPTION
Changes
=======

* applications:
    * interqueuemanager: update some message version

Close #450

Test
====

How to test
-----------

_**Note:** in the following:_
* lines starting with `$` are to be executed on your machine, as a non-root user;
* lines starting with `(docker)$` are to be executed in the Docker container;
* lines starting with `(docker)🐍 $` are to be executed in the Docker container, in the python venv (note: it's a snake, not a duck!)

1. Prepare a test environment:
    1. be sure to have unrestricted access to _test.mosquitto.org_ (IPv4 and IPv6)
    2. be sure to have an MQTT broker that listens locally on port 1883,
       with no credentials and no ACL; if not, run your own:
        ```sh
        $ mosquitto
        ```
    3. in another terminal, prepare a collector implementing the OpenTelemetry API, on localhost. If you don&#39;t have one, you may use an existing one, like:
        ```
        $ docker container run \
            --rm \
            -p 16686:16686 \
            -p 4318:4318 \
            jaegertracing/all-in-one:1.58
        ```
       then open a browser on the Jaegger UI (or that of your own collector if you have one):
        ```
        http://localhost:16686/
        ```
    4. create a test script:
        ```sh
        $ cat >/tmp/load <<_EOF_
        #!/usr/bin/env sh
        while true; do
            printf '{"type": "cam", "origin": "self", "version": "1.1.3", "message": {"protocol_version": 1, "station_id": 21321231, "generation_delta_time": 24470, "basic_container": {"station_type": 5, "reference_position": {"latitude": 447834596, "longitude": -5892960, "altitude": 4600}, "confidence": {"position_confidence_ellipse": {"semi_major_confidence": 10, "semi_minor_confidence": 50, "semi_major_orientation": 1}, "altitude": 1}}, "high_frequency_container": {"heading": '\${RANDOM}', "speed": 0, "longitudinal_acceleration": 0, "drive_direction": 0, "vehicle_length": 40, "vehicle_width": 20, "confidence": {"heading": 2, "speed": 3, "vehicle_length": 0}}, "low_freq_container": {"vehicle_role": 2}},"source_uuid":"flood_123132","timestamp":'\${SECONDS}'}\n'
        done \
        |mosquitto_pub \
            -l \
            -t 'default/inQueue/v2x/cam/flood_13213545464/0/3/1/3/3/3/1/1/1/2/0/1/2/3/2/0/3/0/1/3/1/2'
        _EOF_
        $ chmod 755 /tmp/load
        ```
       **Note**: the generated CAM messages contain random data (`${RANDOM}` and `${SECONDS}`), so no two CAM messages will be identical (statisitcally, at least).
    5. in another terminal, start a container with Python 3.11
       and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.9-slim-bookworm \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential socat psmisc
        $ docker container exec -d iot3 socat UNIX-LISTEN:/tmp/mqtt.socket,fork TCP4:localhost:1883

        $ docker container attach iot3
        ```
       _**Note:**_ the socat command exposes the MQTT broker listening on `localhost:1883` (see 1.2., above), inside the container listening on the UNIX socket `/tmp/mqtt.socket`.
    6. create a configuration file for the IQM:
        ```sh
        (docker)$ cat >/tmp/iqm.cfg <<_EOF_
        [general]
        instance-id = ora_geo_1234
        prefix = default
        suffix = v2x
        multi-instances

        [telemetry]
        endpoint = http://YOUR_IP_ADDRESS:4318

        [local]
        socket-path = /tmp/mqtt.socket
        _EOF_
        ```
    8. prepare a Python 3.11 environment, with tests dependencies and packages' dependencies:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir install \
                        -r python/requirements-tests.txt \
                        $(sed -r -e '/.*"(.+(==|>=|<=).+)".*/!d; s//\1/; s/ //g;' \
                          python/*/pyproject.toml
                         )
        ```
       _**Note:**_ we install the packages dependencies manually, and do not rely on _pip_ to do so, because our Python packages depend one on the others by git hash, as they are not published on PyPi yet, so installing one of our packages may overwrite another.
2. Build the Python packages:
    ```sh
    (docker)🐍 $ for pkg in python/*/; do
                    python -m build "${pkg}" || break
                 done
    ```
3. Install the Python packages:
    ```sh
    (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir \
                        install --no-deps python/*/dist/*.whl
    ```
5. Run a single IQM:
    1. run an mqtt listener:
        ```sh
        $ mosquitto_sub -t '#' -F %t >mqtt-unshared.log
        ```
    2. run the IQM with the configuration file:
        ```sh
        (docker)🐍 $ its-iqm -c /tmp/iqm.cfg &
        ```
    3. run the test-script and wait for completion:
        ```sh
        $ timeout 60 nice -n 19 -- /tmp/load
        ```
    5. kill the mqtt listener
    6. kill the IQM:
        ```sh
        (docker)🐍 $ killall -9 its-iqm
        ```
    7. check the broker logs
    8. check how many messages have been emitted or received on each queue:
        ```sh
        $ grep inQueue mqtt-unshared.log |wc -l
        $ grep outQueue mqtt-unshared.log |wc -l
        $ grep interQueue mqtt-unshared.log |wc -l
        ```
6. Run multiple IQMs in parallel:
    1. run an mqtt listener:
        ```sh
        $ mosquitto_sub -t '#' -F %t >mqtt-shared.log
        ```
    2. run many IQMs with the same configuration file (replace _15_ with the number of CPUs you have, for example)
        ```sh
        (docker)🐍 $ for i in $(seq 15); do its-iqm -c /tmp/iqm.cfg >/dev/null 2>&1 & done
        ```
    3. run the test-script and wait for completion:
        ```sh
        $ timeout 60 nice -n 19 -- /tmp/load
        ```
    5. kill the mqtt listener
    6. kill the IQMs:
        ```sh
        (docker)🐍 $ killall -9 its-iqm
        ```
    7. check the broker logs
    8. check how many messages have been emitted or received on each queue:
        ```sh
        $ grep inQueue mqtt-shared.log |wc -l
        $ grep outQueue mqtt-shared.log |wc -l
        $ grep interQueue mqtt-shared.log |wc -l
        ```

Expected results
----------------

1. The test environment is ready
2. The packages were all built successfully
3. The packages were all installed successfully
4. The single IQM Can't handle the incoming load
    * the broker reports dropping messages delivered to the IQM:
        ```
        Outgoing messages are being dropped for client iqm_[xxxx].
        ```
    * the number of messages received on inQueue is much greater than those on the other queues, which have a very similar number of messages each, e.g.:
        * `inQueue`: 14396484
        * `outQueue`: 402239
        * `interQueue`: 402239
5. The 15 IQMs can handle the load:
    * the broker does not report dropping messages delivered to any IQM
    * the number of messages received on all queues are exactly the same, e.g.:
        * `inQueue`: 1877898
        * `outQueue`: 1877898
        * `interQueue`: 1877898
