### PR TITLE
Java LwM2M IoT3 bootstrap example

### DIFF
--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mCallback.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mCallback.java
@@ -9,6 +9,8 @@ package com.orange.iot3core.clients.lwm2m;
 
 public interface Lwm2mCallback {
 
+    void onBootstrapStart();
+
     void onBootstrap(Throwable bootstrapFailure);
 
     void onRegistration(Throwable registrationFailure);

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mCallback.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mCallback.java
@@ -1,0 +1,22 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ */
+package com.orange.iot3core.clients.lwm2m;
+
+public interface Lwm2mCallback {
+
+    void onBootstrap(Throwable bootstrapFailure);
+
+    void onRegistration(Throwable registrationFailure);
+
+    void onUpdate(Throwable updateFailure);
+
+    void onDeregistration(Throwable deregistrationFailure);
+
+    void onUnexpectedError(Throwable error);
+
+}

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
@@ -100,7 +100,7 @@ public class Lwm2mClient {
 
                     @Override
                     public void onBootstrapStarted(LwM2mServer lwM2mServer, BootstrapRequest bootstrapRequest) {
-
+                        if(lwm2mCallback != null) lwm2mCallback.onBootstrapStart();
                     }
 
                     @Override

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
@@ -267,7 +267,6 @@ public class Lwm2mClient {
         if (security != null) {
             initializer.setInstancesForObject(LwM2mId.SECURITY, security);
         }
-        initializer.setInstancesForObject(LwM2mId.SECURITY, getSecurity(lwm2mConfig));
         initializer.setInstancesForObject(LwM2mId.SERVER, getServer(lwm2mConfig));
         initializer.setInstancesForObject(LwM2mId.DEVICE, lwm2mDevice.getDevice());
         if (lwm2mInstances != null) {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/Lwm2mClient.java
@@ -26,10 +26,13 @@ import org.eclipse.leshan.client.resource.BaseInstanceEnablerFactory;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
 import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.model.*;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.util.Hex;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 public class Lwm2mClient {
@@ -108,7 +111,36 @@ public class Lwm2mClient {
             Lwm2mDevice lwm2mDevice,
             Lwm2mInstance[] lwm2mInstances
     ) {
-        ObjectsInitializer initializer = new ObjectsInitializer();
+        // create our custom IoT3 objects
+        ObjectModel obj36050 = new ObjectModel(
+                36050, "IoT3 Identity", "urn:oma:lwm2m:x:36050", "1.0",
+                false,  // multiple
+                false,  // mandatory
+                new ResourceModel(0, "IoT3 ID", ResourceModel.Operations.R, false, true, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(1, "PSK Identity", ResourceModel.Operations.R, false, true, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(2, "PSK Secret", ResourceModel.Operations.R, false, true, ResourceModel.Type.OPAQUE, null, null, null)
+        );
+
+        ObjectModel obj36051 = new ObjectModel(
+                36051, "IoT3 Service Endpoint", "urn:oma:lwm2m:x:36051", "1.0",
+                true,   // multiple
+                false,  // mandatory
+                new ResourceModel(0, "Service Name", ResourceModel.Operations.R, false, true, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(1, "Payload", ResourceModel.Operations.R, false, false, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(2, "Service URI", ResourceModel.Operations.R, false, true, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(3, "Topic Root", ResourceModel.Operations.R, false, false, ResourceModel.Type.STRING, null, null, null),
+                new ResourceModel(4, "Server Public Key", ResourceModel.Operations.R, false, false, ResourceModel.Type.OPAQUE, null, null, null)
+        );
+
+        // load standard models and add our custom IoT3 models
+        List<ObjectModel> standardModels = ObjectLoader.loadDefault();
+        List<ObjectModel> allModels = new ArrayList<>(standardModels);
+        allModels.add(obj36050);
+        allModels.add(obj36051);
+
+        LwM2mModel model = new StaticModel(allModels);
+
+        ObjectsInitializer initializer = new ObjectsInitializer(model);
 
         Security security = getSecurity(lwm2mConfig);
         if (security != null) {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/IoT3Identity.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/IoT3Identity.java
@@ -1,0 +1,78 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+*/
+package com.orange.iot3core.clients.lwm2m.model;
+
+/**
+ * Model for the LwM2M IoT3 Identity object.
+ * <p>
+ * Object:
+ * - Name: IoT3 Identity
+ * - Object ID: 36050
+ * - Object Version: 1.0 (LwM2M 1.1)
+ * - Instances: Single
+ * - Object URN: urn:oma:lwm2m:x:36050
+ * <p>
+ * Resources (Single, all [R] Mandatory):
+ * - 0 IoT3 ID: String — Uniquely identifies the User Equipment or Low-Latency Application in the IoT3 system.
+ * - 1 PSK Identity: String — Public part of a PSK used for client authentication on an IoT3 service.
+ * - 2 PSK Secret Key: Opaque (byte[]) — Secret part of the PSK used for client authentication on an IoT3 service.
+ * <p>
+ * Immutability & Security:
+ * - Any provided byte[] is defensively copied on construction and when returned by getters.
+ */
+public class IoT3Identity {
+
+    private final String iot3Id;
+    private final String pskIdentity;
+    private final byte[] pskSecretKey;
+
+    private IoT3Identity(Builder builder) {
+        this.iot3Id = builder.iot3Id;
+        this.pskIdentity = builder.pskIdentity;
+        // Defensive copy to protect internal state
+        this.pskSecretKey = builder.pskSecretKey.clone();
+    }
+
+    public String getIot3Id() { return iot3Id; }
+    public String getPskIdentity() { return pskIdentity; }
+
+    /**
+     * Returns a defensive copy of the PSK secret key bytes.
+     */
+    public byte[] getPskSecretKey() {
+        return pskSecretKey.clone();
+    }
+
+    /**
+     * Builder for creating IoT3IdentityUpdate instances.
+     * All fields are mandatory for this object.
+     */
+    public static class Builder {
+        private final String iot3Id;
+        private final String pskIdentity;
+        private final byte[] pskSecretKey;
+
+        /**
+         * Creates a new Builder with all mandatory values.
+         *
+         * @param iot3Id       Unique IoT3 identifier of the UE/LLA
+         * @param pskIdentity  Public PSK identity used for client authentication
+         * @param pskSecretKey Secret PSK key bytes used for client authentication
+         */
+        public Builder(String iot3Id, String pskIdentity, byte[] pskSecretKey) {
+            this.iot3Id = iot3Id;
+            this.pskIdentity = pskIdentity;
+            // Defensive copy to avoid external mutation
+            this.pskSecretKey = pskSecretKey.clone();
+        }
+
+        public IoT3Identity build() {
+            return new IoT3Identity(this);
+        }
+    }
+}

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/IoT3ServiceEndpoint.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/IoT3ServiceEndpoint.java
@@ -1,0 +1,118 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+*/
+package com.orange.iot3core.clients.lwm2m.model;
+
+import io.reactivex.annotations.Nullable;
+
+/**
+ * Model for the LwM2M IoT3 Service Endpoint object.
+ * <p>
+ * Object:
+ * - Name: IoT3 Service Endpoint
+ * - Object ID: 36051
+ * - Object Version: 1.0 (LwM2M 1.1)
+ * - Instances: Multiple
+ * - Object URN: urn:oma:lwm2m:x:36051
+ * <p>
+ * Resources (Single, [R]):
+ * - 0 Service Name: String — Mandatory. Name or category for this IoT3 Service Endpoint.
+ * - 1 Payload: String — Optional. Expected payload type, e.g., json, asn1, otlp/json, logstash, jaeger, grafana.
+ * - 2 Service URI: String — Mandatory. URI of the IoT3 Service Endpoint.
+ * - 3 Topic Root: String — Optional. Root topic to use when connecting to an IoT3 MQTT Broker Endpoint.
+ * - 4 Server Public Key: Opaque (byte[]) — Optional. Server’s certificate used by the client to validate the server’s identity.
+ * <p>
+ * Immutability:
+ * - Any provided byte[] is defensively copied on construction and when returned by getters.
+ */
+public class IoT3ServiceEndpoint {
+
+    private final String serviceName;
+    @Nullable
+    private final String payload;
+    private final String serviceUri;
+    @Nullable
+    private final String topicRoot;
+    @Nullable
+    private final byte[] serverPublicKey;
+
+    private IoT3ServiceEndpoint(Builder builder) {
+        this.serviceName = builder.serviceName;
+        this.payload = builder.payload;
+        this.serviceUri = builder.serviceUri;
+        this.topicRoot = builder.topicRoot;
+        // Defensive copy if present
+        this.serverPublicKey = builder.serverPublicKey != null ? builder.serverPublicKey.clone() : null;
+    }
+
+    public String getServiceName() { return serviceName; }
+    @Nullable
+    public String getPayload() { return payload; }
+    public String getServiceUri() { return serviceUri; }
+    @Nullable
+    public String getTopicRoot() { return topicRoot; }
+
+    /**
+     * Returns a defensive copy of the server public key bytes if present.
+     */
+    @Nullable
+    public byte[] getServerPublicKey() {
+        return serverPublicKey != null ? serverPublicKey.clone() : null;
+    }
+
+    /**
+     * Builder for creating IoT3ServiceEndpoint instances.
+     * Requires the mandatory fields in the constructor; others are optional.
+     */
+    public static class Builder {
+        private final String serviceName;
+        private final String serviceUri;
+        @Nullable private String payload;
+        @Nullable private String topicRoot;
+        @Nullable private byte[] serverPublicKey;
+
+        /**
+         * Creates a new Builder with mandatory values.
+         *
+         * @param serviceName Name or category of this IoT3 service endpoint
+         * @param serviceUri  URI of the IoT3 Service Endpoint
+         */
+        public Builder(String serviceName, String serviceUri) {
+            this.serviceName = serviceName;
+            this.serviceUri = serviceUri;
+        }
+
+        /**
+         * Sets the expected payload type (e.g., json, asn1, otlp/json, logstash).
+         */
+        public Builder payload(@Nullable String payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        /**
+         * Sets the MQTT topic root to be used when connecting (if applicable).
+         */
+        public Builder topicRoot(@Nullable String topicRoot) {
+            this.topicRoot = topicRoot;
+            return this;
+        }
+
+        /**
+         * Sets the server public key bytes used to validate server identity.
+         */
+        public Builder serverPublicKey(@Nullable byte[] serverPublicKey) {
+            // Defensive copy if provided
+            this.serverPublicKey = serverPublicKey != null ? serverPublicKey.clone() : null;
+            return this;
+        }
+
+        public IoT3ServiceEndpoint build() {
+            return new IoT3ServiceEndpoint(this);
+        }
+    }
+}

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mInstance.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mInstance.java
@@ -5,6 +5,7 @@
 
  @authors
     Zbigniew Krawczyk  <zbigniew2.krawczyk@orange.com>
+    Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
 */
 package com.orange.iot3core.clients.lwm2m.model;
 
@@ -28,6 +29,8 @@ public abstract class Lwm2mInstance {
 
     private final int objectId;
 
+    private volatile boolean bootstrapWritable = false;
+
     @Nullable
     private BaseInstanceEnabler instanceEnabler = null;
 
@@ -48,6 +51,13 @@ public abstract class Lwm2mInstance {
 
     public int getObjectId() {
         return objectId;
+    }
+
+    public void enableBootstrapWrites() { this.bootstrapWritable = true; }
+    public void disableBootstrapWrites() { this.bootstrapWritable = false; }
+
+    public boolean isBootstrapWritable() {
+        return bootstrapWritable;
     }
 
     public BaseInstanceEnabler getInstanceEnabler() {
@@ -187,7 +197,8 @@ public abstract class Lwm2mInstance {
 
     public enum ResponseType {
         SUCCESS,
-        NOT_FOUND;
+        NOT_ALLOWED,
+        NOT_FOUND
     }
 
     private class InternalInstanceEnabler extends BaseInstanceEnabler {
@@ -200,6 +211,7 @@ public abstract class Lwm2mInstance {
                 Object content = responseValue.getValue();
                 return switch (type) {
                     case SUCCESS -> ReadResponse.success(convertToResourceValue(resourceId, content));
+                    case NOT_ALLOWED -> ReadResponse.methodNotAllowed();
                     case NOT_FOUND -> ReadResponse.notFound();
                 };
             } else {
@@ -214,6 +226,7 @@ public abstract class Lwm2mInstance {
                 ResponseType type = responseValue.getType();
                 return switch (type) {
                     case SUCCESS -> WriteResponse.success();
+                    case NOT_ALLOWED -> WriteResponse.methodNotAllowed();
                     case NOT_FOUND -> WriteResponse.notFound();
                 };
             } else {
@@ -228,6 +241,7 @@ public abstract class Lwm2mInstance {
                 ResponseType type = responseValue.getType();
                 return switch (type) {
                     case SUCCESS -> ExecuteResponse.success();
+                    case NOT_ALLOWED -> ExecuteResponse.methodNotAllowed();
                     case NOT_FOUND -> ExecuteResponse.notFound();
                 };
             } else {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3Identity.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3Identity.java
@@ -1,0 +1,103 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+*/
+package com.orange.iot3core.clients.lwm2m.model;
+
+import io.reactivex.annotations.Nullable;
+
+/**
+ * LwM2M Object: IoT3 Identity (Object ID: 36050)
+ * <p>
+ * Description:
+ * This object describes the IoT3 Identity of a User Equipment or a Low‑Latency Application
+ * after it has been bootstrapped.
+ * <p>
+ * Object definition:
+ * - Object Version: 1.0 (LwM2M 1.1)
+ * - Object URN: urn:oma:lwm2m:x:36050
+ * - Instances: Single (presence: Optional)
+ * <p>
+ * Resources (all [R]):
+ * - 0 IoT3 ID: String — Mandatory. Uniquely identifies the UE/LLA in the IoT3 system.
+ * - 1 PSK Identity: String — Mandatory. Public part of the PSK used for client authentication.
+ * - 2 PSK Secret Key: Opaque (byte[]) — Mandatory. Secret part of the PSK used for client authentication.
+ * <p>
+ * Class role:
+ * - Extends Lwm2mInstance and exposes read‑only resources to the LwM2M server.
+ * - Sensitive byte[] values are handled with defensive copies.
+ */
+public class Lwm2mIoT3Identity extends Lwm2mInstance {
+
+    private static final int OBJECT_ID = 36050;
+
+    private static final int IOT3_ID_RES_ID = 0;
+    private static final int PSK_IDENTITY_RES_ID = 1;
+    private static final int PSK_SECRET_KEY_RES_ID = 2;
+
+    // All mandatory
+    private String iot3Id;
+    private String pskIdentity;
+    private byte[] pskSecretKey;
+
+    public Lwm2mIoT3Identity() {
+        super(OBJECT_ID);
+        // Initialize mandatory resources with non-null defaults
+        this.iot3Id = "";
+        this.pskIdentity = "";
+        this.pskSecretKey = new byte[0];
+    }
+
+    @Override
+    @Nullable
+    public ResponseValue read(int resourceId) {
+        return switch (resourceId) {
+            case IOT3_ID_RES_ID -> getResponseValue(iot3Id, true);
+            case PSK_IDENTITY_RES_ID -> getResponseValue(pskIdentity, true);
+            case PSK_SECRET_KEY_RES_ID -> getResponseValue(pskSecretKey.clone(), true);
+            default -> null;
+        };
+    }
+
+    @Override
+    @Nullable
+    protected ResponseValue write(int resourceId, @Nullable Object value) {
+        switch (resourceId) {
+            case IOT3_ID_RES_ID: // String
+                if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.iot3Id = (String) value;
+                onResourcesChange(IOT3_ID_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case PSK_IDENTITY_RES_ID: // String
+                if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.pskIdentity = (String) value;
+                onResourcesChange(PSK_IDENTITY_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case PSK_SECRET_KEY_RES_ID: // Opaque
+                if (!(value instanceof byte[] secret)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.pskSecretKey = secret.clone();
+                onResourcesChange(PSK_SECRET_KEY_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            default:
+                return new ResponseValue(ResponseType.NOT_FOUND);
+        }
+    }
+
+    public IoT3Identity toModel() {
+        return new IoT3Identity.Builder(iot3Id, pskIdentity, pskSecretKey.clone()).build();
+    }
+
+    public void fromModel(IoT3Identity model) {
+        this.iot3Id = model.getIot3Id();
+        this.pskIdentity = model.getPskIdentity();
+        this.pskSecretKey = model.getPskSecretKey(); // returns clone already
+        onResourcesChange(0,1,2);
+    }
+
+}

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3Identity.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3Identity.java
@@ -65,6 +65,11 @@ public class Lwm2mIoT3Identity extends Lwm2mInstance {
     @Override
     @Nullable
     protected ResponseValue write(int resourceId, @Nullable Object value) {
+        if (isBootstrapWritable()) return bootstrapWrite(resourceId, value);
+        return new ResponseValue(ResponseType.NOT_ALLOWED);
+    }
+
+    private ResponseValue bootstrapWrite(int resourceId, @Nullable Object value) {
         switch (resourceId) {
             case IOT3_ID_RES_ID: // String
                 if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3ServiceEndpoint.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3ServiceEndpoint.java
@@ -78,6 +78,11 @@ public class Lwm2mIoT3ServiceEndpoint extends Lwm2mInstance {
     @Override
     @Nullable
     protected ResponseValue write(int resourceId, @Nullable Object value) {
+        if (isBootstrapWritable()) return bootstrapWrite(resourceId, value);
+        return new ResponseValue(ResponseType.NOT_ALLOWED);
+    }
+
+    private ResponseValue bootstrapWrite(int resourceId, @Nullable Object value) {
         switch (resourceId) {
             case SERVICE_NAME_RES_ID: // String (M)
                 if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3ServiceEndpoint.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mIoT3ServiceEndpoint.java
@@ -1,0 +1,134 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+*/
+package com.orange.iot3core.clients.lwm2m.model;
+
+import io.reactivex.annotations.Nullable;
+
+/**
+ * LwM2M Object: IoT3 Service Endpoint (Object ID: 36051)
+ * <p>
+ * Description:
+ * This object describes an IoT3 Service Endpoint that can be used by a User Equipment
+ * or a Low‑Latency Application after it has been bootstrapped.
+ * <p>
+ * Object definition:
+ * - Object Version: 1.0 (LwM2M 1.1)
+ * - Object URN: urn:oma:lwm2m:x:36051
+ * - Instances: Multiple (presence: Optional)
+ * <p>
+ * Resources ([R]):
+ * - 0 Service Name: String — Mandatory. Name or category of this IoT3 Service Endpoint.
+ * - 1 Payload: String — Optional. Expected payload type (e.g., json, asn1, otlp/json, logstash, jaeger, grafana).
+ * - 2 Service URI: String — Mandatory. URI of the IoT3 Service Endpoint.
+ * - 3 Topic Root: String — Optional. Root topic used when connecting to an IoT3 MQTT Broker Endpoint.
+ * - 4 Server Public Key: Opaque (byte[]) — Optional. Server certificate used to validate the server identity.
+ * <p>
+ * Class role:
+ * - Extends Lwm2mInstance and exposes read‑only resources to the LwM2M server.
+ * - Any byte[] returned or stored is defensively copied.
+ */
+public class Lwm2mIoT3ServiceEndpoint extends Lwm2mInstance {
+
+    private static final int OBJECT_ID = 36051;
+
+    private static final int SERVICE_NAME_RES_ID = 0;
+    private static final int PAYLOAD_RES_ID = 1;
+    private static final int SERVICE_URI_RES_ID = 2;
+    private static final int TOPIC_ROOT_RES_ID = 3;
+    private static final int SERVER_PUBLIC_KEY_RES_ID = 4;
+
+    // Mandatory
+    private String serviceName;
+    private String serviceUri;
+
+    // Optional
+    @Nullable private String payload;
+    @Nullable private String topicRoot;
+    @Nullable private byte[] serverPublicKey;
+
+    public Lwm2mIoT3ServiceEndpoint() {
+        super(OBJECT_ID);
+        // Initialize mandatory resources with non-null defaults
+        this.serviceName = "";
+        this.serviceUri = "";
+        // Optional stay null by default
+        this.payload = null;
+        this.topicRoot = null;
+        this.serverPublicKey = null;
+    }
+
+    @Override
+    @Nullable
+    public ResponseValue read(int resourceId) {
+        return switch (resourceId) {
+            case SERVICE_NAME_RES_ID -> getResponseValue(serviceName, true);
+            case PAYLOAD_RES_ID -> getResponseValue(payload);
+            case SERVICE_URI_RES_ID -> getResponseValue(serviceUri, true);
+            case TOPIC_ROOT_RES_ID -> getResponseValue(topicRoot);
+            case SERVER_PUBLIC_KEY_RES_ID -> getResponseValue(serverPublicKey != null ? serverPublicKey.clone() : null);
+            default -> null;
+        };
+    }
+
+    @Override
+    @Nullable
+    protected ResponseValue write(int resourceId, @Nullable Object value) {
+        switch (resourceId) {
+            case SERVICE_NAME_RES_ID: // String (M)
+                if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.serviceName = (String) value;
+                onResourcesChange(SERVICE_NAME_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case PAYLOAD_RES_ID: // String (O)
+                if (value != null && !(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.payload = (String) value; // allow null to clear
+                onResourcesChange(PAYLOAD_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case SERVICE_URI_RES_ID: // String (M)
+                if (!(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.serviceUri = (String) value;
+                onResourcesChange(SERVICE_URI_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case TOPIC_ROOT_RES_ID: // String (O)
+                if (value != null && !(value instanceof String)) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.topicRoot = (String) value; // allow null to clear
+                onResourcesChange(TOPIC_ROOT_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            case SERVER_PUBLIC_KEY_RES_ID: // Opaque (O)
+                if (value != null && !(value instanceof byte[])) return new ResponseValue(ResponseType.NOT_FOUND);
+                this.serverPublicKey = (value == null) ? null : ((byte[]) value).clone();
+                onResourcesChange(SERVER_PUBLIC_KEY_RES_ID);
+                return new ResponseValue(ResponseType.SUCCESS);
+
+            default:
+                return new ResponseValue(ResponseType.NOT_FOUND);
+        }
+    }
+
+    public IoT3ServiceEndpoint toModel() {
+        return new IoT3ServiceEndpoint.Builder(serviceName, serviceUri)
+                .payload(payload)
+                .topicRoot(topicRoot)
+                .serverPublicKey(serverPublicKey != null ? serverPublicKey.clone() : null)
+                .build();
+    }
+
+    public void fromModel(IoT3ServiceEndpoint model) {
+        this.serviceName = model.getServiceName();
+        this.serviceUri = model.getServiceUri();
+        this.payload = model.getPayload();
+        this.topicRoot = model.getTopicRoot();
+        this.serverPublicKey = model.getServerPublicKey(); // returns clone
+        onResourcesChange(0,1,2,3,4);
+    }
+
+}

--- a/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
@@ -33,12 +33,9 @@ public class Lwm2mExample {
     }
 
     private static void bootstrapExample() {
-        Lwm2mIoT3Identity identity = new Lwm2mIoT3Identity();
-        Lwm2mIoT3ServiceEndpoint endpoint = new Lwm2mIoT3ServiceEndpoint();
-
         Lwm2mInstance[] lwm2mInstances = new Lwm2mInstance[] {
-                identity,
-                endpoint
+                new Lwm2mIoT3Identity(),
+                new Lwm2mIoT3ServiceEndpoint()
         };
 
         // instantiate LwM2M client
@@ -48,21 +45,39 @@ public class Lwm2mExample {
                 lwm2mInstances,
                 new Lwm2mCallback() {
                     @Override
+                    public void onBootstrapStart() {
+                        // allow to write values during the bootstrap sequence
+                        for(Lwm2mInstance lwm2mInstance: lwm2mInstances) {
+                            lwm2mInstance.enableBootstrapWrites();
+                        }
+                    }
+
+                    @Override
                     public void onBootstrap(Throwable bootstrapFailure) {
+                        // bootstrap sequence has ended, disable write permission
+                        for(Lwm2mInstance lwm2mInstance: lwm2mInstances) {
+                            lwm2mInstance.disableBootstrapWrites();
+                        }
                         if(bootstrapFailure == null) {
                             System.out.println("LwM2M bootstrap success!");
-                            IoT3Identity ioT3Identity = identity.toModel();
-                            IoT3ServiceEndpoint ioT3ServiceEndpoint = endpoint.toModel();
-                            System.out.println("IoT3Identity:"
-                                    + "\nID: " + ioT3Identity.getIot3Id()
-                                    + "\nPSK identity: " + ioT3Identity.getPskIdentity()
-                                    + "\nPSK secret key: " + Arrays.toString(ioT3Identity.getPskSecretKey()));
-                            System.out.println("IoT3ServiceEndpoint:"
-                                    + "\nService name: " + ioT3ServiceEndpoint.getServiceName()
-                                    + "\nPayload: " + ioT3ServiceEndpoint.getPayload()
-                                    + "\nURI: " + ioT3ServiceEndpoint.getServiceUri()
-                                    + "\nTopic root: " + ioT3ServiceEndpoint.getTopicRoot()
-                                    + "\nServer public key: " + Arrays.toString(ioT3ServiceEndpoint.getServerPublicKey()));
+                            for(Lwm2mInstance lwm2mInstance: lwm2mInstances) {
+                                if(lwm2mInstance instanceof Lwm2mIoT3Identity identity) {
+                                    IoT3Identity ioT3Identity = identity.toModel();
+                                    System.out.println("IoT3Identity:"
+                                            + "\nID: " + ioT3Identity.getIot3Id()
+                                            + "\nPSK identity: " + ioT3Identity.getPskIdentity()
+                                            + "\nPSK secret key: " + Arrays.toString(ioT3Identity.getPskSecretKey()));
+                                }
+                                if(lwm2mInstance instanceof Lwm2mIoT3ServiceEndpoint endpoint) {
+                                    IoT3ServiceEndpoint ioT3ServiceEndpoint = endpoint.toModel();
+                                    System.out.println("IoT3ServiceEndpoint:"
+                                            + "\nService name: " + ioT3ServiceEndpoint.getServiceName()
+                                            + "\nPayload: " + ioT3ServiceEndpoint.getPayload()
+                                            + "\nURI: " + ioT3ServiceEndpoint.getServiceUri()
+                                            + "\nTopic root: " + ioT3ServiceEndpoint.getTopicRoot()
+                                            + "\nServer public key: " + Arrays.toString(ioT3ServiceEndpoint.getServerPublicKey()));
+                                }
+                            }
                         } else {
                             System.out.println("LwM2M bootstrap failed: " + bootstrapFailure);
                         }

--- a/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
@@ -1,0 +1,107 @@
+package com.orange;
+
+import com.orange.iot3core.clients.lwm2m.Lwm2mCallback;
+import com.orange.iot3core.clients.lwm2m.Lwm2mClient;
+import com.orange.iot3core.clients.lwm2m.model.*;
+
+import java.util.Arrays;
+
+public class Lwm2mExample {
+
+    private static final Lwm2mDevice EXAMPLE_LWM2M_DEVICE = new Lwm2mDevice(
+            "orange",
+            "123",
+            "456",
+            "U"
+    );
+    private static final Lwm2mServer EXAMPLE_LWM2M_SERVER = new Lwm2mServer(
+            123456,
+            5 * 60,
+            "U"
+    );
+    private static final Lwm2mConfig EXAMPLE_LWM2M_BOOTSTRAP_CONFIG = new Lwm2mConfig.Lwm2mBootstrapConfig(
+            "your_endpoint_name",
+            "your_url",
+            "your_psk_id",
+            "your_private_key_in_hex",
+            EXAMPLE_LWM2M_SERVER,
+            true
+    );
+
+    public static void main(String[] args) {
+        bootstrapExample();
+    }
+
+    private static void bootstrapExample() {
+        Lwm2mIoT3Identity identity = new Lwm2mIoT3Identity();
+        Lwm2mIoT3ServiceEndpoint endpoint = new Lwm2mIoT3ServiceEndpoint();
+
+        Lwm2mInstance[] lwm2mInstances = new Lwm2mInstance[] {
+                identity,
+                endpoint
+        };
+
+        // instantiate LwM2M client
+        Lwm2mClient lwm2mClient = new Lwm2mClient(
+                EXAMPLE_LWM2M_BOOTSTRAP_CONFIG,
+                EXAMPLE_LWM2M_DEVICE,
+                lwm2mInstances,
+                new Lwm2mCallback() {
+                    @Override
+                    public void onBootstrap(Throwable bootstrapFailure) {
+                        if(bootstrapFailure == null) {
+                            System.out.println("LwM2M bootstrap success!");
+                            IoT3Identity ioT3Identity = identity.toModel();
+                            IoT3ServiceEndpoint ioT3ServiceEndpoint = endpoint.toModel();
+                            System.out.println("IoT3Identity:"
+                                    + "\nID: " + ioT3Identity.getIot3Id()
+                                    + "\nPSK identity: " + ioT3Identity.getPskIdentity()
+                                    + "\nPSK secret key: " + Arrays.toString(ioT3Identity.getPskSecretKey()));
+                            System.out.println("IoT3ServiceEndpoint:"
+                                    + "\nService name: " + ioT3ServiceEndpoint.getServiceName()
+                                    + "\nPayload: " + ioT3ServiceEndpoint.getPayload()
+                                    + "\nURI: " + ioT3ServiceEndpoint.getServiceUri()
+                                    + "\nTopic root: " + ioT3ServiceEndpoint.getTopicRoot()
+                                    + "\nServer public key: " + Arrays.toString(ioT3ServiceEndpoint.getServerPublicKey()));
+                        } else {
+                            System.out.println("LwM2M bootstrap failed: " + bootstrapFailure);
+                        }
+                    }
+
+                    @Override
+                    public void onRegistration(Throwable registrationFailure) {
+                        if(registrationFailure == null) {
+                            System.out.println("LwM2M registration success!");
+                        } else {
+                            System.out.println("LwM2M registration failed: " + registrationFailure);
+                        }
+                    }
+
+                    @Override
+                    public void onUpdate(Throwable updateFailure) {
+                        if(updateFailure == null) {
+                            System.out.println("LwM2M update success!");
+                        } else {
+                            System.out.println("LwM2M update failed: " + updateFailure);
+                        }
+                    }
+
+                    @Override
+                    public void onDeregistration(Throwable deregistrationFailure) {
+                        if(deregistrationFailure == null) {
+                            System.out.println("LwM2M deregistration success!");
+                        } else {
+                            System.out.println("LwM2M deregistration failed: " + deregistrationFailure);
+                        }
+                    }
+
+                    @Override
+                    public void onUnexpectedError(Throwable error) {
+                        System.out.println("LwM2M unexpected error: " + error);
+                    }
+                },
+                true);
+        lwm2mClient.connect();
+    }
+
+}

--- a/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
+++ b/java/iot3/examples/src/main/java/com/orange/Lwm2mExample.java
@@ -33,10 +33,14 @@ public class Lwm2mExample {
     }
 
     private static void bootstrapExample() {
-        Lwm2mInstance[] lwm2mInstances = new Lwm2mInstance[] {
-                new Lwm2mIoT3Identity(),
-                new Lwm2mIoT3ServiceEndpoint()
-        };
+        int maxInstanceNb = 20;
+        Lwm2mInstance[] lwm2mInstances = new Lwm2mInstance[maxInstanceNb];
+        for(int i = 0; i < maxInstanceNb; i++) {
+            // create one instance of IoT3Identity
+            if(i == 0) lwm2mInstances[i] = new Lwm2mIoT3Identity();
+            // and multiple instances of IoT3ServiceEndpoints
+            else lwm2mInstances[i] = new Lwm2mIoT3ServiceEndpoint();
+        }
 
         // instantiate LwM2M client
         Lwm2mClient lwm2mClient = new Lwm2mClient(
@@ -70,12 +74,14 @@ public class Lwm2mExample {
                                 }
                                 if(lwm2mInstance instanceof Lwm2mIoT3ServiceEndpoint endpoint) {
                                     IoT3ServiceEndpoint ioT3ServiceEndpoint = endpoint.toModel();
-                                    System.out.println("IoT3ServiceEndpoint:"
-                                            + "\nService name: " + ioT3ServiceEndpoint.getServiceName()
-                                            + "\nPayload: " + ioT3ServiceEndpoint.getPayload()
-                                            + "\nURI: " + ioT3ServiceEndpoint.getServiceUri()
-                                            + "\nTopic root: " + ioT3ServiceEndpoint.getTopicRoot()
-                                            + "\nServer public key: " + Arrays.toString(ioT3ServiceEndpoint.getServerPublicKey()));
+                                    if(!ioT3ServiceEndpoint.getServiceName().isEmpty()) {
+                                        System.out.println("IoT3ServiceEndpoint:"
+                                                + "\nService name: " + ioT3ServiceEndpoint.getServiceName()
+                                                + "\nPayload: " + ioT3ServiceEndpoint.getPayload()
+                                                + "\nURI: " + ioT3ServiceEndpoint.getServiceUri()
+                                                + "\nTopic root: " + ioT3ServiceEndpoint.getTopicRoot()
+                                                + "\nServer public key: " + Arrays.toString(ioT3ServiceEndpoint.getServerPublicKey()));
+                                    }
                                 }
                             }
                         } else {


### PR DESCRIPTION
**What's new**

New classes have been added to handle IoT3 bootstrapping with Live Objects using LwM2M:
- `IoT3Identity` and `Lwm2mIoT3Identity` (LwM2M instance for server interactions)
- `IoT3ServiceEndpoint` and `Lwm2mIoT3ServiceEndpoint` (LwM2M instance for server interactions)
- `Lwm2mCallback` to be notified of LwM2M events (bootstrap, registration, etc.)

The `Lwm2mClient` has been updated to handle the new callback and IoT3-specific object models.

A new `Lwm2mExample` class has been added to demonstrate the LwM2M IoT3 bootstrap sequence.

Close #276

---
**What to do**

After reviewing code changes:

1. Clone the its-client project on your IDE.
2. Ensure that you have Gradle to be able to build the java/iot3 modules (core, mobility and examples).
3. Find the ```Lwm2mExample``` class in the ```examples``` module, and set appropriate values for the following objects:
```
    private static final Lwm2mServer EXAMPLE_LWM2M_SERVER = new Lwm2mServer(
            123456,
            5 * 60,
            "U"
    );
    private static final Lwm2mConfig EXAMPLE_LWM2M_BOOTSTRAP_CONFIG = new Lwm2mConfig.Lwm2mBootstrapConfig(
            "your_endpoint_name",
            "your_url",
            "your_psk_id",
            "your_private_key_in_hex",
            EXAMPLE_LWM2M_SERVER,
            true
    );
```
4. Run the Lwm2mExample.

---
**Expected results**

1. You're getting a ```LwM2M bootstrap success!``` in the console, followed by:
2. The IoT3 Identity :
```
IoT3Identity:
ID: <an_id>
PSK identity: <a_psk_identity>
PSK secret key: <a_psk_secret_******>
```
3. Several instances of IoT3 Service Endpoints:
```
IoT3ServiceEndpoint:
Service name: <service_name>
Payload: <optional>
URI: <service_uri>
Topic root: <optional>
Server public key: <optional>

IoT3ServiceEndpoint:
Service name: <service_name>
Payload: <optional>
URI: <service_uri>
Topic root: <optional>
Server public key: <optional>

...
```
4. And finally, a ```LwM2M registration success!```.