### PR TITLE
python/iqm: allow connecting via TCP, TLS, websockets

### DIFF
--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -29,7 +29,7 @@ endpoint = http://opentelemetry.example.com:1234
 # - establish a TCP-like connection over the UNIX socket socket-path
 # Hostname or IP of the local broker
 host = 127.0.0.1
-# TCP port the local broker listens on (non-TLS)
+# TCP port the local broker listens on (non-TLS); default: 1883
 port = 1883
 # Path to the UNIX socket to connect to; if specified, host and port are ignored
 #socket-path = /run/mqtt-broker/socket

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -23,8 +23,16 @@ endpoint = http://opentelemetry.example.com:1234
 #password = secret
 
 [local]
-# Path to the UNIX socket to connect to the broker
-socket-path = /run/mosquitto/mqtt.socket
+# There are two ways to connect to the local broker, and either,
+# not both, is required:
+# - establish a TCP/IP connection to host:port
+# - establish a TCP-like connection over the UNIX socket socket-path
+# Hostname or IP of the local broker
+host = 127.0.0.1
+# TCP port the local broker listens on (non-TLS)
+port = 1883
+# Path to the UNIX socket to connect to
+#socket-path = /run/mqtt-broker/socket
 # Username and password to authenticate with against the local broker,
 # empty or unset username for no authentication; default: unset
 #username = user

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -31,7 +31,9 @@ endpoint = http://opentelemetry.example.com:1234
 host = 127.0.0.1
 # TCP port the local broker listens on (non-TLS); default: 1883
 port = 1883
-# Path to the UNIX socket to connect to; if specified, host and port are ignored
+# Whether to connect using TLS over TCP; default: use TLS, unless port == 1883
+# tls = True|False
+# Path to the UNIX socket to connect to; if specified, host, port, and tls are ignored
 #socket-path = /run/mqtt-broker/socket
 # Username and password to authenticate with against the local broker,
 # empty or unset username for no authentication; default: unset

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -33,7 +33,10 @@ host = 127.0.0.1
 port = 1883
 # Whether to connect using TLS over TCP; default: use TLS, unless port == 1883
 # tls = True|False
-# Path to the UNIX socket to connect to; if specified, host, port, and tls are ignored
+# Path of the websocket; if unset, do not use WebSockets; default: unset
+#websocket_path = /mqtt
+# Path to the UNIX socket to connect to; if specified, host, port, tls, and
+# websocket_path are ignored
 #socket-path = /run/mqtt-broker/socket
 # Username and password to authenticate with against the local broker,
 # empty or unset username for no authentication; default: unset

--- a/python/its-interqueuemanager/its-iqm.cfg
+++ b/python/its-interqueuemanager/its-iqm.cfg
@@ -31,7 +31,7 @@ endpoint = http://opentelemetry.example.com:1234
 host = 127.0.0.1
 # TCP port the local broker listens on (non-TLS)
 port = 1883
-# Path to the UNIX socket to connect to
+# Path to the UNIX socket to connect to; if specified, host and port are ignored
 #socket-path = /run/mqtt-broker/socket
 # Username and password to authenticate with against the local broker,
 # empty or unset username for no authentication; default: unset

--- a/python/its-interqueuemanager/src/its_iqm/authority/mqtt.py
+++ b/python/its-interqueuemanager/src/its_iqm/authority/mqtt.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 import iot3.core.mqtt
+from its_iqm.helpers import str2bool
 
 
 class Authority:
@@ -29,7 +30,7 @@ class Authority:
             host=self.cfg["host"],
             port=int(self.cfg["port"]),
             websocket_path=self.cfg.get("websocket_path"),
-            tls=self.cfg.get("tls"),
+            tls=str2bool(self.cfg.get("tls")),
             username=self.cfg.get("username"),
             password=self.cfg.get("password"),
             msg_cb=self.msg_cb,

--- a/python/its-interqueuemanager/src/its_iqm/helpers.py
+++ b/python/its-interqueuemanager/src/its_iqm/helpers.py
@@ -1,0 +1,31 @@
+# Software Name: its-interqueuemanager
+# SPDX-FileCopyrightText: Copyright (c) 2023 Orange
+# SPDX-License-Identifier: MIT
+# Author: Yann E. MORIN <yann.morin@orange.com>
+
+from configparser import ConfigParser
+from typing import Any, Optional
+
+
+def str2bool(
+    value: Optional[str],
+    *,
+    fallback: Any = None,
+):
+    """Convert a string to a boolean
+
+    If value is None, default is returned. Otherwise, the boolean
+    corresponding to value is returned; value can be any of the
+    boolean values define by the module configparser, e.g. "False",
+    "True", etc…
+
+    The signature is similar to that of configparser.ConfigParser.get(),
+    with fallback a keyword-only.
+    """
+    if value is None:
+        return fallback
+
+    try:
+        return ConfigParser.BOOLEAN_STATES[value]
+    except KeyError:
+        raise ValueError(f"Expected boolean value, got '{value}'")

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -91,6 +91,12 @@ class IQM:
             self.filters[new_filter.type].append(new_filter)
 
         logging.info("create local qm")
+        conn = dict()
+        try:
+            conn["host"] = cfg["local"]["host"]
+            conn["port"] = int(cfg["local"]["port"])
+        except TypeError:
+            conn["socket_path"] = cfg["local"]["socket-path"]
 
         qm_data = {
             "copy_qm": None,
@@ -101,9 +107,9 @@ class IQM:
 
         self.local_qm = iot3.core.mqtt.MqttClient(
             client_id=cfg["local"]["client_id"],
-            socket_path=cfg["local"]["socket-path"],
             username=cfg["local"]["username"],
             password=cfg["local"]["password"],
+            **conn,
             msg_cb=self.qm_copy_cb,
             msg_cb_data=qm_data,
             span_ctxmgr_cb=self.span_cb,

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -98,6 +98,7 @@ class IQM:
             conn["host"] = cfg["local"]["host"]
             conn["port"] = int(cfg["local"]["port"])
             conn["tls"] = str2bool(cfg["local"].get("tls"))
+            conn["websocket_path"] = cfg["local"].get("websocket_path")
 
         qm_data = {
             "copy_qm": None,

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -11,6 +11,7 @@ import random
 import time
 from . import authority
 from . import filters
+from its_iqm.helpers import str2bool
 
 
 class IQM:
@@ -96,6 +97,7 @@ class IQM:
         except KeyError:
             conn["host"] = cfg["local"]["host"]
             conn["port"] = int(cfg["local"]["port"])
+            conn["tls"] = str2bool(cfg["local"].get("tls"))
 
         qm_data = {
             "copy_qm": None,

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -4,7 +4,6 @@
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
 from __future__ import annotations
-import configparser
 import iot3.core.mqtt
 import iot3.core.otel
 import logging
@@ -17,7 +16,7 @@ from . import filters
 class IQM:
     def __init__(
         self: IQM,
-        cfg: configparser.ConfigParser,
+        cfg: dict,
     ):
         logging.info("create")
         self.cfg = cfg

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -93,10 +93,10 @@ class IQM:
         logging.info("create local qm")
         conn = dict()
         try:
+            conn["socket_path"] = cfg["local"]["socket-path"]
+        except KeyError:
             conn["host"] = cfg["local"]["host"]
             conn["port"] = int(cfg["local"]["port"])
-        except TypeError:
-            conn["socket_path"] = cfg["local"]["socket-path"]
 
         qm_data = {
             "copy_qm": None,

--- a/python/its-interqueuemanager/src/its_iqm/main.py
+++ b/python/its-interqueuemanager/src/its_iqm/main.py
@@ -22,6 +22,9 @@ DEFAULTS = {
         "password": None,
     },
     "local": {
+        "host": None,
+        "port": None,
+        "socket-path": None,
         "username": None,
         "password": None,
         "client_id": "iqm",

--- a/python/its-interqueuemanager/src/its_iqm/main.py
+++ b/python/its-interqueuemanager/src/its_iqm/main.py
@@ -69,7 +69,7 @@ def main():
     # configparser.ConfigParser() only accepts strings as values, but we
     # need None for some defaults, so make it a true dict() of dicts()s,
     # which is easier to work with.
-    cfg = {s: {k: cfg[s][k] for k in cfg[s]} for s in cfg if s != "DEFAULT"}
+    cfg = {s: {k: cfg[s][k] for k in cfg[s]} for s in cfg.sections()}
 
     def _set_default(section, key, default):
         if section not in cfg:

--- a/python/its-interqueuemanager/src/its_iqm/main.py
+++ b/python/its-interqueuemanager/src/its_iqm/main.py
@@ -22,9 +22,7 @@ DEFAULTS = {
         "password": None,
     },
     "local": {
-        "host": None,
-        "port": None,
-        "socket-path": None,
+        "port": 1883,
         "username": None,
         "password": None,
         "client_id": "iqm",


### PR DESCRIPTION
Changes
=======

* applications:
    * interqueuemanager:
        * restore connection throuch TCP
        * add support for TLS connections
        * add support for websockets connections

Close #475

Test
====

How to test
-----------

**Note:** in the following:
* lines starting with `$` are to be executed on your machine, as a non-root user;
* lines starting with `(docker)$` are to be executed in the Docker container;
* lines starting with `(docker)🐍 $` are to be executed in the Docker container, in the python venv.

1. Prepare a test environment:
    1. be sure to have unrestricted access to _test.mosquitto.org_ (IPv4 and IPv6)
    2. run an MQTT client that listens on _test.mosquitto.org_:
        ```sh
        $ mosquitto_sub \
            -h test.mosquitto.org -p 8886 \
            --tls-version tlsv1.3 --capath /etc/ssl/certs/ \
            -i SUyX8BNsbCr633okVYVwVPIX \
            -t 'default/+/v2x/#' \
            -V 5 \
            -F %J
        ```
    4. in another terminal, start a container with Python 3.11 and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.14-slim-trixie \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential socat
        $ docker container exec -d iot3 socat UNIX-LISTEN:/tmp/mqtt.socket,fork TCP4:test.mosquitto.org:1884

        $ docker container attach iot3
        ```
       _**Note:**_ the socat command exposes the MQTT broker from _test.mosquitto.org_, inside the container, listening on the UNIX socket `/tmp/mqtt.socket`.
    5. prepare a Python 3.11 environment, with tests dependencies
       and packages' dependencies:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir install \
                        -r python/requirements-tests.txt \
                        $(sed -r -e '/.*"(.+(==|>=|<=).+)".*/!d; s//\1/; s/ //g;' \
                          python/*/pyproject.toml
                         )
        ```
       _**Note:**_ we install the packages dependencies manually, and do not rely on _pip_ to do so, because our Python packages depend one on the others by git hash, as they are not published on PyPi yet, so installing one of our packages may overwrite another.
2. create the IQM configuration files:
    * `/tmp/iqm-unix.cfg`
        ```
        (docker)🐍 $ cat >/tmp/iqm-unix.cfg <<_EOF_
        [general]
        instance-id = geo_4afad84c
        prefix = default
        suffix = v2x
        [local]
        socket-path = /tmp/mqtt.socket
        username = rw
        password = readwrite
        _EOF_
        ```
    * `/tmp/iqm-tcp.cfg`
        ```
        (docker)🐍 $ cat >/tmp/iqm-tcp.cfg <<_EOF_
        [general]
        instance-id = geo_4afad84c
        prefix = default
        suffix = v2x
        [local]
        host = test.mosquitto.org
        port = 1884
        tls = false
        username = rw
        password = readwrite
        _EOF_
        ```
    * `/tmp/iqm-tls.cfg`
        ```
        (docker)🐍 $ cat >/tmp/iqm-tls.cfg <<_EOF_
        [general]
        instance-id = geo_4afad84c
        prefix = default
        suffix = v2x
        [local]
        host = test.mosquitto.org
        port = 8886
        _EOF_
        ```
    * `/tmp/iqm-wss.cfg`
        ```
        (docker)🐍 $ cat >/tmp/iqm-wss.cfg <<_EOF_
        [general]
        instance-id = geo_4afad84c
        prefix = default
        suffix = v2x
        [local]
        host = test.mosquitto.org
        port = 8081
        websocket_path = /
        _EOF_
        ```
3. Build the Python packages:
    ```sh
    (docker)🐍 $ for pkg in python/*/; do
                    python -m build -w "${pkg}" || break
                 done
    ```
4. Install the Python packages:
    ```sh
    (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir \
                        install --no-deps python/*/dist/*.whl
    ```
5. Test the IQM on various connection protocols::
    1. run the IQM with one of the configuration files above, e.g. with `/tmp/iqm-unix.cfg`:
        ```sh
        (docker)🐍 $ its-iqm -c /tmp/iqm-unix.cfg
        ```
    2. send an MQTT message:
        ```sh
        $ mosquitto_pub \
            -h test.mosquitto.org -p 8886 \
            --tls-version tlsv1.3 --capath /etc/ssl/certs/ \
            -i H15/VGZbiFtxzPVrCrolUXbL \
            -t 'default/inQueue/v2x/cam/0/1/2/3/3/2/1/0' \
            -V 5 \
            -m '["test-me"]'
        ```
    3. stop the IQM (with Ctrl-C) and start again at step 2, above, using another configuration file

Expected results
-------

1. The test environment is ready
2. The configuration files were all created successfully
3. The packages were all built successfully
4. The packages were all installed successfully
5. The IQM relays messages as expected, whatever the connection means: messages posted on _inQueue_ are copied to _outQueue_ and _interQueue_