### PR TITLE
CAM message payload format

### DIFF
--- a/schema/cam/cam_schema_2-3-0.json
+++ b/schema/cam/cam_schema_2-3-0.json
@@ -56,7 +56,7 @@
     "version": {
       "type": "string",
       "description": "JSON message format version.",
-      "const": "2.3.0-dev"
+      "const": "2.3.0"
     },
     "message": {
       "type": "object",


### PR DESCRIPTION
What's new
---------------

### CAM version 2.3.0

- `message` property payload is now accepting several formats using `oneOf` array
- Add a new `message_format` at root to indicate what payload is carried by the `message` property

Related to #382 