### PR TITLE
java/iot3core: remove disconnect timeout

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -149,7 +149,6 @@ public class MqttClient {
         }
         closed = true;
         mqttClient.disconnect()
-                .orTimeout(500, TimeUnit.MILLISECONDS) // don't wait more than 500 milliseconds
                 .whenComplete((mqtt5DisconnectResult, throwable) -> {
                     if(throwable != null) {
                         LOGGER.log(Level.WARNING, "Error during disconnection: " + throwable.getMessage());


### PR DESCRIPTION
**What's been fixed**

Removed CompletableFuture timeout feature that was added in Java 9 and is not compatible with Java 8 used on Android versions < 13.

Close #455 

**What do to**

Just read changes.