### PR TITLE
Fix IoT3Mobility message processing crash

### DIFF
--- a/java/iot3/core/build.gradle
+++ b/java/iot3/core/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.orange.iot3core'
-version '0.1.1'
+version '0.1.2'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/java/iot3/mobility/build.gradle
+++ b/java/iot3/mobility/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.orange.iot3mobility'
-version '0.1.1'
+version '0.1.2'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadHazardManager.java
@@ -43,7 +43,9 @@ public class RoadHazardManager {
         if(ioT3RoadHazardCallback != null) {
             try {
                 DENM denm = DENM.jsonParser(new JSONObject(message));
-                if(denm != null) {
+                if(denm == null) {
+                    LOGGER.log(Level.WARNING, TAG, "DENM parsing returned null");
+                } else {
                     ioT3RoadHazardCallback.denmArrived(denm);
                     //associate the received DENM to a RoadHazard object
                     String uuid = denm.getManagementContainer().getActionId().getOriginatingStationId()

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadSensorManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadSensorManager.java
@@ -42,30 +42,33 @@ public class RoadSensorManager {
         if(ioT3RoadSensorCallback != null) {
             try {
                 CPM cpm = CPM.jsonParser(new JSONObject(message));
-                ioT3RoadSensorCallback.cpmArrived(cpm);
-
-                //associate the received CPM to a RoadSensor object
-                String uuid = cpm.getSourceUuid() + "_" + cpm.getStationId();
-                LatLng position = new LatLng(
-                        cpm.getManagementContainer().getReferencePosition().getLatitudeDegree(),
-                        cpm.getManagementContainer().getReferencePosition().getLongitudeDegree());
-                if(ROAD_SENSOR_MAP.containsKey(uuid)) {
-                    synchronized (ROAD_SENSOR_MAP) {
-                        RoadSensor roadSensor = ROAD_SENSOR_MAP.get(uuid);
-                        if(roadSensor != null) {
-                            roadSensor.updateTimestamp();
-                            roadSensor.setCpm(cpm);
-                            if(cpm.getPerceivedObjectContainer() != null)
-                                roadSensor.updateSensorObjects(cpm.getPerceivedObjectContainer().getPerceivedObjects());
-                            ioT3RoadSensorCallback.roadSensorUpdate(roadSensor);
-                        }
-                    }
+                if(cpm == null) {
+                    LOGGER.log(Level.WARNING, TAG, "CPM parsing returned null");
                 } else {
-                    RoadSensor roadSensor = new RoadSensor(uuid, position, cpm, ioT3RoadSensorCallback);
-                    if(cpm.getPerceivedObjectContainer() != null)
-                        roadSensor.updateSensorObjects(cpm.getPerceivedObjectContainer().getPerceivedObjects());
-                    addRoadSensor(uuid, roadSensor);
-                    ioT3RoadSensorCallback.newRoadSensor(roadSensor);
+                    ioT3RoadSensorCallback.cpmArrived(cpm);
+                    //associate the received CPM to a RoadSensor object
+                    String uuid = cpm.getSourceUuid() + "_" + cpm.getStationId();
+                    LatLng position = new LatLng(
+                            cpm.getManagementContainer().getReferencePosition().getLatitudeDegree(),
+                            cpm.getManagementContainer().getReferencePosition().getLongitudeDegree());
+                    if(ROAD_SENSOR_MAP.containsKey(uuid)) {
+                        synchronized (ROAD_SENSOR_MAP) {
+                            RoadSensor roadSensor = ROAD_SENSOR_MAP.get(uuid);
+                            if(roadSensor != null) {
+                                roadSensor.updateTimestamp();
+                                roadSensor.setCpm(cpm);
+                                if(cpm.getPerceivedObjectContainer() != null)
+                                    roadSensor.updateSensorObjects(cpm.getPerceivedObjectContainer().getPerceivedObjects());
+                                ioT3RoadSensorCallback.roadSensorUpdate(roadSensor);
+                            }
+                        }
+                    } else {
+                        RoadSensor roadSensor = new RoadSensor(uuid, position, cpm, ioT3RoadSensorCallback);
+                        if(cpm.getPerceivedObjectContainer() != null)
+                            roadSensor.updateSensorObjects(cpm.getPerceivedObjectContainer().getPerceivedObjects());
+                        addRoadSensor(uuid, roadSensor);
+                        ioT3RoadSensorCallback.newRoadSensor(roadSensor);
+                    }
                 }
             } catch (JSONException e) {
                 LOGGER.log(Level.WARNING, TAG, "CPM parsing error: " + e);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadUserManager.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/managers/RoadUserManager.java
@@ -43,33 +43,36 @@ public class RoadUserManager {
         if(ioT3RoadUserCallback != null) {
             try {
                 CAM cam = CAM.jsonParser(new JSONObject(message));
-                ioT3RoadUserCallback.camArrived(cam);
-
-                //associate the received CAM to a RoadUser object
-                String uuid = cam.getSourceUuid() + "_" + cam.getStationId();
-                StationType stationType = StationType.fromId(cam.getBasicContainer().getStationType());
-                LatLng position = new LatLng(
-                        cam.getBasicContainer().getPosition().getLatitudeDegree(),
-                        cam.getBasicContainer().getPosition().getLongitudeDegree());
-                float speed = cam.getHighFrequencyContainer().getSpeedMs();
-                float heading = cam.getHighFrequencyContainer().getHeadingDegree();
-                if(ROAD_USER_MAP.containsKey(uuid)) {
-                    synchronized (ROAD_USER_MAP) {
-                        RoadUser roadUser = ROAD_USER_MAP.get(uuid);
-                        if(roadUser != null) {
-                            roadUser.updateTimestamp();
-                            roadUser.setStationType(stationType);
-                            roadUser.setPosition(position);
-                            roadUser.setSpeed(speed);
-                            roadUser.setHeading(heading);
-                            roadUser.setCam(cam);
-                            ioT3RoadUserCallback.roadUserUpdate(roadUser);
-                        }
-                    }
+                if(cam == null) {
+                    LOGGER.log(Level.WARNING, TAG, "CAM parsing returned null");
                 } else {
-                    RoadUser roadUser = new RoadUser(uuid, stationType, position, speed, heading, cam);
-                    addRoadUser(uuid, roadUser);
-                    ioT3RoadUserCallback.newRoadUser(roadUser);
+                    ioT3RoadUserCallback.camArrived(cam);
+                    //associate the received CAM to a RoadUser object
+                    String uuid = cam.getSourceUuid() + "_" + cam.getStationId();
+                    StationType stationType = StationType.fromId(cam.getBasicContainer().getStationType());
+                    LatLng position = new LatLng(
+                            cam.getBasicContainer().getPosition().getLatitudeDegree(),
+                            cam.getBasicContainer().getPosition().getLongitudeDegree());
+                    float speed = cam.getHighFrequencyContainer().getSpeedMs();
+                    float heading = cam.getHighFrequencyContainer().getHeadingDegree();
+                    if(ROAD_USER_MAP.containsKey(uuid)) {
+                        synchronized (ROAD_USER_MAP) {
+                            RoadUser roadUser = ROAD_USER_MAP.get(uuid);
+                            if(roadUser != null) {
+                                roadUser.updateTimestamp();
+                                roadUser.setStationType(stationType);
+                                roadUser.setPosition(position);
+                                roadUser.setSpeed(speed);
+                                roadUser.setHeading(heading);
+                                roadUser.setCam(cam);
+                                ioT3RoadUserCallback.roadUserUpdate(roadUser);
+                            }
+                        }
+                    } else {
+                        RoadUser roadUser = new RoadUser(uuid, stationType, position, speed, heading, cam);
+                        addRoadUser(uuid, roadUser);
+                        ioT3RoadUserCallback.newRoadUser(roadUser);
+                    }
                 }
             } catch (JSONException e) {
                 LOGGER.log(Level.WARNING, TAG, "CAM parsing error: " + e);


### PR DESCRIPTION
**What changed**

Check if the CAM, DENM or CPM message parser didn't return null before processing them.
Bumped version of IoT3Core and IoT3Mobility to 0.1.2.

Close #462 

**What to do**

Read changes.