### PR TITLE
java/iot3: add unit tests

### DIFF
--- a/.github/workflows/java_iot3-core.yml
+++ b/.github/workflows/java_iot3-core.yml
@@ -24,6 +24,17 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-      - name: Java iot3-core
+      - name: Java iot3-core test
         working-directory: java/iot3
-        run: ./gradlew :core:build
+        run: ./gradlew :core:test
+
+      - name: Publish test failure results
+        uses: actions/upload-artifact@v4
+        if: failure()   # upload only if tests fail
+        with:
+          name: Java iot3-core test-failure-results
+          path: java/iot3/core/build/reports/tests/test/
+
+      - name: Java iot3-core build
+        working-directory: java/iot3
+        run: ./gradlew :core:build -x test   # skip re-running tests

--- a/.github/workflows/java_iot3-mobility.yml
+++ b/.github/workflows/java_iot3-mobility.yml
@@ -24,6 +24,17 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-      - name: Java iot3-mobility
+      - name: Java iot3-mobility test
         working-directory: java/iot3
-        run: ./gradlew :mobility:build
+        run: ./gradlew :mobility:test
+
+      - name: Publish test failure results
+        uses: actions/upload-artifact@v4
+        if: failure()   # upload only if tests fail
+        with:
+          name: Java iot3-mobility test-failure-results
+          path: java/iot3/mobility/build/reports/tests/test/
+
+      - name: Java iot3-mobility build
+        working-directory: java/iot3
+        run: ./gradlew :mobility:build -x test   # skip re-running tests

--- a/java/iot3/core/build.gradle
+++ b/java/iot3/core/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+    // Mockito for mocking MQTT client internals
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    // OkHttp MockWebServer for BootstrapHelper HTTP tests (same version as production okhttp)
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 tasks.named('test') {

--- a/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/bootstrap/BootstrapHelper.java
@@ -8,7 +8,6 @@
 package com.orange.iot3core.bootstrap;
 
 import okhttp3.*;
-import org.json.JSONException;
 import org.json.JSONObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -75,8 +74,8 @@ public class BootstrapHelper {
                 if (statusCode >= 400 && statusCode < 600) {
                     bootstrapCallback.boostrapError(new Throwable("Error: " + statusCode + " - " + responseBody));
                 } else {
-                    JSONObject jsonResponse = new JSONObject(responseBody);
                     try {
+                        JSONObject jsonResponse = new JSONObject(responseBody);
                         BootstrapConfig bootstrapConfig = new BootstrapConfig(jsonResponse);
                         bootstrapCallback.boostrapSuccess(bootstrapConfig);
                     }

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -57,6 +57,18 @@ public class MqttClient {
     // client state
     private volatile boolean closed;
 
+    /**
+     * Package-private constructor for unit testing.
+     * Accepts an already-built {@link Mqtt5AsyncClient}, skipping the network connection setup.
+     */
+    MqttClient(Mqtt5AsyncClient injectedClient, MqttCallback callback, OpenTelemetryClient openTelemetryClient) {
+        this.callback = callback;
+        this.openTelemetryClient = openTelemetryClient;
+        this.mqttClient = injectedClient;
+        this.closed = false;
+        injectedClient.publishes(MqttGlobalPublishFilter.SUBSCRIBED, this::processPublish);
+    }
+
     public MqttClient(String serverHost,
                       int serverPort,
                       String username,
@@ -389,7 +401,7 @@ public class MqttClient {
         return isConnected() && mqttClient.getConfig().getSslConfig().isPresent();
     }
 
-    public boolean isValidMqttPubTopic(String topic) {
+    public static boolean isValidMqttPubTopic(String topic) {
         // Check for null or empty string
         if (topic == null || topic.isEmpty()) {
             LOGGER.log(Level.FINER, "Publication topic cannot be null or empty!");

--- a/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
@@ -1,0 +1,179 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core;
+
+import com.orange.iot3core.clients.lwm2m.model.Lwm2mConfig;
+import com.orange.iot3core.clients.lwm2m.model.Lwm2mDevice;
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link IoT3Core.IoT3CoreBuilder}.
+ *
+ * <p>All tests that call {@code build()} deliberately omit {@code mqttParams()} so that
+ * no real MQTT connection is attempted during testing.  The resulting {@link IoT3Core}
+ * instance will simply have a null internal {@code MqttClient}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>Null-guard validation on each builder method</li>
+ *   <li>Default state of an instance built without MQTT params</li>
+ *   <li>Idempotent / safe delegating methods when no client is present</li>
+ * </ul>
+ */
+@DisplayName("IoT3CoreBuilder — validation and default state")
+class IoT3CoreBuilderTest {
+
+    private IoT3CoreCallback mockCallback;
+
+    @BeforeEach
+    void setUp() {
+        mockCallback = mock(IoT3CoreCallback.class);
+    }
+
+    // ── mqttParams null-guard ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("mqttParams(null host, …) throws IllegalArgumentException")
+    void mqttParams_nullHost_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IoT3Core.IoT3CoreBuilder()
+                        .mqttParams(null, 1883, "user", "pass", "clientId", false)
+        );
+    }
+
+    // ── telemetryParams null-guard ────────────────────────────────────────────
+
+    @Test
+    @DisplayName("telemetryParams(null host, …) throws IllegalArgumentException")
+    void telemetryParams_nullHost_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                new IoT3Core.IoT3CoreBuilder()
+                        .telemetryParams("http", null, 4318, "/endpoint", "user", "pass")
+        );
+    }
+
+    // ── lwm2mParams null-guards ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("lwm2mParams(null config, …) throws IllegalArgumentException")
+    void lwm2mParams_nullConfig_throwsIllegalArgumentException() {
+        Lwm2mDevice mockDevice = mock(Lwm2mDevice.class);
+        assertThrows(IllegalArgumentException.class, () ->
+                new IoT3Core.IoT3CoreBuilder()
+                        .lwm2mParams(null, mockDevice)
+        );
+    }
+
+    @Test
+    @DisplayName("lwm2mParams(config, null device) throws IllegalArgumentException")
+    void lwm2mParams_nullDevice_throwsIllegalArgumentException() {
+        Lwm2mConfig mockConfig = mock(Lwm2mConfig.class);
+        assertThrows(IllegalArgumentException.class, () ->
+                new IoT3Core.IoT3CoreBuilder()
+                        .lwm2mParams(mockConfig, null)
+        );
+    }
+
+    // ── default state after build() (no MQTT params) ──────────────────────────
+
+    @Test
+    @DisplayName("isMqttConnected() is false when no MQTT params were supplied")
+    void build_withNoMqttParams_isMqttConnectedIsFalse() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertFalse(core.isMqttConnected());
+    }
+
+    @Test
+    @DisplayName("isMqttConnectionSecured() is false when no MQTT params were supplied")
+    void build_withNoMqttParams_isMqttConnectionSecuredIsFalse() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertFalse(core.isMqttConnectionSecured());
+    }
+
+    // ── safe no-op delegation when MqttClient is absent ──────────────────────
+
+    @Test
+    @DisplayName("mqttPublish() does not throw when no MqttClient exists")
+    void mqttPublish_withNoClient_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(() -> core.mqttPublish("test/topic", "hello"));
+    }
+
+    @Test
+    @DisplayName("mqttPublish(retain) does not throw when no MqttClient exists")
+    void mqttPublishRetain_withNoClient_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(() -> core.mqttPublish("test/topic", "hello", true));
+    }
+
+    @Test
+    @DisplayName("mqttPublish(retain, qos, expiry) does not throw when no MqttClient exists")
+    void mqttPublishFull_withNoClient_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(() -> core.mqttPublish("test/topic", "hello", false, 1, 60));
+    }
+
+    @Test
+    @DisplayName("mqttSubscribe() does not throw when no MqttClient exists")
+    void mqttSubscribe_withNoClient_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(() -> core.mqttSubscribe("test/topic"));
+    }
+
+    @Test
+    @DisplayName("mqttUnsubscribe() does not throw when no MqttClient exists")
+    void mqttUnsubscribe_withNoClient_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(() -> core.mqttUnsubscribe("test/topic"));
+    }
+
+    @Test
+    @DisplayName("close() does not throw when no clients are initialised")
+    void close_withNoClients_doesNotThrow() {
+        IoT3Core core = new IoT3Core.IoT3CoreBuilder()
+                .callback(mockCallback)
+                .build();
+        assertDoesNotThrow(core::close);
+    }
+
+    // ── builder fluent API ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("mqttKeepAlive() can be set without throwing")
+    void mqttKeepAlive_doesNotThrow() {
+        assertDoesNotThrow(() ->
+                new IoT3Core.IoT3CoreBuilder()
+                        .mqttKeepAlive(30)
+                        .callback(mockCallback)
+                        .build()
+        );
+    }
+
+    @Test
+    @DisplayName("building with no parameters at all does not throw")
+    void build_withNoParams_doesNotThrow() {
+        // No mqttHost → no client created, should be safe
+        assertDoesNotThrow(() -> new IoT3Core.IoT3CoreBuilder().build());
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/IoT3CoreBuilderTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core.bootstrap;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
@@ -1,0 +1,249 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core.bootstrap;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link BootstrapConfig} JSON parsing, protocol selection and security detection.
+ * All tests work in-memory — no network access required.
+ */
+@DisplayName("BootstrapConfig — JSON parsing and service URI resolution")
+class BootstrapConfigTest {
+
+    // ── JSON builder helpers ─────────────────────────────────────────────────
+
+    /**
+     * Builds a minimal valid JSON response for the bootstrap endpoint.
+     *
+     * @param includeMqtts when true, adds an {@code mqtts://} URI alongside the plain {@code mqtt://} one
+     * @param includeHttps when true, uses {@code https://} and {@code https://} for telemetry and api services
+     */
+    private static JSONObject buildValidJson(boolean includeMqtts, boolean includeHttps) {
+        JSONObject json = new JSONObject();
+        json.put("iot3_id", "test-id");
+        json.put("psk_iot3_id", "test-login");
+        json.put("psk_iot3_secret", "test-secret");
+
+        JSONObject services = new JSONObject();
+
+        // message service
+        JSONArray message = new JSONArray();
+        message.put(new JSONObject().put("uri", "mqtt://broker.example.com:1883"));
+        if (includeMqtts) {
+            message.put(new JSONObject().put("uri", "mqtts://broker.example.com:8883"));
+        }
+        services.put("message", message);
+
+        // telemetry service
+        String telemetryScheme = includeHttps ? "https" : "http";
+        JSONArray telemetry = new JSONArray();
+        telemetry.put(new JSONObject().put("uri", telemetryScheme + "://otel.example.com:4318"));
+        services.put("telemetry", telemetry);
+
+        // api (Jaeger) service
+        String apiScheme = includeHttps ? "https" : "http";
+        JSONArray api = new JSONArray();
+        api.put(new JSONObject().put("uri", apiScheme + "://jaeger.example.com:16686"));
+        services.put("api", api);
+
+        json.put("services", services);
+        return json;
+    }
+
+    // ── basic field parsing ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("valid JSON — iot3_id, psk_iot3_id, psk_iot3_secret are parsed correctly")
+    void validJson_parsesBasicFields() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        assertEquals("test-id",     config.getIot3Id());
+        assertEquals("test-login",  config.getPskRunLogin());
+        assertEquals("test-secret", config.getPskRunPassword());
+    }
+
+    @Test
+    @DisplayName("valid JSON with all protocols — all protocol URIs are non-null")
+    void validJson_withAllProtocols_parsesAll() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(true, true));
+        assertNotNull(config.getProtocolUri(BootstrapConfig.Protocol.MQTT));
+        assertNotNull(config.getProtocolUri(BootstrapConfig.Protocol.MQTTS));
+        assertNotNull(config.getProtocolUri(BootstrapConfig.Protocol.OTLP_HTTPS));
+        assertNotNull(config.getProtocolUri(BootstrapConfig.Protocol.JAEGER_HTTPS));
+    }
+
+    @Test
+    @DisplayName("getProtocolUri(MQTT) returns the correct host and port")
+    void getProtocolUri_mqtt_returnsCorrectHostAndPort() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        URI uri = config.getProtocolUri(BootstrapConfig.Protocol.MQTT);
+        assertNotNull(uri);
+        assertEquals("broker.example.com", uri.getHost());
+        assertEquals(1883, uri.getPort());
+    }
+
+    @Test
+    @DisplayName("getProtocolUri for an absent protocol returns null")
+    void getProtocolUri_absentProtocol_returnsNull() throws Exception {
+        // JSON only has plain mqtt, not mqtts
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        assertNull(config.getProtocolUri(BootstrapConfig.Protocol.MQTTS));
+    }
+
+    // ── service URI selection (prefers secured) ───────────────────────────────
+
+    @Test
+    @DisplayName("getServiceUri(MQTT) prefers mqtts over mqtt when both are present")
+    void getServiceUri_mqtt_prefersMqttsOverMqtt() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(true, false));
+        URI uri = config.getServiceUri(BootstrapConfig.Service.MQTT);
+        assertNotNull(uri);
+        assertEquals("mqtts", uri.getScheme());
+    }
+
+    @Test
+    @DisplayName("getServiceUri(MQTT) falls back to mqtt when mqtts is absent")
+    void getServiceUri_mqtt_fallsBackToMqtt() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        URI uri = config.getServiceUri(BootstrapConfig.Service.MQTT);
+        assertNotNull(uri);
+        assertEquals("mqtt", uri.getScheme());
+    }
+
+    @Test
+    @DisplayName("getServiceUri(OPEN_TELEMETRY) prefers https over http")
+    void getServiceUri_openTelemetry_prefersHttpsOverHttp() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, true));
+        URI uri = config.getServiceUri(BootstrapConfig.Service.OPEN_TELEMETRY);
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+    }
+
+    @Test
+    @DisplayName("getServiceUri(OPEN_TELEMETRY) falls back to http when https is absent")
+    void getServiceUri_openTelemetry_fallsBackToHttp() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        URI uri = config.getServiceUri(BootstrapConfig.Service.OPEN_TELEMETRY);
+        assertNotNull(uri);
+        assertEquals("http", uri.getScheme());
+    }
+
+    @Test
+    @DisplayName("getServiceUri(JAEGER) prefers https over http")
+    void getServiceUri_jaeger_prefersHttpsOverHttp() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, true));
+        URI uri = config.getServiceUri(BootstrapConfig.Service.JAEGER);
+        assertNotNull(uri);
+        assertEquals("https", uri.getScheme());
+    }
+
+    // ── isServiceSecured() ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("isServiceSecured(MQTT) is true when mqtts URI is present")
+    void isServiceSecured_mqtt_trueWhenMqttsPresent() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(true, false));
+        assertTrue(config.isServiceSecured(BootstrapConfig.Service.MQTT));
+    }
+
+    @Test
+    @DisplayName("isServiceSecured(MQTT) is false when only plain mqtt is present")
+    void isServiceSecured_mqtt_falseWhenOnlyPlainMqtt() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        assertFalse(config.isServiceSecured(BootstrapConfig.Service.MQTT));
+    }
+
+    @Test
+    @DisplayName("isServiceSecured(OPEN_TELEMETRY) is true when https URI is present")
+    void isServiceSecured_openTelemetry_trueWhenHttpsPresent() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, true));
+        assertTrue(config.isServiceSecured(BootstrapConfig.Service.OPEN_TELEMETRY));
+    }
+
+    @Test
+    @DisplayName("isServiceSecured(OPEN_TELEMETRY) is false when only http URI is present")
+    void isServiceSecured_openTelemetry_falseWhenOnlyHttp() throws Exception {
+        BootstrapConfig config = new BootstrapConfig(buildValidJson(false, false));
+        assertFalse(config.isServiceSecured(BootstrapConfig.Service.OPEN_TELEMETRY));
+    }
+
+    // ── missing required service keys ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("JSON without 'message' service key throws Exception")
+    void missingMessageKey_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services").remove("message");
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    @Test
+    @DisplayName("JSON without 'telemetry' service key throws Exception")
+    void missingTelemetryKey_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services").remove("telemetry");
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    @Test
+    @DisplayName("JSON without 'api' service key throws Exception")
+    void missingApiKey_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services").remove("api");
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    // ── unknown URI schemes ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("unknown scheme in 'message' service throws Exception")
+    void unknownMessageScheme_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services")
+            .put("message", new JSONArray().put(new JSONObject().put("uri", "ftp://broker.example.com:21")));
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    @Test
+    @DisplayName("unknown scheme in 'telemetry' service throws Exception")
+    void unknownTelemetryScheme_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services")
+            .put("telemetry", new JSONArray().put(new JSONObject().put("uri", "ftp://otel.example.com:21")));
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    @Test
+    @DisplayName("unknown scheme in 'api' service throws Exception")
+    void unknownApiScheme_throwsException() {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services")
+            .put("api", new JSONArray().put(new JSONObject().put("uri", "ftp://jaeger.example.com:21")));
+        assertThrows(Exception.class, () -> new BootstrapConfig(json));
+    }
+
+    // ── MQTT Websocket ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("mqtt+ws URI is parsed and returned for MQTT_WEBSOCKET service")
+    void mqttWsUri_parsedCorrectly() throws Exception {
+        JSONObject json = buildValidJson(false, false);
+        json.getJSONObject("services").getJSONArray("message")
+            .put(new JSONObject().put("uri", "mqtt+ws://broker.example.com:8080"));
+        BootstrapConfig config = new BootstrapConfig(json);
+        URI wsUri = config.getProtocolUri(BootstrapConfig.Protocol.MQTT_WS);
+        assertNotNull(wsUri);
+        assertEquals("mqtt+ws", wsUri.getScheme());
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapConfigTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core.bootstrap;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core.bootstrap;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
@@ -1,0 +1,248 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core.bootstrap;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link BootstrapHelper#bootstrap} using an in-process {@link MockWebServer}.
+ *
+ * <p>Covers:
+ * <ul>
+ *   <li>HTTP 200 with a valid JSON response → {@code boostrapSuccess} called</li>
+ *   <li>HTTP 4xx / 5xx → {@code boostrapError} called with the status code in the message</li>
+ *   <li>HTTP 200 with malformed JSON → {@code boostrapError} called</li>
+ *   <li>HTTP 200 with missing required fields → {@code boostrapError} called</li>
+ *   <li>Invalid URL → {@code boostrapError} called immediately</li>
+ *   <li>Request contains the expected JSON body fields and Basic-Auth header</li>
+ * </ul>
+ */
+@DisplayName("BootstrapHelper — HTTP flow")
+class BootstrapHelperTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() throws IOException {
+        server.shutdown();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private String bootstrapUrl() {
+        return server.url("/bootstrap").toString();
+    }
+
+    /** Builds the JSON body that a real bootstrap server would return. */
+    private static String buildValidResponseBody() {
+        JSONObject json = new JSONObject();
+        json.put("iot3_id", "my-iot3-id");
+        json.put("psk_iot3_id", "my-psk-login");
+        json.put("psk_iot3_secret", "my-psk-secret");
+
+        JSONObject services = new JSONObject();
+        services.put("message",  new JSONArray()
+                .put(new JSONObject().put("uri", "mqtt://broker.example.com:1883")));
+        services.put("telemetry", new JSONArray()
+                .put(new JSONObject().put("uri", "http://otel.example.com:4318")));
+        services.put("api", new JSONArray()
+                .put(new JSONObject().put("uri", "http://jaeger.example.com:16686")));
+        json.put("services", services);
+        return json.toString();
+    }
+
+    /** Invokes bootstrap and returns a pair of (successConfig, errorThrowable) via AtomicReferences. */
+    private record CallResult(AtomicReference<BootstrapConfig> config,
+                              AtomicReference<Throwable> error) {}
+
+    private CallResult callBootstrap(String url) {
+        AtomicReference<BootstrapConfig> config = new AtomicReference<>();
+        AtomicReference<Throwable>       error  = new AtomicReference<>();
+
+        BootstrapHelper.bootstrap(
+                "device-id", "login", "password",
+                BootstrapHelper.Role.USER_EQUIPMENT,
+                url,
+                new BootstrapCallback() {
+                    @Override public void boostrapSuccess(BootstrapConfig c) { config.set(c); }
+                    @Override public void boostrapError(Throwable t)         { error.set(t); }
+                }
+        );
+        return new CallResult(config, error);
+    }
+
+    // ── success path ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("HTTP 200 with valid JSON → boostrapSuccess is called with a populated BootstrapConfig")
+    void http200ValidJson_callsBootstrapSuccess() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(buildValidResponseBody()));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNotNull(result.config().get(), "boostrapSuccess should have been called");
+        assertNull(result.error().get(),    "boostrapError should NOT have been called");
+        assertEquals("my-iot3-id",    result.config().get().getIot3Id());
+        assertEquals("my-psk-login",  result.config().get().getPskRunLogin());
+        assertEquals("my-psk-secret", result.config().get().getPskRunPassword());
+    }
+
+    @Test
+    @DisplayName("Request carries the correct Content-Type and Basic-Auth headers")
+    void http200_requestHasCorrectHeaders() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(buildValidResponseBody()));
+
+        callBootstrap(bootstrapUrl());
+
+        RecordedRequest request = server.takeRequest();
+        // OkHttp appends "; charset=utf-8" to the Content-Type, so check with startsWith
+        assertTrue(Objects.requireNonNull(request.getHeader("Content-Type")).startsWith("application/json"),
+                "Content-Type should be application/json (charset suffix is acceptable)");
+        String auth = request.getHeader("Authorization");
+        assertNotNull(auth);
+        assertTrue(auth.startsWith("Basic "), "Authorization header should use Basic scheme");
+    }
+
+    @Test
+    @DisplayName("Request body contains ue_id, psk_login, psk_password, and role fields")
+    void http200_requestBodyContainsExpectedFields() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(buildValidResponseBody()));
+
+        callBootstrap(bootstrapUrl());
+
+        RecordedRequest request = server.takeRequest();
+        JSONObject body = new JSONObject(request.getBody().readUtf8());
+        assertEquals("device-id",        body.getString("ue_id"));
+        assertEquals("login",             body.getString("psk_login"));
+        assertEquals("password",          body.getString("psk_password"));
+        assertEquals("user-equipment",    body.getString("role"));
+    }
+
+    // ── HTTP error codes ──────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("HTTP 400 → boostrapError is called and message contains the status code")
+    void http400_callsBootstrapError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setBody("Bad Request"));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNull(result.config().get(),   "boostrapSuccess should NOT have been called");
+        assertNotNull(result.error().get(), "boostrapError should have been called");
+        assertTrue(result.error().get().getMessage().contains("400"));
+    }
+
+    @Test
+    @DisplayName("HTTP 401 → boostrapError is called")
+    void http401_callsBootstrapError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .setBody("Unauthorized"));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNotNull(result.error().get());
+        assertTrue(result.error().get().getMessage().contains("401"));
+    }
+
+    @Test
+    @DisplayName("HTTP 500 → boostrapError is called and message contains the status code")
+    void http500_callsBootstrapError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal Server Error"));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNull(result.config().get());
+        assertNotNull(result.error().get());
+        assertTrue(result.error().get().getMessage().contains("500"));
+    }
+
+    // ── malformed / incomplete response bodies ────────────────────────────────
+
+    @Test
+    @DisplayName("HTTP 200 with non-JSON body → boostrapError is called")
+    void http200MalformedJson_callsBootstrapError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("this-is-not-json"));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNull(result.config().get());
+        assertNotNull(result.error().get());
+    }
+
+    @Test
+    @DisplayName("HTTP 200 with JSON missing required fields → boostrapError is called")
+    void http200MissingFields_callsBootstrapError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"unexpected_key\": \"value\"}"));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNull(result.config().get());
+        assertNotNull(result.error().get());
+    }
+
+    @Test
+    @DisplayName("HTTP 200 with JSON missing 'services' key → boostrapError is called")
+    void http200MissingServicesKey_callsBootstrapError() {
+        JSONObject partial = new JSONObject();
+        partial.put("iot3_id", "id");
+        partial.put("psk_iot3_id", "login");
+        partial.put("psk_iot3_secret", "secret");
+        // no "services" key
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody(partial.toString()));
+
+        CallResult result = callBootstrap(bootstrapUrl());
+
+        assertNull(result.config().get());
+        assertNotNull(result.error().get());
+    }
+
+    // ── network / URL errors ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("completely invalid URL → boostrapError is called immediately")
+    void invalidUrl_callsBootstrapError() {
+        CallResult result = callBootstrap("not-a-valid-url-at-all");
+
+        assertNull(result.config().get());
+        assertNotNull(result.error().get());
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/bootstrap/BootstrapHelperTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core.bootstrap;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
@@ -1,0 +1,185 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core.clients;
+
+import com.hivemq.client.mqtt.MqttClientState;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishBuilder;
+import org.junit.jupiter.api.*;
+import org.mockito.Answers;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MqttClient} using a mock {@link Mqtt5AsyncClient} injected via the
+ * package-private constructor, so no real broker connection is needed.
+ *
+ * <p>Tests cover:
+ * <ul>
+ *   <li>Connection state delegation ({@code isConnected()})</li>
+ *   <li>Guard behaviour when the client is closed (subscribe / publish / double-close)</li>
+ *   <li>QoS 0 message drop when disconnected</li>
+ *   <li>Invalid-topic guard inside {@code publishMessage}</li>
+ * </ul>
+ */
+@DisplayName("MqttClient — guard and state behaviour")
+class MqttClientTest {
+
+    private Mqtt5AsyncClient mockMqttClient;
+    private MqttCallback     mockCallback;
+    private MqttClient       client;
+
+    @BeforeEach
+    void setUp() {
+        // RETURNS_DEEP_STUBS automatically stubs the entire fluent-builder chain
+        // (subscribeWith(), publishWith(), disconnect()…) without manual setup.
+        mockMqttClient = mock(Mqtt5AsyncClient.class, RETURNS_DEEP_STUBS);
+        mockCallback   = mock(MqttCallback.class);
+        setupPublishChainStub();
+        client         = new MqttClient(mockMqttClient, mockCallback, null);
+    }
+
+    /**
+     * Explicitly wires the {@code publishWith()} fluent chain to avoid two problems:
+     * <ol>
+     *   <li><b>ClassCastException</b> — {@code RETURNS_DEEP_STUBS} resolves the self-generic
+     *       {@code B extends Mqtt5PublishBuilderBase.Complete<B>} to the raw bound
+     *       {@code Mqtt5PublishBuilderBase.Complete} instead of
+     *       {@code Mqtt5PublishBuilder.Send.Complete}.</li>
+     *   <li><b>NullPointerException</b> — {@code RETURNS_DEEP_STUBS} cannot infer the
+     *       unbound generic {@code P} in {@code CompletableFuture<P>} returned by
+     *       {@code send()}, so it falls back to {@code null}.</li>
+     * </ol>
+     *
+     * <p>{@code Answers.RETURNS_SELF} solves (1) automatically: every builder method whose
+     * return type is compatible with {@code Mqtt5PublishBuilder.Send.Complete} (i.e. all
+     * the chaining methods) returns the same mock. {@code send()} is incompatible, so it
+     * is stubbed explicitly to return a mock {@link CompletableFuture}.
+     */
+    @SuppressWarnings("rawtypes")
+    private void setupPublishChainStub() {
+        Mqtt5PublishBuilder.Send.Complete builderStub =
+                mock(Mqtt5PublishBuilder.Send.Complete.class, Answers.RETURNS_SELF);
+        // send() → CompletableFuture<P>: incompatible with mock type, RETURNS_SELF gives null
+        CompletableFuture mockFuture = mock(CompletableFuture.class);
+        doReturn(mockFuture).when(builderStub).send();
+        doReturn(builderStub).when(mockMqttClient).publishWith();
+    }
+
+    // ── isConnected() ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("isConnected() returns true when underlying state is CONNECTED")
+    void isConnected_whenStateConnected_returnsTrue() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.CONNECTED);
+        assertTrue(client.isConnected());
+    }
+
+    @Test
+    @DisplayName("isConnected() returns false when underlying state is DISCONNECTED")
+    void isConnected_whenStateDisconnected_returnsFalse() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.DISCONNECTED);
+        assertFalse(client.isConnected());
+    }
+
+    // ── close() guard ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("calling close() twice only triggers one disconnect on the broker")
+    void close_calledTwice_disconnectsOnlyOnce() {
+        client.close();
+        client.close(); // second call must be a no-op
+        verify(mockMqttClient, times(1)).disconnect();
+    }
+
+    @Test
+    @DisplayName("subscribeToTopic() after close() never calls the broker")
+    void subscribeToTopic_afterClose_neverCallsBroker() {
+        client.close();
+        client.subscribeToTopic("test/topic");
+        verify(mockMqttClient, never()).subscribeWith();
+    }
+
+    @Test
+    @DisplayName("unsubscribeFromTopic() after close() never calls the broker")
+    void unsubscribeFromTopic_afterClose_neverCallsBroker() {
+        client.close();
+        client.unsubscribeFromTopic("test/topic");
+        verify(mockMqttClient, never()).unsubscribeWith();
+    }
+
+    @Test
+    @DisplayName("publishMessage() after close() never calls the broker")
+    void publishMessage_afterClose_neverCallsBroker() {
+        client.close();
+        client.publishMessage("valid/topic", "message", false, 0, 0);
+        verify(mockMqttClient, never()).publishWith();
+    }
+
+    // ── disconnected state guards ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("subscribeToTopic() when not connected stores topic but does not call broker")
+    void subscribeToTopic_whenNotConnected_neverCallsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.DISCONNECTED);
+        client.subscribeToTopic("test/topic");
+        verify(mockMqttClient, never()).subscribeWith();
+    }
+
+    @Test
+    @DisplayName("unsubscribeFromTopic() when not connected does not call broker")
+    void unsubscribeFromTopic_whenNotConnected_neverCallsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.DISCONNECTED);
+        client.unsubscribeFromTopic("test/topic");
+        verify(mockMqttClient, never()).unsubscribeWith();
+    }
+
+    @Test
+    @DisplayName("QoS 0 publish is silently dropped when the client is disconnected")
+    void publishMessage_qos0WhenDisconnected_neverCallsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.DISCONNECTED);
+        client.publishMessage("valid/topic", "message", false, 0, 0);
+        verify(mockMqttClient, never()).publishWith();
+    }
+
+    @Test
+    @DisplayName("QoS 1 publish is forwarded even when disconnected (broker will queue it)")
+    void publishMessage_qos1WhenDisconnected_callsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.DISCONNECTED);
+        client.publishMessage("valid/topic", "message", false, 1, 0);
+        verify(mockMqttClient).publishWith();
+    }
+
+    // ── topic validation inside publishMessage ────────────────────────────────
+
+    @Test
+    @DisplayName("publishMessage() with '#' wildcard topic never calls the broker")
+    void publishMessage_hashWildcardTopic_neverCallsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.CONNECTED);
+        client.publishMessage("invalid/#/topic", "message", false, 0, 0);
+        verify(mockMqttClient, never()).publishWith();
+    }
+
+    @Test
+    @DisplayName("publishMessage() with '+' wildcard topic never calls the broker")
+    void publishMessage_plusWildcardTopic_neverCallsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.CONNECTED);
+        client.publishMessage("invalid/+/topic", "message", false, 0, 0);
+        verify(mockMqttClient, never()).publishWith();
+    }
+
+    @Test
+    @DisplayName("publishMessage() with valid topic when connected calls the broker")
+    void publishMessage_validTopicWhenConnected_callsBroker() {
+        when(mockMqttClient.getState()).thenReturn(MqttClientState.CONNECTED);
+        client.publishMessage("context/inQueue/v2x/cam/uuid/0/3/1/2", "payload", false, 0, 0);
+        verify(mockMqttClient).publishWith();
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core.clients;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttClientTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core.clients;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core.clients;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core.clients;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/MqttTopicValidationTest.java
@@ -1,0 +1,110 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core.clients;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MqttClient#isValidMqttPubTopic(String)}.
+ * This method is pure logic (no I/O) and can be tested entirely in isolation.
+ */
+@DisplayName("MQTT publish topic validation")
+class MqttTopicValidationTest {
+
+    // ── happy-path ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("single-level topic is valid")
+    void singleLevelTopic_returnsTrue() {
+        assertTrue(MqttClient.isValidMqttPubTopic("topic"));
+    }
+
+    @Test
+    @DisplayName("multi-level topic with slashes is valid")
+    void multiLevelTopic_returnsTrue() {
+        assertTrue(MqttClient.isValidMqttPubTopic("a/b/c/d/e"));
+    }
+
+    @Test
+    @DisplayName("topic at exactly max length (65535) is valid")
+    void topicAtMaxLength_returnsTrue() {
+        String maxTopic = "a".repeat(65535);
+        assertTrue(MqttClient.isValidMqttPubTopic(maxTopic));
+    }
+
+    @Test
+    @DisplayName("topic with digits and special chars (except wildcards) is valid")
+    void topicWithDigitsAndSpecialChars_returnsTrue() {
+        assertTrue(MqttClient.isValidMqttPubTopic("context/inQueue/v2x/cam/uuid-123/0/3/1/2"));
+    }
+
+    // ── null / empty ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("null topic is invalid")
+    void nullTopic_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic(null));
+    }
+
+    @Test
+    @DisplayName("empty topic is invalid")
+    void emptyTopic_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic(""));
+    }
+
+    // ── wildcard characters ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("topic ending with '#' wildcard is invalid")
+    void topicWithHashAtEnd_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic("my/topic/#"));
+    }
+
+    @Test
+    @DisplayName("topic containing '#' in the middle is invalid")
+    void topicWithHashInMiddle_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic("my/#/topic"));
+    }
+
+    @Test
+    @DisplayName("topic containing '+' single-level wildcard is invalid")
+    void topicWithPlusWildcard_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic("my/+/topic"));
+    }
+
+    @Test
+    @DisplayName("topic that is just '+' is invalid")
+    void topicIsOnlyPlus_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic("+"));
+    }
+
+    // ── whitespace ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("topic with leading space is invalid")
+    void topicWithLeadingSpace_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic(" my/topic"));
+    }
+
+    @Test
+    @DisplayName("topic with trailing space is invalid")
+    void topicWithTrailingSpace_returnsFalse() {
+        assertFalse(MqttClient.isValidMqttPubTopic("my/topic "));
+    }
+
+    // ── length limit ──────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("topic exceeding 65535 chars is invalid")
+    void topicExceedingMaxLength_returnsFalse() {
+        String tooLong = "a".repeat(65536);
+        assertFalse(MqttClient.isValidMqttPubTopic(tooLong));
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3core.clients.lwm2m.model;
 

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
@@ -1,0 +1,222 @@
+/*
+ Copyright 2016-2025 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3core.clients.lwm2m.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the LwM2M data-model classes:
+ * {@link Lwm2mConfig.Lwm2mBootstrapConfig}, {@link Lwm2mConfig.Lwm2mClassicConfig},
+ * and {@link Lwm2mServer}.
+ *
+ * <p>All classes are pure value objects (no I/O, no network), so no mocking is required.
+ */
+@DisplayName("LwM2M config model — field storage and defaults")
+class Lwm2mConfigTest {
+
+    /** Shared server config used as a dependency in both config sub-types. */
+    private Lwm2mServer serverConfig;
+
+    @BeforeEach
+    void setUp() {
+        // "U" = UDP, the standard LwM2M binding mode
+        serverConfig = new Lwm2mServer(1, 300, "U");
+    }
+
+    // ── Lwm2mServer ───────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Lwm2mServer stores shortServerId correctly")
+    void server_storesShortServerId() {
+        Lwm2mServer server = new Lwm2mServer(99, 600, "U");
+        assertEquals(99, server.getShortServerId());
+    }
+
+    @Test
+    @DisplayName("Lwm2mServer stores lifetime correctly")
+    void server_storesLifetime() {
+        Lwm2mServer server = new Lwm2mServer(1, 600, "U");
+        assertEquals(600, server.getLifetime());
+    }
+
+    @Test
+    @DisplayName("Lwm2mServer notifyWhenDisable defaults to false")
+    void server_notifyWhenDisable_defaultFalse() {
+        Lwm2mServer server = new Lwm2mServer(1, 300, "U");
+        assertFalse(server.isNotifyWhenDisable());
+    }
+
+    @Test
+    @DisplayName("Lwm2mServer notifyWhenDisable can be set to true")
+    void server_notifyWhenDisable_canBeEnabled() {
+        Lwm2mServer server = new Lwm2mServer(1, 300, "U", true);
+        assertTrue(server.isNotifyWhenDisable());
+    }
+
+    @Test
+    @DisplayName("Lwm2mServer bindingModes is non-null and non-empty")
+    void server_bindingModes_nonEmpty() {
+        assertNotNull(serverConfig.getBindingModes());
+        assertFalse(serverConfig.getBindingModes().isEmpty());
+    }
+
+    @Test
+    @DisplayName("Lwm2mServer preferredTransport is non-null")
+    void server_preferredTransport_nonNull() {
+        assertNotNull(serverConfig.getPreferredTransport());
+    }
+
+    // ── Lwm2mBootstrapConfig ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("BootstrapConfig stores endpointName correctly")
+    void bootstrap_storesEndpointName() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "my-endpoint", "coaps://bootstrap.example.com:5684",
+                "psk-identity", "deadbeef01", serverConfig
+        );
+        assertEquals("my-endpoint", config.getEndpointName());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig stores URI correctly")
+    void bootstrap_storesUri() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "coaps://bootstrap.example.com:5684",
+                "psk-identity", "deadbeef01", serverConfig
+        );
+        assertEquals("coaps://bootstrap.example.com:5684", config.getUri());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig stores PSK identity correctly")
+    void bootstrap_storesPskIdentity() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "coaps://bs.example.com:5684",
+                "my-psk-id", "deadbeef01", serverConfig
+        );
+        assertEquals("my-psk-id", config.getPskIdentity());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig stores private key correctly")
+    void bootstrap_storesPrivateKey() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "coaps://bs.example.com:5684",
+                "psk-id", "cafebabe42", serverConfig
+        );
+        assertEquals("cafebabe42", config.getPrivateKey());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig stores serverConfig reference")
+    void bootstrap_storesServerConfig() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "uri", "id", "key", serverConfig
+        );
+        assertSame(serverConfig, config.getServerConfig());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig queueMode defaults to false")
+    void bootstrap_queueMode_defaultFalse() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "uri", "id", "key", serverConfig
+        );
+        assertFalse(config.isQueueMode());
+    }
+
+    @Test
+    @DisplayName("BootstrapConfig queueMode can be set to true")
+    void bootstrap_queueMode_canBeEnabled() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mBootstrapConfig(
+                "ep", "uri", "id", "key", serverConfig, true
+        );
+        assertTrue(config.isQueueMode());
+    }
+
+    // ── Lwm2mClassicConfig ────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("ClassicConfig stores endpointName correctly")
+    void classic_storesEndpointName() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "classic-endpoint", "coaps://server.example.com:5684",
+                "psk-id", "deadbeef01", 1, serverConfig
+        );
+        assertEquals("classic-endpoint", config.getEndpointName());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig stores URI correctly")
+    void classic_storesUri() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "coaps://server.example.com:5684",
+                "psk-id", "deadbeef01", 1, serverConfig
+        );
+        assertEquals("coaps://server.example.com:5684", config.getUri());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig stores shortServerId correctly")
+    void classic_storesShortServerId() {
+        Lwm2mConfig.Lwm2mClassicConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "coaps://server.example.com:5684",
+                "psk-id", "deadbeef01", 42, serverConfig
+        );
+        assertEquals(42, config.getShortServerId());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig stores PSK identity correctly")
+    void classic_storesPskIdentity() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "uri", "my-classic-psk", "key", 1, serverConfig
+        );
+        assertEquals("my-classic-psk", config.getPskIdentity());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig stores private key correctly")
+    void classic_storesPrivateKey() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "uri", "psk-id", "cafebabe42", 1, serverConfig
+        );
+        assertEquals("cafebabe42", config.getPrivateKey());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig stores serverConfig reference")
+    void classic_storesServerConfig() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "uri", "id", "key", 1, serverConfig
+        );
+        assertSame(serverConfig, config.getServerConfig());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig queueMode defaults to false")
+    void classic_queueMode_defaultFalse() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "uri", "id", "key", 1, serverConfig
+        );
+        assertFalse(config.isQueueMode());
+    }
+
+    @Test
+    @DisplayName("ClassicConfig queueMode can be set to true")
+    void classic_queueMode_canBeEnabled() {
+        Lwm2mConfig config = new Lwm2mConfig.Lwm2mClassicConfig(
+                "ep", "uri", "id", "key", 1, serverConfig, true
+        );
+        assertTrue(config.isQueueMode());
+    }
+}
+

--- a/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
+++ b/java/iot3/core/src/test/java/com/orange/iot3core/clients/lwm2m/model/Lwm2mConfigTest.java
@@ -1,7 +1,9 @@
 /*
- Copyright 2016-2025 Orange
+ Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3core.clients.lwm2m.model;
 

--- a/java/iot3/mobility/build.gradle
+++ b/java/iot3/mobility/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
+    // Mockito for mock-based unit tests.
+    testImplementation 'org.mockito:mockito-core:5.11.0'
 }
 
 tasks.named('test') {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadSensor.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadSensor.java
@@ -71,6 +71,7 @@ public class RoadSensor {
     public void updateSensorObjects() {
         if(cpmFrame != null && cpmFrame.version() == CpmVersion.V1_2_1) {
             CpmEnvelope121 cpmEnvelope121 = (CpmEnvelope121) cpmFrame.envelope();
+            if(cpmEnvelope121.message().perceivedObjectContainer() == null) return;
             List<PerceivedObject> perceivedObjects = cpmEnvelope121.message().perceivedObjectContainer().perceivedObjects();
 
             if(!perceivedObjects.isEmpty()) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadUser.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadUser.java
@@ -58,7 +58,7 @@ public class RoadUser {
     }
 
     public double getSpeedKmh() {
-        return speed * 3.6f;
+        return speed * 3.6;
     }
 
     public void setSpeed(double speed) {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SensorObject.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SensorObject.java
@@ -56,7 +56,7 @@ public class SensorObject {
     }
 
     public double getSpeedKmh() {
-        return speed * 3.6f;
+        return speed * 3.6;
     }
 
     public void setSpeed(double speed) {

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
@@ -1,0 +1,135 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility;
+
+import com.orange.iot3mobility.quadkey.LatLng;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilsTest {
+
+    private static final double DELTA = 1e-6;
+
+    // -------------------------------------------------------------------------
+    // pointFromPosition
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pointFromPositionNorthShiftsLatitude() {
+        LatLng origin = new LatLng(0.0, 0.0);
+        // Move 1 km North (bearing 0°). Latitude should increase, longitude unchanged.
+        LatLng result = Utils.pointFromPosition(origin, 0.0, 1000.0);
+        assertTrue(result.getLatitude() > 0.0,
+                "Moving North should increase latitude");
+        assertEquals(0.0, result.getLongitude(), 1e-4,
+                "Moving North should not change longitude");
+    }
+
+    @Test
+    void pointFromPositionEastShiftsLongitude() {
+        LatLng origin = new LatLng(0.0, 0.0);
+        // Move 1 km East (bearing 90°). Longitude should increase, latitude roughly unchanged.
+        LatLng result = Utils.pointFromPosition(origin, 90.0, 1000.0);
+        assertTrue(result.getLongitude() > 0.0,
+                "Moving East should increase longitude");
+        assertEquals(0.0, result.getLatitude(), 1e-4,
+                "Moving East at equator should not change latitude");
+    }
+
+    @Test
+    void pointFromPositionZeroDistanceReturnsSamePoint() {
+        LatLng origin = new LatLng(48.8566, 2.3522);
+        LatLng result = Utils.pointFromPosition(origin, 45.0, 0.0);
+        assertEquals(origin.getLatitude(), result.getLatitude(), DELTA);
+        assertEquals(origin.getLongitude(), result.getLongitude(), DELTA);
+    }
+
+    @Test
+    void pointFromPositionApproximateDistanceCheck() {
+        // 111 km ≈ 1 degree of latitude at the equator
+        LatLng origin = new LatLng(0.0, 0.0);
+        LatLng result = Utils.pointFromPosition(origin, 0.0, 111000.0);
+        assertEquals(1.0, result.getLatitude(), 0.01,
+                "111 km North should be ~1 degree of latitude");
+    }
+
+    // -------------------------------------------------------------------------
+    // clamp
+    // -------------------------------------------------------------------------
+
+    @Test
+    void clampReturnMinWhenBelowMin() {
+        assertEquals(0.0f, Utils.clamp(-5.0f, 0.0f, 10.0f), 0.0f);
+    }
+
+    @Test
+    void clampReturnMaxWhenAboveMax() {
+        assertEquals(10.0f, Utils.clamp(15.0f, 0.0f, 10.0f), 0.0f);
+    }
+
+    @Test
+    void clampReturnValueWhenWithinRange() {
+        assertEquals(5.0f, Utils.clamp(5.0f, 0.0f, 10.0f), 0.0f);
+    }
+
+    @Test
+    void clampReturnMinWhenEqualToMin() {
+        assertEquals(0.0f, Utils.clamp(0.0f, 0.0f, 10.0f), 0.0f);
+    }
+
+    @Test
+    void clampReturnMaxWhenEqualToMax() {
+        assertEquals(10.0f, Utils.clamp(10.0f, 0.0f, 10.0f), 0.0f);
+    }
+
+    // -------------------------------------------------------------------------
+    // normalizeAngle
+    // -------------------------------------------------------------------------
+
+    @Test
+    void normalizeAnglePositiveWithinRangeUnchanged() {
+        assertEquals(90.0f, Utils.normalizeAngle(90.0f), 0.001f);
+    }
+
+    @Test
+    void normalizeAngleZeroStaysZero() {
+        assertEquals(0.0f, Utils.normalizeAngle(0.0f), 0.001f);
+    }
+
+    @Test
+    void normalizeAngle360BecomesZero() {
+        assertEquals(0.0f, Utils.normalizeAngle(360.0f), 0.001f);
+    }
+
+    @Test
+    void normalizeAngleNegativeWrapsAround() {
+        assertEquals(270.0f, Utils.normalizeAngle(-90.0f), 0.001f);
+    }
+
+    @Test
+    void normalizeAngleOver360Wraps() {
+        assertEquals(90.0f, Utils.normalizeAngle(450.0f), 0.001f);
+    }
+
+    // -------------------------------------------------------------------------
+    // randomBetween
+    // -------------------------------------------------------------------------
+
+    @RepeatedTest(20)
+    void randomBetweenIsWithinBounds() {
+        int result = Utils.randomBetween(5, 10);
+        assertTrue(result >= 5 && result <= 10,
+                "randomBetween(5,10) must be in [5, 10], got " + result);
+    }
+
+    @Test
+    void randomBetweenSameMinAndMaxReturnsThatValue() {
+        assertEquals(7, Utils.randomBetween(7, 7));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/UtilsTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadHazardManagerTest.java
@@ -1,0 +1,240 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.managers;
+
+import com.orange.iot3mobility.messages.denm.DenmHelper;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.EventType;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.SituationContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.CauseCode;
+import com.orange.iot3mobility.roadobjects.RoadHazard;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RoadHazardManagerTest {
+
+    private IoT3RoadHazardCallback mockCallback;
+    private final DenmHelper denmHelper = new DenmHelper();
+
+    // Valid far-future timestamp so hazard is not expired
+    private static final long VALID_TIMESTAMP = System.currentTimeMillis();
+
+    @BeforeEach
+    void resetStaticState() throws Exception {
+        mockCallback = mock(IoT3RoadHazardCallback.class);
+
+        Field hazardsField = RoadHazardManager.class.getDeclaredField("ROAD_HAZARDS");
+        hazardsField.setAccessible(true);
+        ((ArrayList<?>) hazardsField.get(null)).clear();
+
+        Field mapField = RoadHazardManager.class.getDeclaredField("ROAD_HAZARD_MAP");
+        mapField.setAccessible(true);
+        ((HashMap<?, ?>) mapField.get(null)).clear();
+
+        RoadHazardManager.init(mockCallback);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper factories
+    // -------------------------------------------------------------------------
+
+    /** Build a v1.1.3 DENM JSON with given sequenceNumber and validityDuration.
+     *  termination=null means active hazard. */
+    private String denm113Json(int originatingStationId, int sequenceNumber,
+                                int validityDurationSec, Integer termination) throws Exception {
+        ReferencePosition pos = new ReferencePosition(488566000, 23522000, 0);
+        ManagementContainer mgmt = ManagementContainer.builder()
+                .actionId(new ActionId(originatingStationId, sequenceNumber))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(pos)
+                .validityDuration(validityDurationSec)
+                .termination(termination)
+                .build();
+        SituationContainer situation = SituationContainer.builder()
+                .eventType(new EventType(1, 5)) // TRAFFIC_STATIONARY
+                .build();
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(originatingStationId)
+                .managementContainer(mgmt)
+                .situationContainer(situation)
+                .build();
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(VALID_TIMESTAMP)
+                .message(message)
+                .build();
+        return denmHelper.toJson(envelope);
+    }
+
+    /** Build a v2.2.0 DENM JSON with given sequenceNumber and validityDuration. */
+    private String denm220Json(int originatingStationId, int sequenceNumber,
+                                int validityDurationSec, Integer termination) throws Exception {
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition pos =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition.builder()
+                        .latitude(488566000)
+                        .longitude(23522000)
+                        .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                        .altitude(new Altitude(0, 0))
+                        .build();
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer mgmt =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer.builder()
+                        .actionId(new com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId(
+                                originatingStationId, sequenceNumber))
+                        .detectionTime(0)
+                        .referenceTime(0)
+                        .eventPosition(pos)
+                        .validityDuration(validityDurationSec)
+                        .termination(termination)
+                        .stationType(5)
+                        .build();
+        com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer situation =
+                com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer.builder()
+                        .informationQuality(7)
+                        .eventType(new CauseCode(1, 5))
+                        .build();
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(originatingStationId)
+                .managementContainer(mgmt)
+                .situationContainer(situation)
+                .build();
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(VALID_TIMESTAMP)
+                .message(message)
+                .build();
+        return denmHelper.toJson(envelope);
+    }
+
+    // -------------------------------------------------------------------------
+    // v1.1.3 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processDenm113FirstMessageTriggersNewRoadHazard() throws Exception {
+        String json = denm113Json(1, 1, 600, null);
+        RoadHazardManager.processDenm(json, denmHelper);
+
+        verify(mockCallback, times(1)).newRoadHazard(any(RoadHazard.class));
+        verify(mockCallback, never()).roadHazardUpdate(any());
+    }
+
+    @Test
+    void processDenm113DenmArrivedCallbackIsAlwaysFired() throws Exception {
+        String json = denm113Json(1, 10, 600, null);
+        RoadHazardManager.processDenm(json, denmHelper);
+        RoadHazardManager.processDenm(json, denmHelper);
+
+        verify(mockCallback, times(2)).denmArrived(any());
+    }
+
+    @Test
+    void processDenm113SecondMessageWithSameIdTriggersUpdate() throws Exception {
+        String json = denm113Json(1, 20, 600, null);
+        RoadHazardManager.processDenm(json, denmHelper);
+        RoadHazardManager.processDenm(json, denmHelper);
+
+        verify(mockCallback, times(1)).newRoadHazard(any());
+        verify(mockCallback, times(1)).roadHazardUpdate(any());
+    }
+
+    @Test
+    void processDenm113TerminationRemovesExistingHazard() throws Exception {
+        RoadHazardManager.processDenm(denm113Json(1, 30, 600, null), denmHelper);
+        RoadHazardManager.processDenm(denm113Json(1, 30, 600, 0 /* termination */), denmHelper);
+
+        verify(mockCallback, times(1)).newRoadHazard(any());
+        verify(mockCallback, times(1)).roadHazardExpired(any());
+        verify(mockCallback, never()).roadHazardUpdate(any());
+        assertEquals(0, RoadHazardManager.getRoadHazards().size());
+    }
+
+    @Test
+    void processDenm113NewHazardHasCorrectPosition() throws Exception {
+        RoadHazardManager.processDenm(denm113Json(1, 50, 600, null), denmHelper);
+
+        ArgumentCaptor<RoadHazard> captor = ArgumentCaptor.forClass(RoadHazard.class);
+        verify(mockCallback).newRoadHazard(captor.capture());
+        assertEquals(48.8566, captor.getValue().getPosition().getLatitude(), 1e-4);
+        assertEquals(2.3522, captor.getValue().getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void processDenm113TwoDifferentHazardsAreCreated() throws Exception {
+        RoadHazardManager.processDenm(denm113Json(1, 60, 600, null), denmHelper);
+        RoadHazardManager.processDenm(denm113Json(1, 61, 600, null), denmHelper);
+
+        verify(mockCallback, times(2)).newRoadHazard(any());
+        assertEquals(2, RoadHazardManager.getRoadHazards().size());
+    }
+
+    // -------------------------------------------------------------------------
+    // v2.2.0 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processDenm220FirstMessageTriggersNewRoadHazard() throws Exception {
+        String json = denm220Json(2, 1, 600, null);
+        RoadHazardManager.processDenm(json, denmHelper);
+
+        verify(mockCallback, times(1)).newRoadHazard(any(RoadHazard.class));
+    }
+
+    @Test
+    void processDenm220SecondMessageTriggersUpdate() throws Exception {
+        String json = denm220Json(2, 2, 600, null);
+        RoadHazardManager.processDenm(json, denmHelper);
+        RoadHazardManager.processDenm(json, denmHelper);
+
+        verify(mockCallback, times(1)).newRoadHazard(any());
+        verify(mockCallback, times(1)).roadHazardUpdate(any());
+    }
+
+    @Test
+    void processDenm220TerminationRemovesHazard() throws Exception {
+        RoadHazardManager.processDenm(denm220Json(2, 3, 600, null), denmHelper);
+        RoadHazardManager.processDenm(denm220Json(2, 3, 600, 0), denmHelper);
+
+        verify(mockCallback, times(1)).roadHazardExpired(any());
+        assertEquals(0, RoadHazardManager.getRoadHazards().size());
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processDenmInvalidJsonDoesNotCrash() {
+        assertDoesNotThrow(() ->
+                RoadHazardManager.processDenm("{invalid}", denmHelper));
+    }
+
+    @Test
+    void getRoadHazardsReturnsUnmodifiableList() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> RoadHazardManager.getRoadHazards().add(null));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
@@ -1,0 +1,195 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.managers;
+
+import com.orange.iot3mobility.messages.cpm.CpmHelper;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmEnvelope121;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmMessage121;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmEnvelope211;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmMessage211;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
+import com.orange.iot3mobility.roadobjects.RoadSensor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RoadSensorManagerTest {
+
+    private IoT3RoadSensorCallback mockCallback;
+    private final CpmHelper cpmHelper = new CpmHelper();
+
+    @BeforeEach
+    void resetStaticState() throws Exception {
+        mockCallback = mock(IoT3RoadSensorCallback.class);
+
+        Field sensorsField = RoadSensorManager.class.getDeclaredField("ROAD_SENSORS");
+        sensorsField.setAccessible(true);
+        ((ArrayList<?>) sensorsField.get(null)).clear();
+
+        Field mapField = RoadSensorManager.class.getDeclaredField("ROAD_SENSOR_MAP");
+        mapField.setAccessible(true);
+        ((HashMap<?, ?>) mapField.get(null)).clear();
+
+        RoadSensorManager.init(mockCallback);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper factories
+    // -------------------------------------------------------------------------
+
+    /** Build a minimal v1.2.1 CPM JSON string. */
+    private String cpm121Json(String sourceUuid, long stationId) throws Exception {
+        ReferencePosition ref = new ReferencePosition(488566000, 23522000, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(ref)
+                .confidence(confidence)
+                .build();
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(stationId)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                // no perceivedObjectContainer: omitted → null, avoids [1,128] size validation
+                .build();
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid(sourceUuid)
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+        return cpmHelper.toJson(envelope);
+    }
+
+    /** Build a minimal v2.1.1 CPM JSON string. */
+    private String cpm211Json(String sourceUuid, long stationId) throws Exception {
+        com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse ellipse =
+                new com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse(0, 0, 0);
+        com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition ref =
+                com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition.builder()
+                        .latitudeLongitude(488566000, 23522000)
+                        .positionConfidenceEllipse(ellipse)
+                        .altitude(new Altitude(0, 0))
+                        .build();
+        com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer management =
+                com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(ref)
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(stationId)
+                .managementContainer(management)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid(sourceUuid)
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+        return cpmHelper.toJson(envelope);
+    }
+
+    // -------------------------------------------------------------------------
+    // v1.2.1 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processCpm121FirstMessageTriggersNewRoadSensor() throws Exception {
+        RoadSensorManager.processCpm(cpm121Json("sensor_A", 1), cpmHelper);
+
+        verify(mockCallback, times(1)).newRoadSensor(any(RoadSensor.class));
+        verify(mockCallback, never()).roadSensorUpdate(any());
+    }
+
+    @Test
+    void processCpm121NewSensorHasCorrectPosition() throws Exception {
+        RoadSensorManager.processCpm(cpm121Json("sensor_B", 2), cpmHelper);
+
+        ArgumentCaptor<RoadSensor> captor = ArgumentCaptor.forClass(RoadSensor.class);
+        verify(mockCallback).newRoadSensor(captor.capture());
+        assertEquals(48.8566, captor.getValue().getPosition().getLatitude(), 1e-4);
+        assertEquals(2.3522, captor.getValue().getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void processCpm121SecondMessageTriggersRoadSensorUpdate() throws Exception {
+        String json = cpm121Json("sensor_C", 3);
+        RoadSensorManager.processCpm(json, cpmHelper);
+        RoadSensorManager.processCpm(json, cpmHelper);
+
+        verify(mockCallback, times(1)).newRoadSensor(any());
+        verify(mockCallback, times(1)).roadSensorUpdate(any());
+    }
+
+    @Test
+    void processCpm121CpmArrivedCallbackIsAlwaysFired() throws Exception {
+        String json = cpm121Json("sensor_D", 4);
+        RoadSensorManager.processCpm(json, cpmHelper);
+        RoadSensorManager.processCpm(json, cpmHelper);
+
+        verify(mockCallback, times(2)).cpmArrived(any());
+    }
+
+    @Test
+    void processCpm121TwoDifferentSensorsAreCreated() throws Exception {
+        RoadSensorManager.processCpm(cpm121Json("sensor_E", 5), cpmHelper);
+        RoadSensorManager.processCpm(cpm121Json("sensor_F", 6), cpmHelper);
+
+        verify(mockCallback, times(2)).newRoadSensor(any());
+        assertEquals(2, RoadSensorManager.getRoadSensors().size());
+    }
+
+    // -------------------------------------------------------------------------
+    // v2.1.1 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processCpm211FirstMessageTriggersNewRoadSensor() throws Exception {
+        RoadSensorManager.processCpm(cpm211Json("sensor_G", 7), cpmHelper);
+
+        verify(mockCallback, times(1)).newRoadSensor(any(RoadSensor.class));
+    }
+
+    @Test
+    void processCpm211SecondMessageTriggersUpdate() throws Exception {
+        String json = cpm211Json("sensor_H", 8);
+        RoadSensorManager.processCpm(json, cpmHelper);
+        RoadSensorManager.processCpm(json, cpmHelper);
+
+        verify(mockCallback, times(1)).newRoadSensor(any());
+        verify(mockCallback, times(1)).roadSensorUpdate(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processCpmInvalidJsonDoesNotCrash() {
+        assertDoesNotThrow(() ->
+                RoadSensorManager.processCpm("{not valid json}", cpmHelper));
+    }
+
+    @Test
+    void getRoadSensorsReturnsUnmodifiableList() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> RoadSensorManager.getRoadSensors().add(null));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadSensorManagerTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.managers;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/managers/RoadUserManagerTest.java
@@ -1,0 +1,210 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.managers;
+
+import com.orange.iot3mobility.messages.cam.CamHelper;
+import com.orange.iot3mobility.messages.cam.v113.model.CamEnvelope113;
+import com.orange.iot3mobility.messages.cam.v113.model.CamMessage113;
+import com.orange.iot3mobility.messages.cam.v230.model.CamEnvelope230;
+import com.orange.iot3mobility.messages.cam.v230.model.CamStructuredData;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.Altitude;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.BasicContainer;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.ReferencePosition;
+import com.orange.iot3mobility.roadobjects.RoadUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RoadUserManagerTest {
+
+    private IoT3RoadUserCallback mockCallback;
+    private final CamHelper camHelper = new CamHelper();
+
+    @BeforeEach
+    void resetStaticState() throws Exception {
+        mockCallback = mock(IoT3RoadUserCallback.class);
+
+        // Clear static collections to avoid cross-test contamination
+        Field usersField = RoadUserManager.class.getDeclaredField("ROAD_USERS");
+        usersField.setAccessible(true);
+        ((ArrayList<?>) usersField.get(null)).clear();
+
+        Field mapField = RoadUserManager.class.getDeclaredField("ROAD_USER_MAP");
+        mapField.setAccessible(true);
+        ((HashMap<?, ?>) mapField.get(null)).clear();
+
+        RoadUserManager.init(mockCallback);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper factories
+    // -------------------------------------------------------------------------
+
+    /** Build a minimal valid v1.1.3 CAM JSON string. */
+    private String cam113Json(String sourceUuid, long stationId) throws Exception {
+        com.orange.iot3mobility.messages.cam.v113.model.BasicContainer basic =
+                com.orange.iot3mobility.messages.cam.v113.model.BasicContainer.builder()
+                        .stationType(5)
+                        .referencePosition(
+                                new com.orange.iot3mobility.messages.cam.v113.model.ReferencePosition(
+                                        488566000, 23522000, 0))
+                        .build();
+        com.orange.iot3mobility.messages.cam.v113.model.HighFrequencyContainer hf113 =
+                com.orange.iot3mobility.messages.cam.v113.model.HighFrequencyContainer.builder()
+                        .heading(900)
+                        .speed(1389)
+                        .build();
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId((int) stationId)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(hf113)
+                .build();
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid(sourceUuid)
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+        return camHelper.toJson(envelope);
+    }
+
+    /** Build a minimal valid v2.3.0 CAM JSON string (all v230 HF types fully qualified). */
+    private String cam230Json(String sourceUuid, long stationId) throws Exception {
+        ReferencePosition ref = ReferencePosition.builder()
+                .latitudeLongitude(488566000, 23522000)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(ref)
+                .build();
+        com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.BasicVehicleContainerHighFrequency hf =
+                com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.BasicVehicleContainerHighFrequency.builder()
+                        .heading(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Heading(900, 1))
+                        .speed(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Speed(1389, 1))
+                        .driveDirection(0)
+                        .vehicleLength(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.VehicleLength(45, 0))
+                        .vehicleWidth(20)
+                        .longitudinalAcceleration(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.AccelerationComponent(0, 1))
+                        .curvature(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Curvature(0, 0))
+                        .curvatureCalculationMode(0)
+                        .yawRate(new com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.YawRate(0, 0))
+                        .build();
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId((int) stationId)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(hf)
+                .build();
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid(sourceUuid)
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+        return camHelper.toJson(envelope);
+    }
+
+    // -------------------------------------------------------------------------
+    // v1.1.3 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processCam113FirstMessageTriggersNewRoadUser() throws Exception {
+        String json = cam113Json("vehicle_A", 1001);
+        RoadUserManager.processCam(json, camHelper);
+
+        verify(mockCallback, times(1)).newRoadUser(any(RoadUser.class));
+        verify(mockCallback, never()).roadUserUpdate(any());
+    }
+
+    @Test
+    void processCam113NewRoadUserHasCorrectPosition() throws Exception {
+        String json = cam113Json("vehicle_A", 1001);
+        RoadUserManager.processCam(json, camHelper);
+
+        ArgumentCaptor<RoadUser> captor = ArgumentCaptor.forClass(RoadUser.class);
+        verify(mockCallback).newRoadUser(captor.capture());
+        RoadUser user = captor.getValue();
+        assertEquals(48.8566, user.getPosition().getLatitude(), 1e-4);
+        assertEquals(2.3522, user.getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void processCam113SecondMessageTriggersRoadUserUpdate() throws Exception {
+        String json = cam113Json("vehicle_B", 2002);
+        RoadUserManager.processCam(json, camHelper);
+        RoadUserManager.processCam(json, camHelper);
+
+        verify(mockCallback, times(1)).newRoadUser(any());
+        verify(mockCallback, times(1)).roadUserUpdate(any());
+    }
+
+    @Test
+    void processCam113CamArrivedCallbackIsAlwaysFired() throws Exception {
+        String json = cam113Json("vehicle_C", 3003);
+        RoadUserManager.processCam(json, camHelper);
+        RoadUserManager.processCam(json, camHelper);
+
+        verify(mockCallback, times(2)).camArrived(any());
+    }
+
+    @Test
+    void processCam113TwoDifferentVehiclesBothCreate() throws Exception {
+        RoadUserManager.processCam(cam113Json("veh_X", 101), camHelper);
+        RoadUserManager.processCam(cam113Json("veh_Y", 102), camHelper);
+
+        verify(mockCallback, times(2)).newRoadUser(any());
+        assertEquals(2, RoadUserManager.getRoadUsers().size());
+    }
+
+    @Test
+    void processCamInvalidJsonDoesNotCrash() {
+        assertDoesNotThrow(() ->
+                RoadUserManager.processCam("{not valid json at all}", camHelper));
+    }
+
+    // -------------------------------------------------------------------------
+    // v2.3.0 tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void processCam230FirstMessageTriggersNewRoadUser() throws Exception {
+        String json = cam230Json("com_car_42", 42);
+        RoadUserManager.processCam(json, camHelper);
+
+        verify(mockCallback, times(1)).newRoadUser(any(RoadUser.class));
+    }
+
+    @Test
+    void processCam230SecondMessageTriggersRoadUserUpdate() throws Exception {
+        String json = cam230Json("com_car_43", 43);
+        RoadUserManager.processCam(json, camHelper);
+        RoadUserManager.processCam(json, camHelper);
+
+        verify(mockCallback, times(1)).newRoadUser(any());
+        verify(mockCallback, times(1)).roadUserUpdate(any());
+    }
+
+    @Test
+    void getRoadUsersReturnsUnmodifiableList() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> RoadUserManager.getRoadUsers().add(null));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/EtsiConverterTest.java
@@ -1,0 +1,516 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EtsiConverterTest {
+
+    private static final double DELTA = 1e-9;
+
+    // -------------------------------------------------------------------------
+    // Time
+    // -------------------------------------------------------------------------
+
+    @Test
+    void generationDeltaTimeEtsiWrapsAt65536() {
+        assertEquals(0, EtsiConverter.generationDeltaTimeEtsi(0L));
+        assertEquals(1000, EtsiConverter.generationDeltaTimeEtsi(1000L));
+        assertEquals(65535, EtsiConverter.generationDeltaTimeEtsi(65535L));
+        assertEquals(0, EtsiConverter.generationDeltaTimeEtsi(65536L));
+        assertEquals(4, EtsiConverter.generationDeltaTimeEtsi(65540L));
+    }
+
+    @Test
+    void unixToEtsiTimestampMsShiftsBy2004Epoch() {
+        // 2004-01-01 in UNIX ms is DELTA_1970_2004_MILLISEC; ETSI value must be 0
+        assertEquals(0L, EtsiConverter.unixToEtsiTimestampMs(EtsiConverter.DELTA_1970_2004_MILLISEC));
+        assertEquals(1000L, EtsiConverter.unixToEtsiTimestampMs(EtsiConverter.DELTA_1970_2004_MILLISEC + 1000L));
+    }
+
+    @Test
+    void epochMillisToSecondsConvertsCorrectly() {
+        assertEquals(1.0, EtsiConverter.epochMillisToSeconds(1000L), DELTA);
+        assertEquals(0.5, EtsiConverter.epochMillisToSeconds(500L), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Latitude
+    // -------------------------------------------------------------------------
+
+    @Test
+    void latitudeRoundTrip() {
+        double lat = 48.8566; // Paris
+        assertEquals(lat, EtsiConverter.latitudeDegrees(EtsiConverter.latitudeEtsi(lat)), 1e-7);
+    }
+
+    @Test
+    void latitudeEtsiEncodesCorrectly() {
+        assertEquals(488566000, EtsiConverter.latitudeEtsi(48.8566));
+        assertEquals(0, EtsiConverter.latitudeEtsi(0.0));
+        assertEquals(-900000000, EtsiConverter.latitudeEtsi(-90.0));
+        assertEquals(900000000, EtsiConverter.latitudeEtsi(90.0));
+    }
+
+    @Test
+    void latitudeEtsiClampsAboveMax() {
+        assertEquals(900000001, EtsiConverter.latitudeEtsi(91.0));
+    }
+
+    @Test
+    void latitudeEtsiClampsBelowMin() {
+        assertEquals(-900000000, EtsiConverter.latitudeEtsi(-91.0));
+    }
+
+    @Test
+    void latitudeDegreesConvertsCorrectly() {
+        assertEquals(48.8566, EtsiConverter.latitudeDegrees(488566000), DELTA);
+        assertEquals(0.0, EtsiConverter.latitudeDegrees(0), DELTA);
+        assertEquals(-90.0, EtsiConverter.latitudeDegrees(-900000000), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Longitude
+    // -------------------------------------------------------------------------
+
+    @Test
+    void longitudeRoundTrip() {
+        double lon = 2.3522; // Paris
+        assertEquals(lon, EtsiConverter.longitudeDegrees(EtsiConverter.longitudeEtsi(lon)), 1e-7);
+    }
+
+    @Test
+    void longitudeEtsiEncodesCorrectly() {
+        assertEquals(23522000, EtsiConverter.longitudeEtsi(2.3522));
+        assertEquals(0, EtsiConverter.longitudeEtsi(0.0));
+        assertEquals(-1800000000, EtsiConverter.longitudeEtsi(-180.0));
+        assertEquals(1800000000, EtsiConverter.longitudeEtsi(180.0));
+    }
+
+    @Test
+    void longitudeEtsiClampsOutOfRange() {
+        assertEquals(1800000001, EtsiConverter.longitudeEtsi(181.0));
+        assertEquals(-1800000000, EtsiConverter.longitudeEtsi(-181.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Altitude
+    // -------------------------------------------------------------------------
+
+    @Test
+    void altitudeRoundTrip() {
+        double altMeters = 150.0;
+        assertEquals(altMeters, EtsiConverter.altitudeMeters(EtsiConverter.altitudeEtsi(altMeters)), 1e-2);
+    }
+
+    @Test
+    void altitudeEtsiEncodesCorrectly() {
+        assertEquals(15000, EtsiConverter.altitudeEtsi(150.0));
+        assertEquals(0, EtsiConverter.altitudeEtsi(0.0));
+        assertEquals(800001, EtsiConverter.altitudeEtsi(8000.01));
+    }
+
+    @Test
+    void altitudeEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.altitudeEtsi(-1.0));
+        assertEquals(800001, EtsiConverter.altitudeEtsi(99999.0));
+    }
+
+    @Test
+    void altitudeMetersConvertsCorrectly() {
+        assertEquals(150.0, EtsiConverter.altitudeMeters(15000), DELTA);
+        assertEquals(0.0, EtsiConverter.altitudeMeters(0), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Speed
+    // -------------------------------------------------------------------------
+
+    @Test
+    void speedRoundTripMetersPerSecond() {
+        double mps = 13.89; // ~50 km/h
+        assertEquals(mps, EtsiConverter.speedMetersPerSecond(EtsiConverter.speedEtsiFromMetersPerSecond(mps)), 1e-2);
+    }
+
+    @Test
+    void speedEtsiFromMetersPerSecondEncodesCorrectly() {
+        assertEquals(0, EtsiConverter.speedEtsiFromMetersPerSecond(0.0));
+        assertEquals(1389, EtsiConverter.speedEtsiFromMetersPerSecond(13.89));
+        assertEquals(16383, EtsiConverter.speedEtsiFromMetersPerSecond(163.83));
+    }
+
+    @Test
+    void speedEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.speedEtsiFromMetersPerSecond(-1.0));
+        assertEquals(16383, EtsiConverter.speedEtsiFromMetersPerSecond(999.0));
+    }
+
+    @Test
+    void speedKilometersPerHourConvertsCorrectly() {
+        // 0 m/s -> 0 km/h
+        assertEquals(0.0, EtsiConverter.speedKilometersPerHour(0), DELTA);
+        // 100 ETSI = 1 m/s = 3.6 km/h
+        assertEquals(3.6, EtsiConverter.speedKilometersPerHour(100), 1e-9);
+    }
+
+    @Test
+    void speedRoundTripKilometersPerHour() {
+        double kmh = 90.0;
+        int etsi = EtsiConverter.speedEtsiFromKilometersPerHour(kmh);
+        assertEquals(kmh, EtsiConverter.speedKilometersPerHour(etsi), 0.05); // ~0.05 km/h tolerance
+    }
+
+    @Test
+    void metersPerSecondToKilometersPerHourAndBack() {
+        double mps = 10.0;
+        double kmh = EtsiConverter.metersPerSecondToKilometersPerHour(mps);
+        assertEquals(36.0, kmh, DELTA);
+        assertEquals(mps, EtsiConverter.kilometersPerHourToMetersPerSecond(kmh), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // Heading
+    // -------------------------------------------------------------------------
+
+    @Test
+    void headingRoundTripDegrees() {
+        double deg = 90.0;
+        assertEquals(deg, EtsiConverter.headingDegrees(EtsiConverter.headingEtsiFromDegrees(deg)), 1e-1);
+    }
+
+    @Test
+    void headingEtsiFromDegreesEncodesCorrectly() {
+        assertEquals(0, EtsiConverter.headingEtsiFromDegrees(0.0));
+        assertEquals(900, EtsiConverter.headingEtsiFromDegrees(90.0));
+        assertEquals(1800, EtsiConverter.headingEtsiFromDegrees(180.0));
+        assertEquals(2700, EtsiConverter.headingEtsiFromDegrees(270.0));
+    }
+
+    @Test
+    void headingNormalizesNegativeAngles() {
+        // -90° normalizes to 270°
+        assertEquals(2700, EtsiConverter.headingEtsiFromDegrees(-90.0));
+    }
+
+    @Test
+    void headingNormalizesOver360() {
+        // 360° normalizes to 0°
+        assertEquals(0, EtsiConverter.headingEtsiFromDegrees(360.0));
+        // 450° normalizes to 90°
+        assertEquals(900, EtsiConverter.headingEtsiFromDegrees(450.0));
+    }
+
+    @Test
+    void headingNaNReturnsUnavailableSentinel() {
+        assertEquals(3601, EtsiConverter.headingEtsiFromDegrees(Double.NaN));
+        assertEquals(3601, EtsiConverter.headingEtsiFromRadians(Double.NaN));
+    }
+
+    @Test
+    void headingDegreesReturnsSentinelAsNaN() {
+        assertTrue(Double.isNaN(EtsiConverter.headingDegrees(3600)));
+        assertTrue(Double.isNaN(EtsiConverter.headingDegrees(3601)));
+    }
+
+    @Test
+    void headingDegreesConvertsNormalValues() {
+        assertEquals(90.0, EtsiConverter.headingDegrees(900), DELTA);
+        assertEquals(0.0, EtsiConverter.headingDegrees(0), DELTA);
+    }
+
+    @Test
+    void headingRadiansRoundTrip() {
+        double rad = Math.PI / 2; // 90°
+        assertEquals(rad, EtsiConverter.headingRadians(EtsiConverter.headingEtsiFromRadians(rad)), 1e-3);
+    }
+
+    @Test
+    void headingRadiansReturnNaNForSentinel() {
+        assertTrue(Double.isNaN(EtsiConverter.headingRadians(3600)));
+    }
+
+    // -------------------------------------------------------------------------
+    // Vehicle dimensions
+    // -------------------------------------------------------------------------
+
+    @Test
+    void vehicleLengthRoundTrip() {
+        double meters = 4.5;
+        assertEquals(meters, EtsiConverter.vehicleLengthMeters(EtsiConverter.vehicleLengthEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void vehicleLengthEtsiEncodesCorrectly() {
+        assertEquals(45, EtsiConverter.vehicleLengthEtsi(4.5));
+        assertEquals(0, EtsiConverter.vehicleLengthEtsi(0.0));
+        assertEquals(1023, EtsiConverter.vehicleLengthEtsi(102.3));
+    }
+
+    @Test
+    void vehicleLengthEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.vehicleLengthEtsi(-1.0));
+        assertEquals(1023, EtsiConverter.vehicleLengthEtsi(999.0));
+    }
+
+    @Test
+    void vehicleWidthRoundTrip() {
+        double meters = 2.0;
+        assertEquals(meters, EtsiConverter.vehicleWidthMeters(EtsiConverter.vehicleWidthEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void vehicleWidthEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.vehicleWidthEtsi(-1.0));
+        assertEquals(62, EtsiConverter.vehicleWidthEtsi(999.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Acceleration
+    // -------------------------------------------------------------------------
+
+    @Test
+    void accelerationRoundTrip() {
+        double mps2 = 3.5;
+        assertEquals(mps2, EtsiConverter.accelerationMetersPerSecondSquared(EtsiConverter.accelerationEtsi(mps2)), 1e-1);
+    }
+
+    @Test
+    void accelerationEtsiEncodesCorrectly() {
+        assertEquals(0, EtsiConverter.accelerationEtsi(0.0));
+        assertEquals(35, EtsiConverter.accelerationEtsi(3.5));
+        assertEquals(-35, EtsiConverter.accelerationEtsi(-3.5));
+    }
+
+    @Test
+    void accelerationEtsiClampsOutOfRange() {
+        assertEquals(161, EtsiConverter.accelerationEtsi(99.0));
+        assertEquals(-160, EtsiConverter.accelerationEtsi(-99.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Curvature
+    // -------------------------------------------------------------------------
+
+    @Test
+    void curvatureRoundTrip() {
+        double perMeter = 0.01;
+        assertEquals(perMeter, EtsiConverter.curvaturePerMeter(EtsiConverter.curvatureEtsi(perMeter)), 1e-5);
+    }
+
+    @Test
+    void curvatureEtsiClampsOutOfRange() {
+        assertEquals(1023, EtsiConverter.curvatureEtsi(99.0));
+        assertEquals(-1023, EtsiConverter.curvatureEtsi(-99.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Yaw rate
+    // -------------------------------------------------------------------------
+
+    @Test
+    void yawRateRoundTripDegPerSec() {
+        double degPerSec = 5.0;
+        int etsi = EtsiConverter.yawRateEtsiFromDegreesPerSecond(degPerSec);
+        assertEquals(degPerSec, Math.toDegrees(EtsiConverter.yawRateRadiansPerSecond(etsi)), 1e-2);
+    }
+
+    @Test
+    void yawRateEtsiClampsOutOfRange() {
+        assertEquals(32767, EtsiConverter.yawRateEtsiFromDegreesPerSecond(99999.0));
+        assertEquals(-32766, EtsiConverter.yawRateEtsiFromDegreesPerSecond(-99999.0));
+    }
+
+    @Test
+    void yawRateRoundTripRadiansPerSec() {
+        double radPerSec = 0.1;
+        int etsi = EtsiConverter.yawRateEtsiFromRadiansPerSecond(radPerSec);
+        assertEquals(radPerSec, EtsiConverter.yawRateRadiansPerSecond(etsi), 1e-3);
+    }
+
+    // -------------------------------------------------------------------------
+    // Delta positions
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deltaPositionRoundTrip() {
+        double meters = 50.0;
+        assertEquals(meters, EtsiConverter.deltaPositionMeters(EtsiConverter.deltaPositionEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void deltaPositionEtsiClampsOutOfRange() {
+        assertEquals(131072, EtsiConverter.deltaPositionEtsi(99999.0));
+        assertEquals(-131071, EtsiConverter.deltaPositionEtsi(-99999.0));
+    }
+
+    @Test
+    void deltaAltitudeRoundTrip() {
+        double meters = 10.0;
+        assertEquals(meters, EtsiConverter.deltaAltitudeMeters(EtsiConverter.deltaAltitudeEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void deltaAltitudeEtsiClampsOutOfRange() {
+        assertEquals(12800, EtsiConverter.deltaAltitudeEtsi(99999.0));
+        assertEquals(-12700, EtsiConverter.deltaAltitudeEtsi(-99999.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Generic helpers
+    // -------------------------------------------------------------------------
+
+    @Test
+    void degreesToRadiansAndBack() {
+        assertEquals(Math.PI / 2, EtsiConverter.degreesToRadians(90.0), DELTA);
+        assertEquals(90.0, EtsiConverter.radiansToDegrees(Math.PI / 2), DELTA);
+    }
+
+    // -------------------------------------------------------------------------
+    // CPM-specific helpers
+    // -------------------------------------------------------------------------
+
+    @Test
+    void cpmDistanceRoundTrip() {
+        double meters = 25.5;
+        assertEquals(meters, EtsiConverter.cpmDistanceMeters(EtsiConverter.cpmDistanceEtsi(meters)), 1e-2);
+    }
+
+    @Test
+    void cpmDistanceEtsiClampsOutOfRange() {
+        assertEquals(132767, EtsiConverter.cpmDistanceEtsi(99999.0));
+        assertEquals(-132768, EtsiConverter.cpmDistanceEtsi(-99999.0));
+    }
+
+    @Test
+    void cpmSpeedRoundTrip() {
+        double mps = 5.0;
+        assertEquals(mps, EtsiConverter.cpmSpeedMetersPerSecond(EtsiConverter.cpmSpeedEtsiFromMetersPerSecond(mps)), 1e-2);
+    }
+
+    @Test
+    void cpmSpeedEtsiClampsOutOfRange() {
+        assertEquals(16383, EtsiConverter.cpmSpeedEtsiFromMetersPerSecond(999.0));
+        assertEquals(-16383, EtsiConverter.cpmSpeedEtsiFromMetersPerSecond(-999.0));
+    }
+
+    @Test
+    void cpmDerivedSpeedFromComponents() {
+        // xSpeed=300, ySpeed=400 → speed=5 m/s (3-4-5 triangle)
+        assertEquals(5.0, EtsiConverter.cpmDerivedSpeedMetersPerSecond(300, 400), 1e-9);
+    }
+
+    @Test
+    void cpmDerivedHeadingFromComponents() {
+        // xSpeed=100, ySpeed=0 → East → 90°
+        assertEquals(90.0, EtsiConverter.cpmDerivedHeadingDegrees(100, 0), 1e-9);
+        // xSpeed=0, ySpeed=100 → North → 0° (or 360°)
+        double heading = EtsiConverter.cpmDerivedHeadingDegrees(0, 100);
+        // heading = (90 - 90) % 360 = 0
+        assertEquals(0.0, heading % 360, 1e-9);
+    }
+
+    @Test
+    void cpmAngleRoundTrip() {
+        double deg = 45.0;
+        assertEquals(deg, EtsiConverter.cpmAngleDegrees(EtsiConverter.cpmAngleEtsiFromDegrees(deg)), 1e-1);
+    }
+
+    @Test
+    void cpmAngleSentinelHandling() {
+        assertEquals(3601, EtsiConverter.cpmAngleEtsiFromDegrees(Double.NaN));
+        assertTrue(Double.isNaN(EtsiConverter.cpmAngleDegrees(3601)));
+    }
+
+    @Test
+    void cpmAngularRateRoundTrip() {
+        double degPerSec = 2.5;
+        int etsi = EtsiConverter.cpmAngularRateEtsiFromDegreesPerSecond(degPerSec);
+        assertEquals(degPerSec, EtsiConverter.cpmAngularRateDegreesPerSecond(etsi), 1e-2);
+    }
+
+    @Test
+    void cpmAngularRateRadiansRoundTrip() {
+        double radPerSec = 0.05;
+        int etsi = EtsiConverter.cpmAngularRateEtsiFromRadiansPerSecond(radPerSec);
+        assertEquals(radPerSec, EtsiConverter.cpmAngularRateRadiansPerSecond(etsi), 1e-3);
+    }
+
+    @Test
+    void cpmAngularAccelerationRoundTrip() {
+        double degPerSec2 = 1.0;
+        int etsi = EtsiConverter.cpmAngularAccelerationEtsiFromDegreesPerSecondSquared(degPerSec2);
+        assertEquals(degPerSec2, EtsiConverter.cpmAngularAccelerationDegreesPerSecondSquared(etsi), 1e-2);
+    }
+
+    @Test
+    void cpmObjectDimensionRoundTrip() {
+        double meters = 3.0;
+        assertEquals(meters, EtsiConverter.cpmObjectDimensionMeters(EtsiConverter.cpmObjectDimensionEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void cpmObjectDimensionEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.cpmObjectDimensionEtsi(-1.0));
+        assertEquals(1023, EtsiConverter.cpmObjectDimensionEtsi(9999.0));
+    }
+
+    @Test
+    void cpmLanePositionRoundTrip() {
+        double meters = 2.5;
+        assertEquals(meters, EtsiConverter.cpmLanePositionMeters(EtsiConverter.cpmLanePositionEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void cpmOffsetRoundTrip() {
+        double meters = -15.0;
+        assertEquals(meters, EtsiConverter.cpmOffsetMeters(EtsiConverter.cpmOffsetEtsi(meters)), 1e-2);
+    }
+
+    @Test
+    void cpmOffsetEtsiClampsOutOfRange() {
+        assertEquals(32767, EtsiConverter.cpmOffsetEtsi(99999.0));
+        assertEquals(-32768, EtsiConverter.cpmOffsetEtsi(-99999.0));
+    }
+
+    @Test
+    void cpmRangeRoundTrip() {
+        double meters = 500.0;
+        assertEquals(meters, EtsiConverter.cpmRangeMeters(EtsiConverter.cpmRangeEtsi(meters)), 1e-1);
+    }
+
+    @Test
+    void cpmRangeEtsiClampsOutOfRange() {
+        assertEquals(0, EtsiConverter.cpmRangeEtsi(-1.0));
+        assertEquals(10000, EtsiConverter.cpmRangeEtsi(99999.0));
+    }
+
+    @Test
+    void cpmOpeningAngleRoundTrip() {
+        double deg = 120.0;
+        assertEquals(deg, EtsiConverter.cpmOpeningAngleDegrees(EtsiConverter.cpmOpeningAngleEtsiFromDegrees(deg)), 1e-1);
+    }
+
+    @Test
+    void cpmOpeningAngleSentinelHandling() {
+        assertEquals(3601, EtsiConverter.cpmOpeningAngleEtsiFromDegrees(Double.NaN));
+        assertTrue(Double.isNaN(EtsiConverter.cpmOpeningAngleDegrees(3601)));
+    }
+
+    @Test
+    void cpmCorrelationRoundTrip() {
+        double coeff = 0.75;
+        assertEquals(coeff, EtsiConverter.cpmCorrelationCoefficient(EtsiConverter.cpmCorrelationEtsiFromCoefficient(coeff)), 1e-2);
+    }
+
+    @Test
+    void cpmCorrelationEtsiClampsOutOfRange() {
+        assertEquals(100, EtsiConverter.cpmCorrelationEtsiFromCoefficient(2.0));
+        assertEquals(-100, EtsiConverter.cpmCorrelationEtsiFromCoefficient(-2.0));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StationTypeTest {
+
+    @Test
+    void fromValueReturnsCorrectEnumForKnownValues() {
+        assertEquals(StationType.UNKNOWN, StationType.fromValue(0));
+        assertEquals(StationType.PEDESTRIAN, StationType.fromValue(1));
+        assertEquals(StationType.CYCLIST, StationType.fromValue(2));
+        assertEquals(StationType.MOPED, StationType.fromValue(3));
+        assertEquals(StationType.MOTORCYCLE, StationType.fromValue(4));
+        assertEquals(StationType.PASSENGER_CAR, StationType.fromValue(5));
+        assertEquals(StationType.BUS, StationType.fromValue(6));
+        assertEquals(StationType.LIGHT_TRUCK, StationType.fromValue(7));
+        assertEquals(StationType.HEAVY_TRUCK, StationType.fromValue(8));
+        assertEquals(StationType.TRAILER, StationType.fromValue(9));
+        assertEquals(StationType.SPECIAL_VEHICLES, StationType.fromValue(10));
+        assertEquals(StationType.TRAM, StationType.fromValue(11));
+        assertEquals(StationType.ROAD_SIDE_UNIT, StationType.fromValue(15));
+    }
+
+    @Test
+    void fromValueReturnsUnknownForUnrecognizedValue() {
+        assertEquals(StationType.UNKNOWN, StationType.fromValue(99));
+        assertEquals(StationType.UNKNOWN, StationType.fromValue(-1));
+        assertEquals(StationType.UNKNOWN, StationType.fromValue(255));
+    }
+
+    @Test
+    void intValueMatchesEtsiStandardCodes() {
+        assertEquals(0, StationType.UNKNOWN.value);
+        assertEquals(5, StationType.PASSENGER_CAR.value);
+        assertEquals(15, StationType.ROAD_SIDE_UNIT.value);
+    }
+
+    @Test
+    void fromValueRoundTrip() {
+        for (StationType type : StationType.values()) {
+            assertEquals(type, StationType.fromValue(type.value));
+        }
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/StationTypeTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cam;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
@@ -1,0 +1,139 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cam;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.orange.iot3mobility.messages.cam.core.CamCodec;
+import com.orange.iot3mobility.messages.cam.core.CamException;
+import com.orange.iot3mobility.messages.cam.core.CamVersion;
+import com.orange.iot3mobility.messages.cam.v113.model.CamEnvelope113;
+import com.orange.iot3mobility.messages.cam.v113.model.CamMessage113;
+import com.orange.iot3mobility.messages.cam.v113.model.HighFrequencyContainer;
+import com.orange.iot3mobility.messages.cam.v113.model.ReferencePosition;
+import com.orange.iot3mobility.messages.cam.v230.model.CamEnvelope230;
+import com.orange.iot3mobility.messages.cam.v230.model.CamStructuredData;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.Altitude;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.BasicContainer;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.AccelerationComponent;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.BasicVehicleContainerHighFrequency;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Curvature;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Heading;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.Speed;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.VehicleLength;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.YawRate;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CamCodecTest {
+
+    @Test
+    void writeRead113RoundTrip() throws Exception {
+        CamEnvelope113 envelope = validEnvelope113();
+        CamCodec codec = new CamCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V1_1_3, envelope, out);
+
+        CamCodec.CamFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(CamVersion.V1_1_3, frame.version());
+        assertTrue(frame.envelope() instanceof CamEnvelope113);
+        CamEnvelope113 parsed = (CamEnvelope113) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void writeRead230RoundTrip() throws Exception {
+        CamEnvelope230 envelope = validEnvelope230();
+        CamCodec codec = new CamCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V2_3_0, envelope, out);
+
+        CamCodec.CamFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(CamVersion.V2_3_0, frame.version());
+        assertTrue(frame.envelope() instanceof CamEnvelope230);
+        CamEnvelope230 parsed = (CamEnvelope230) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void readRejectsMissingVersion() {
+        CamCodec codec = new CamCodec(new JsonFactory());
+        String json = "{\"type\":\"cam\"}";
+        assertThrows(CamException.class, () -> codec.read(json));
+    }
+
+    private static CamEnvelope113 validEnvelope113() {
+        com.orange.iot3mobility.messages.cam.v113.model.BasicContainer basic =
+                com.orange.iot3mobility.messages.cam.v113.model.BasicContainer.builder()
+                 .stationType(5)
+                 .referencePosition(new ReferencePosition(0, 0, 0))
+                 .build();
+        HighFrequencyContainer high = HighFrequencyContainer.builder().build();
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+
+        return CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CamEnvelope230 validEnvelope230() {
+        com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.ReferencePosition reference =
+                com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.ReferencePosition.builder()
+                          .latitudeLongitude(0, 0)
+                          .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                          .altitude(new Altitude(0, 0))
+                          .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                         .stationType(5)
+                         .referencePosition(reference)
+                         .build();
+
+        BasicVehicleContainerHighFrequency high = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+
+        return CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cam;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
@@ -66,6 +66,176 @@ class CamValidator113Test {
         assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
     }
 
+    @Test
+    void validateHighFrequencyRejectsInvalidAccelerationControl() {
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder()
+                        .accelerationControl("1010102")
+                        .build())
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateLowFrequencyRejectsInvalidExteriorLights() {
+        LowFrequencyContainer low = LowFrequencyContainer.builder()
+                .vehicleRole(0)
+                .exteriorLights("0101012")
+                .pathHistory(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1)))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateHighFrequencyRejectsHeadingOutOfRange() {
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder()
+                        .heading(4000)
+                        .build())
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateLowFrequencyRejectsPathDeltaTimeOutOfRange() {
+        LowFrequencyContainer low = LowFrequencyContainer.builder()
+                .vehicleRole(0)
+                .exteriorLights("00000000")
+                .pathHistory(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 0)))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateBasicContainerRejectsLatitudeOutOfRange() {
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(900000002, 0, 0))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateBasicContainerRejectsAltitudeOutOfRange() {
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 0, -100001))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateHighFrequencyRejectsSpeedOutOfRange() {
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder()
+                        .speed(20000)
+                        .build())
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
     private static CamEnvelope113 validEnvelope() {
         return CamEnvelope113.builder()
                 .origin("self")
@@ -92,4 +262,3 @@ class CamValidator113Test {
                 .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cam.v113.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cam.v113.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
@@ -22,6 +22,59 @@ class CamValidator113Test {
     }
 
     @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 0, 0))
+                .positionConfidence(new PositionConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+
+        HighFrequencyContainer hf = HighFrequencyContainer.builder()
+                .heading(0)
+                .speed(0)
+                .driveDirection(0)
+                .vehicleSize(10, 10)
+                .curvature(0)
+                .curvatureCalculationMode(0)
+                .longitudinalAcceleration(0)
+                .yawRate(0)
+                .accelerationControl("0000000")
+                .lanePosition(0)
+                .lateralAcceleration(0)
+                .verticalAcceleration(0)
+                .highFrequencyConfidence(HighFrequencyConfidence.builder()
+                        .heading(1).speed(1).vehicleLength(0).yawRate(0)
+                        .longitudinalAcceleration(0).curvature(0)
+                        .lateralAcceleration(0).verticalAcceleration(0)
+                        .build())
+                .build();
+
+        LowFrequencyContainer lf = LowFrequencyContainer.builder()
+                .vehicleRole(0)
+                .exteriorLights("00000000")
+                .pathHistory(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1)))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(hf)
+                .lowFrequencyContainer(lf)
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CamValidator113.validateEnvelope(envelope);
+    }
+
+    @Test
     void validateEnvelopeRejectsInvalidOrigin() {
         CamEnvelope113 envelope = new CamEnvelope113(
                 "cam",

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/validation/CamValidator113Test.java
@@ -1,0 +1,95 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cam.v113.validation;
+
+import com.orange.iot3mobility.messages.cam.v113.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CamValidator113Test {
+
+    @Test
+    void validateEnvelopeAcceptsMinimalValid() {
+        CamEnvelope113 envelope = validEnvelope();
+        CamValidator113.validateEnvelope(envelope);
+    }
+
+    @Test
+    void validateEnvelopeRejectsInvalidOrigin() {
+        CamEnvelope113 envelope = new CamEnvelope113(
+                "cam",
+                "invalid_origin",
+                "1.1.3",
+                "CCU6",
+                1514764800000L,
+                validMessage());
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateLowFrequencyRejectsTooManyPathPoints() {
+        List<PathPoint> points = new ArrayList<>();
+        for (int i = 0; i < 41; i++) {
+            points.add(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1));
+        }
+
+        LowFrequencyContainer low = LowFrequencyContainer.builder()
+                .vehicleRole(0)
+                .exteriorLights("00000000")
+                .pathHistory(points)
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope113 envelope = CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator113.validateEnvelope(envelope));
+    }
+
+    private static CamEnvelope113 validEnvelope() {
+        return CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(validMessage())
+                .build();
+    }
+
+    private static CamMessage113 validMessage() {
+        return CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasic())
+                .highFrequencyContainer(HighFrequencyContainer.builder().build())
+                .build();
+    }
+
+    private static BasicContainer validBasic() {
+        return BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 0, 0))
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
@@ -30,6 +30,33 @@ class CamValidator230Test {
     }
 
     @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        LowFrequencyContainer low = new LowFrequencyContainer(
+                new BasicVehicleContainerLowFrequency(
+                        0,
+                        new ExteriorLights(true, false, false, false, false, false, false, false),
+                        List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1))));
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CamValidator230.validateEnvelope(envelope);
+    }
+
+    @Test
     void validateEnvelopeRejectsMessageFormatMismatch() {
         CamEnvelope230 envelope = CamEnvelope230.builder()
                 .messageFormat("asn1/uper")

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
@@ -1,0 +1,81 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cam.v230.validation;
+
+import com.orange.iot3mobility.messages.cam.v230.model.CamEnvelope230;
+import com.orange.iot3mobility.messages.cam.v230.model.CamStructuredData;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.Altitude;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.BasicContainer;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CamValidator230Test {
+
+    @Test
+    void validateEnvelopeAcceptsStructuredPayload() {
+        CamEnvelope230 envelope = validEnvelope();
+        CamValidator230.validateEnvelope(envelope);
+    }
+
+    @Test
+    void validateEnvelopeRejectsMessageFormatMismatch() {
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("asn1/uper")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(validStructuredMessage())
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    private static CamEnvelope230 validEnvelope() {
+        return CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(validStructuredMessage())
+                .build();
+    }
+
+    private static CamStructuredData validStructuredMessage() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+
+        BasicVehicleContainerHighFrequency high = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+
+        return CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cam.v230.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
@@ -5,6 +5,7 @@
  */
 package com.orange.iot3mobility.messages.cam.v230.validation;
 
+import com.orange.iot3mobility.messages.cam.v230.model.CamAsn1Payload;
 import com.orange.iot3mobility.messages.cam.v230.model.CamEnvelope230;
 import com.orange.iot3mobility.messages.cam.v230.model.CamStructuredData;
 import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.Altitude;
@@ -12,7 +13,11 @@ import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.BasicConta
 import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.cam.v230.model.basiccontainer.ReferencePosition;
 import com.orange.iot3mobility.messages.cam.v230.model.highfrequencycontainer.*;
+import com.orange.iot3mobility.messages.cam.v230.model.lowfrequencycontainer.*;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,18 +41,141 @@ class CamValidator230Test {
         assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
     }
 
-    private static CamEnvelope230 validEnvelope() {
-        return CamEnvelope230.builder()
+    @Test
+    void validateEnvelopeRejectsAsn1InvalidBase64() {
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("asn1/uper")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(new CamAsn1Payload("1", "not_base64"))
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateEnvelopeRejectsEmptyRsuZones() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+
+        RsuContainerHighFrequency rsu = new RsuContainerHighFrequency(List.of());
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(rsu)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
                 .messageFormat("json/raw")
                 .sourceUuid("com_car_42")
                 .timestamp(1514764800000L)
-                .message(validStructuredMessage())
+                .message(message)
                 .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
     }
 
-    private static CamStructuredData validStructuredMessage() {
+    @Test
+    void validateEnvelopeRejectsReferenceAltitudeOutOfRange() {
         ReferencePosition reference = ReferencePosition.builder()
                 .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(-100001, 0))
+                .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+
+        BasicVehicleContainerHighFrequency high = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateEnvelopeRejectsHeadingOutOfRange() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+
+        BasicVehicleContainerHighFrequency high = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(4000, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateEnvelopeRejectsReferenceLatitudeOutOfRange() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(900000002, 0)
                 .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
                 .altitude(new Altitude(0, 0))
                 .build();
@@ -69,13 +197,168 @@ class CamValidator230Test {
                 .yawRate(new YawRate(0, 0))
                 .build();
 
-        return CamStructuredData.builder()
+        CamStructuredData message = CamStructuredData.builder()
                 .protocolVersion(1)
                 .stationId(42)
                 .generationDeltaTime(1)
                 .basicContainer(basic)
                 .highFrequencyContainer(high)
                 .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateEnvelopeRejectsSpeedOutOfRange() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+
+        BasicVehicleContainerHighFrequency high = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(20000, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateLowFrequencyRejectsTooManyPathPoints() {
+        List<PathPoint> points = new ArrayList<>();
+        for (int i = 0; i < 41; i++) {
+            points.add(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1));
+        }
+
+        LowFrequencyContainer low = new LowFrequencyContainer(
+                new BasicVehicleContainerLowFrequency(
+                        0,
+                        new ExteriorLights(false, false, false, false, false, false, false, false),
+                        points));
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateLowFrequencyRejectsPathDeltaTimeOutOfRange() {
+        LowFrequencyContainer low = new LowFrequencyContainer(
+                new BasicVehicleContainerLowFrequency(
+                        0,
+                        new ExteriorLights(false, false, false, false, false, false, false, false),
+                        List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 0))));
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope230 envelope = CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CamValidationException.class, () -> CamValidator230.validateEnvelope(envelope));
+    }
+
+    private static CamEnvelope230 validEnvelope() {
+        return CamEnvelope230.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(validStructuredMessage())
+                .build();
+    }
+
+    private static CamStructuredData validStructuredMessage() {
+        return CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .build();
+    }
+
+    private static BasicContainer validBasicContainer() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        return BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+    }
+
+    private static BasicVehicleContainerHighFrequency validHighFrequencyContainer() {
+        return BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v230/validation/CamValidator230Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cam.v230.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
@@ -1,0 +1,122 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cpm;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.orange.iot3mobility.messages.cpm.core.CpmCodec;
+import com.orange.iot3mobility.messages.cpm.core.CpmException;
+import com.orange.iot3mobility.messages.cpm.core.CpmVersion;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmEnvelope121;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmMessage121;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmEnvelope211;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmMessage211;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CpmCodecTest {
+
+    @Test
+    void writeRead121RoundTrip() throws Exception {
+        CpmEnvelope121 envelope = validEnvelope121();
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V1_2_1, envelope, out);
+
+        CpmCodec.CpmFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(CpmVersion.V1_2_1, frame.version());
+        assertTrue(frame.envelope() instanceof CpmEnvelope121);
+        CpmEnvelope121 parsed = (CpmEnvelope121) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void writeRead211RoundTrip() throws Exception {
+        CpmEnvelope211 envelope = validEnvelope211();
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V2_1_1, envelope, out);
+
+        CpmCodec.CpmFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(CpmVersion.V2_1_1, frame.version());
+        assertTrue(frame.envelope() instanceof CpmEnvelope211);
+        CpmEnvelope211 parsed = (CpmEnvelope211) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void readRejectsMissingVersion() {
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+        String json = "{\"type\":\"cpm\"}";
+        assertThrows(CpmException.class, () -> codec.read(json));
+    }
+
+    private static CpmEnvelope121 validEnvelope121() {
+        ReferencePosition referencePosition = new ReferencePosition(0, 0, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(referencePosition)
+                .confidence(confidence)
+                .build();
+
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+
+        return CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CpmEnvelope211 validEnvelope211() {
+        com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse ellipse =
+                new com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse(0, 0, 0);
+        Altitude altitude = new Altitude(0, 0);
+        com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition reference =
+                com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition.builder()
+                        .latitudeLongitude(0, 0)
+                        .positionConfidenceEllipse(ellipse)
+                        .altitude(altitude)
+                        .build();
+        com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer management =
+                com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer.builder()
+                        .referenceTime(0)
+                        .referencePosition(reference)
+                        .build();
+
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        return CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cpm;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/CpmCodecTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cpm;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
@@ -11,6 +11,10 @@ import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.Manag
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.OriginatingRsuContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.OriginatingVehicleContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.StationDataContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.VehicleConfidence;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,6 +38,112 @@ class CpmValidator121Test {
         assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
     }
 
+    @Test
+    void validateStationDataContainerRejectsBothPresent() {
+        VehicleConfidence confidence = VehicleConfidence.builder()
+                .heading(1)
+                .speed(1)
+                .build();
+        OriginatingVehicleContainer vehicle = OriginatingVehicleContainer.builder()
+                .heading(0)
+                .speed(0)
+                .confidence(confidence)
+                .build();
+        OriginatingRsuContainer rsu = new OriginatingRsuContainer(1, 2, 3);
+        StationDataContainer stationData = StationDataContainer.builder()
+                .originatingVehicleContainer(vehicle)
+                .originatingRsuContainer(rsu)
+                .build();
+
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(validManagement())
+                .stationDataContainer(stationData)
+                .build();
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsStationTypeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(300)
+                .referencePosition(new ReferencePosition(0, 0, 0))
+                .confidence(new ManagementConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsReferenceLongitudeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 1800000002, 0))
+                .confidence(new ManagementConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsReferenceLatitudeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(900000002, 0, 0))
+                .confidence(new ManagementConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
+    }
+
     private static CpmEnvelope121 validEnvelope() {
         return CpmEnvelope121.builder()
                 .origin("self")
@@ -44,21 +154,22 @@ class CpmValidator121Test {
     }
 
     private static CpmMessage121 validMessage() {
-        ReferencePosition reference = new ReferencePosition(0, 0, 0);
-        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
-        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
-        ManagementContainer management = ManagementContainer.builder()
-                .stationType(5)
-                .referencePosition(reference)
-                .confidence(confidence)
-                .build();
-
         return CpmMessage121.builder()
                 .protocolVersion(1)
                 .stationId(42)
                 .generationDeltaTime(1)
-                .managementContainer(management)
+                .managementContainer(validManagement())
+                .build();
+    }
+
+    private static ManagementContainer validManagement() {
+        ReferencePosition reference = new ReferencePosition(0, 0, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        return ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .confidence(confidence)
                 .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cpm.v121.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
@@ -11,11 +11,16 @@ import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.Manag
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObject;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.OriginatingRsuContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.OriginatingVehicleContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.StationDataContainer;
 import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.VehicleConfidence;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -24,6 +29,58 @@ class CpmValidator121Test {
     @Test
     void validateEnvelopeAcceptsMinimalValid() {
         CpmValidator121.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        VehicleConfidence vehicleConf = VehicleConfidence.builder()
+                .heading(1).speed(1).build();
+        OriginatingVehicleContainer vehicle = OriginatingVehicleContainer.builder()
+                .heading(0)
+                .speed(0)
+                .confidence(vehicleConf)
+                .driveDirection(0)
+                .vehicleLength(10)
+                .vehicleWidth(10)
+                .longitudinalAcceleration(0)
+                .yawRate(0)
+                .build();
+        StationDataContainer stationData = StationDataContainer.builder()
+                .originatingVehicleContainer(vehicle)
+                .build();
+
+        PerceivedObjectConfidence objConf = PerceivedObjectConfidence.builder()
+                .distance(1, 1)
+                .speed(0, 0)
+                .object(0)
+                .build();
+        PerceivedObject obj = PerceivedObject.builder()
+                .objectId(0)
+                .timeOfMeasurement(0)
+                .distance(0, 0)
+                .speed(0, 0)
+                .objectAge(0)
+                .confidence(objConf)
+                .build();
+        PerceivedObjectContainer perceivedObjects = new PerceivedObjectContainer(List.of(obj));
+
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(validManagement())
+                .stationDataContainer(stationData)
+                .perceivedObjectContainer(perceivedObjects)
+                .build();
+
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CpmValidator121.validateEnvelope(envelope);
     }
 
     @Test

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cpm.v121.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/validation/CpmValidator121Test.java
@@ -1,0 +1,64 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cpm.v121.validation;
+
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmEnvelope121;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmMessage121;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CpmValidator121Test {
+
+    @Test
+    void validateEnvelopeAcceptsMinimalValid() {
+        CpmValidator121.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeRejectsTimestampOutOfRange() {
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1L)
+                .message(validMessage())
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator121.validateEnvelope(envelope));
+    }
+
+    private static CpmEnvelope121 validEnvelope() {
+        return CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(validMessage())
+                .build();
+    }
+
+    private static CpmMessage121 validMessage() {
+        ReferencePosition reference = new ReferencePosition(0, 0, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .confidence(confidence)
+                .build();
+
+        return CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.cpm.v211.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.cpm.v211.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
@@ -8,9 +8,20 @@ package com.orange.iot3mobility.messages.cpm.v211.validation;
 import com.orange.iot3mobility.messages.cpm.v211.model.CpmEnvelope211;
 import com.orange.iot3mobility.messages.cpm.v211.model.CpmMessage211;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Angle;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianCoordinateWithConfidence;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianPosition3dWithConfidence;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Speed;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.VelocityComponent;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.CartesianVelocity;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObject;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObjectContainer;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PolarVelocity;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.Velocity;
 import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.SegmentationInfo;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,6 +31,17 @@ class CpmValidator211Test {
     @Test
     void validateEnvelopeAcceptsMinimalValid() {
         CpmValidator211.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeRejectsTimestampOutOfRange() {
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1L)
+                .message(validMessage())
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
     }
 
     @Test
@@ -34,6 +56,133 @@ class CpmValidator211Test {
         assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
     }
 
+    @Test
+    void validatePerceivedObjectRejectsVelocityWithBothOptions() {
+        CartesianPosition3dWithConfidence position = new CartesianPosition3dWithConfidence(
+                new CartesianCoordinateWithConfidence(0, 1),
+                new CartesianCoordinateWithConfidence(0, 1),
+                null);
+        PolarVelocity polar = new PolarVelocity(new Speed(0, 1), new Angle(0, 1), new VelocityComponent(0, 1));
+        CartesianVelocity cartesian = new CartesianVelocity(
+                new VelocityComponent(0, 1),
+                new VelocityComponent(0, 1),
+                null);
+        Velocity velocity = new Velocity(polar, cartesian);
+        PerceivedObject object = PerceivedObject.builder()
+                .measurementDeltaTime(0)
+                .position(position)
+                .velocity(velocity)
+                .build();
+        PerceivedObjectContainer perceivedObjectContainer = PerceivedObjectContainer.builder()
+                .perceivedObjects(java.util.List.of(object))
+                .build();
+
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .perceivedObjectContainer(perceivedObjectContainer)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsSegmentationInfoOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(validReferencePosition())
+                .segmentationInfo(new SegmentationInfo(0, 1))
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsReferenceTimeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(4398046511104L)
+                .referencePosition(validReferencePosition())
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsReferenceLatitudeOutOfRange() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(900000002, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(reference)
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsReferenceLongitudeOutOfRange() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 1800000002)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(reference)
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
     private static CpmEnvelope211 validEnvelope() {
         return CpmEnvelope211.builder()
                 .sourceUuid("com_application_42")
@@ -43,23 +192,27 @@ class CpmValidator211Test {
     }
 
     private static CpmMessage211 validMessage() {
+        return CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .build();
+    }
+
+    private static ManagementContainer validManagement() {
+        return ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(validReferencePosition())
+                .build();
+    }
+
+    private static ReferencePosition validReferencePosition() {
         PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
         Altitude altitude = new Altitude(0, 0);
-        ReferencePosition reference = ReferencePosition.builder()
+        return ReferencePosition.builder()
                 .latitudeLongitude(0, 0)
                 .positionConfidenceEllipse(ellipse)
                 .altitude(altitude)
                 .build();
-        ManagementContainer management = ManagementContainer.builder()
-                .referenceTime(0)
-                .referencePosition(reference)
-                .build();
-
-        return CpmMessage211.builder()
-                .protocolVersion(1)
-                .stationId(42)
-                .managementContainer(management)
-                .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
@@ -1,0 +1,65 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.cpm.v211.validation;
+
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmEnvelope211;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmMessage211;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CpmValidator211Test {
+
+    @Test
+    void validateEnvelopeAcceptsMinimalValid() {
+        CpmValidator211.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeRejectsObjectIdRotationCountOutOfRange() {
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .objectIdRotationCount(300)
+                .message(validMessage())
+                .build();
+
+        assertThrows(CpmValidationException.class, () -> CpmValidator211.validateEnvelope(envelope));
+    }
+
+    private static CpmEnvelope211 validEnvelope() {
+        return CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(validMessage())
+                .build();
+    }
+
+    private static CpmMessage211 validMessage() {
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        Altitude altitude = new Altitude(0, 0);
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(ellipse)
+                .altitude(altitude)
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(reference)
+                .build();
+
+        return CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/validation/CpmValidator211Test.java
@@ -11,17 +11,20 @@ import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.Angle;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianCoordinateWithConfidence;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianPosition3dWithConfidence;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.MessageRateHz;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.Speed;
 import com.orange.iot3mobility.messages.cpm.v211.model.defs.VelocityComponent;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.MessageRateRange;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.SegmentationInfo;
+import com.orange.iot3mobility.messages.cpm.v211.model.originatingvehiclecontainer.OriginatingVehicleContainer;
 import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.CartesianVelocity;
 import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObject;
 import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObjectContainer;
 import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PolarVelocity;
 import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.Velocity;
-import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer;
-import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.SegmentationInfo;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,6 +34,50 @@ class CpmValidator211Test {
     @Test
     void validateEnvelopeAcceptsMinimalValid() {
         CpmValidator211.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(validReferencePosition())
+                .segmentationInfo(new SegmentationInfo(1, 1))
+                .messageRateRange(new MessageRateRange(new MessageRateHz(1, 0), new MessageRateHz(10, 0)))
+                .build();
+
+        OriginatingVehicleContainer ovc = OriginatingVehicleContainer.builder()
+                .orientationAngle(new Angle(0, 1))
+                .build();
+
+        CartesianPosition3dWithConfidence position = new CartesianPosition3dWithConfidence(
+                new CartesianCoordinateWithConfidence(0, 1),
+                new CartesianCoordinateWithConfidence(0, 1),
+                null);
+        PerceivedObject obj = PerceivedObject.builder()
+                .measurementDeltaTime(0)
+                .position(position)
+                .objectId(1)
+                .build();
+        PerceivedObjectContainer perceivedObjects = PerceivedObjectContainer.builder()
+                .perceivedObjects(java.util.List.of(obj))
+                .build();
+
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .originatingVehicleContainer(ovc)
+                .perceivedObjectContainer(perceivedObjects)
+                .build();
+
+        CpmEnvelope211 envelope = CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .objectIdRotationCount(10)
+                .message(message)
+                .build();
+
+        CpmValidator211.validateEnvelope(envelope);
     }
 
     @Test

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.denm;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.denm;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/DenmCodecTest.java
@@ -1,0 +1,124 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.denm;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.orange.iot3mobility.messages.denm.core.DenmCodec;
+import com.orange.iot3mobility.messages.denm.core.DenmException;
+import com.orange.iot3mobility.messages.denm.core.DenmVersion;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DenmCodecTest {
+
+    @Test
+    void writeRead113RoundTrip() throws Exception {
+        DenmEnvelope113 envelope = validEnvelope113();
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V1_1_3, envelope, out);
+
+        DenmCodec.DenmFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(DenmVersion.V1_1_3, frame.version());
+        assertTrue(frame.envelope() instanceof DenmEnvelope113);
+        DenmEnvelope113 parsed = (DenmEnvelope113) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void writeRead220RoundTrip() throws Exception {
+        DenmEnvelope220 envelope = validEnvelope220();
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V2_2_0, envelope, out);
+
+        DenmCodec.DenmFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(DenmVersion.V2_2_0, frame.version());
+        assertTrue(frame.envelope() instanceof DenmEnvelope220);
+        DenmEnvelope220 parsed = (DenmEnvelope220) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        assertEquals(envelope.timestamp(), parsed.timestamp());
+    }
+
+    @Test
+    void readRejectsMissingVersion() {
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+        String json = "{\"type\":\"denm\"}";
+        assertThrows(DenmException.class, () -> codec.read(json));
+    }
+
+    private static DenmEnvelope113 validEnvelope113() {
+        ReferencePosition position = new ReferencePosition(0, 0, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(position)
+                .build();
+
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        return DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static DenmEnvelope220 validEnvelope220() {
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition position =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition.builder()
+                        .latitude(0)
+                        .longitude(0)
+                        .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                        .altitude(new Altitude(0, 0))
+                        .build();
+
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer management =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer.builder()
+                        .actionId(new com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId(1, 1))
+                        .detectionTime(0)
+                        .referenceTime(0)
+                        .eventPosition(position)
+                        .stationType(5)
+                        .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        return DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.denm.v113.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
@@ -8,10 +8,22 @@ package com.orange.iot3mobility.messages.denm.v113.validation;
 import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
 import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
 import com.orange.iot3mobility.messages.denm.v113.model.alacartecontainer.AlacarteContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.LocationConfidence;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.LocationContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.PathHistory;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.PathPoint;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.PositionConfidence;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.EventType;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.LinkedCause;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.SituationContainer;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -20,6 +32,58 @@ class DenmValidator113Test {
     @Test
     void validateEnvelopeAcceptsMinimalValid() {
         DenmValidator113.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(1000L)
+                .referenceTime(1000L)
+                .termination(0)
+                .eventPosition(new ReferencePosition(0, 0, 0))
+                .relevanceDistance(0)
+                .relevanceTrafficDirection(0)
+                .validityDuration(60)
+                .transmissionInterval(1000)
+                .stationType(5)
+                .confidence(new PositionConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(3)
+                .eventType(new EventType(97, 0))
+                .linkedCause(new LinkedCause(1, 0))
+                .build();
+
+        LocationContainer location = LocationContainer.builder()
+                .eventSpeed(500)
+                .eventPositionHeading(900)
+                .traces(List.of(new PathHistory(
+                        List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 10)))))
+                .roadType(0)
+                .confidence(new LocationConfidence(1, 1))
+                .build();
+
+        AlacarteContainer alacarte = new AlacarteContainer(0, 1);
+
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .locationContainer(location)
+                .alacarteContainer(alacarte)
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        DenmValidator113.validateEnvelope(envelope);
     }
 
     @Test

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
@@ -7,6 +7,7 @@ package com.orange.iot3mobility.messages.denm.v113.validation;
 
 import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
 import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.alacartecontainer.AlacarteContainer;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
 import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
@@ -35,6 +36,98 @@ class DenmValidator113Test {
         assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
     }
 
+    @Test
+    void validateAlacarteRejectsNegativePositioningSolution() {
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .alacarteContainer(new AlacarteContainer(null, -1))
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsStationTypeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(new ReferencePosition(0, 0, 0))
+                .stationType(300)
+                .build();
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsDetectionTimeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(4398046511104L)
+                .referenceTime(0)
+                .eventPosition(new ReferencePosition(0, 0, 0))
+                .build();
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsEventPositionLatitudeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(new ReferencePosition(900000002, 0, 0))
+                .build();
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
+    }
+
     private static DenmEnvelope113 validEnvelope() {
         return DenmEnvelope113.builder()
                 .origin("self")
@@ -45,19 +138,20 @@ class DenmValidator113Test {
     }
 
     private static DenmMessage113 validMessage() {
+        return DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .build();
+    }
+
+    private static ManagementContainer validManagement() {
         ReferencePosition position = new ReferencePosition(0, 0, 0);
-        ManagementContainer management = ManagementContainer.builder()
+        return ManagementContainer.builder()
                 .actionId(new ActionId(1, 1))
                 .detectionTime(0)
                 .referenceTime(0)
                 .eventPosition(position)
                 .build();
-
-        return DenmMessage113.builder()
-                .protocolVersion(1)
-                .stationId(42)
-                .managementContainer(management)
-                .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.denm.v113.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/validation/DenmValidator113Test.java
@@ -1,0 +1,63 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.denm.v113.validation;
+
+import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DenmValidator113Test {
+
+    @Test
+    void validateEnvelopeAcceptsMinimalValid() {
+        DenmValidator113.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeRejectsInvalidOrigin() {
+        DenmEnvelope113 envelope = new DenmEnvelope113(
+                "denm",
+                "invalid_origin",
+                "1.1.3",
+                "CCU6",
+                1514764800000L,
+                null,
+                validMessage());
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator113.validateEnvelope(envelope));
+    }
+
+    private static DenmEnvelope113 validEnvelope() {
+        return DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(validMessage())
+                .build();
+    }
+
+    private static DenmMessage113 validMessage() {
+        ReferencePosition position = new ReferencePosition(0, 0, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(position)
+                .build();
+
+        return DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
@@ -1,0 +1,70 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.messages.denm.v220.validation;
+
+import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DenmValidator220Test {
+
+    @Test
+    void validateEnvelopeAcceptsMinimalValid() {
+        DenmValidator220.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeRejectsMessageTypeMismatch() {
+        DenmEnvelope220 envelope = new DenmEnvelope220(
+                "invalid",
+                "com_application_42",
+                1514764800000L,
+                "2.2.0",
+                null,
+                validMessage());
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    private static DenmEnvelope220 validEnvelope() {
+        return DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(validMessage())
+                .build();
+    }
+
+    private static DenmMessage220 validMessage() {
+        ReferencePosition position = ReferencePosition.builder()
+                .latitude(0)
+                .longitude(0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(position)
+                .stationType(5)
+                .build();
+
+        return DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.denm.v220.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
@@ -9,13 +9,22 @@ import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
 import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
 import com.orange.iot3mobility.messages.denm.v220.model.alacartecontainer.AlacarteContainer;
 import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.DeltaReferencePosition;
 import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.DetectionZone;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.EventPositionHeading;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.EventSpeed;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.LocationContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.PathPoint;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition;
 import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.CauseCode;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.EventZone;
 import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -24,6 +33,66 @@ class DenmValidator220Test {
     @Test
     void validateEnvelopeAcceptsMinimalValid() {
         DenmValidator220.validateEnvelope(validEnvelope());
+    }
+
+    @Test
+    void validateEnvelopeAcceptsFullyPopulatedMessage() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(1000L)
+                .referenceTime(1000L)
+                .termination(0)
+                .eventPosition(validEventPosition())
+                .awarenessDistance(0)
+                .trafficDirection(0)
+                .validityDuration(60)
+                .transmissionInterval(1000)
+                .stationType(5)
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(3)
+                .eventType(new CauseCode(97, 0))
+                .linkedCause(new CauseCode(1, 0))
+                .eventZone(List.of(EventZone.builder()
+                        .eventPosition(new DeltaReferencePosition(0, 0, 0))
+                        .eventDeltaTime(100)
+                        .informationQuality(1)
+                        .build()))
+                .linkedDenms(List.of(new ActionId(2, 1)))
+                .eventEnd(100)
+                .build();
+
+        LocationContainer location = LocationContainer.builder()
+                .eventSpeed(new EventSpeed(500, 1))
+                .eventPositionHeading(new EventPositionHeading(900, 1))
+                .detectionZonesToEventPosition(List.of(DetectionZone.builder()
+                        .path(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 10)))
+                        .build()))
+                .roadType(0)
+                .build();
+
+        AlacarteContainer alacarte = AlacarteContainer.builder()
+                .lanePosition(0)
+                .positioningSolution(1)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .locationContainer(location)
+                .alacarteContainer(alacarte)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        DenmValidator220.validateEnvelope(envelope);
     }
 
     @Test

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
@@ -7,11 +7,14 @@ package com.orange.iot3mobility.messages.denm.v220.validation;
 
 import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
 import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.alacartecontainer.AlacarteContainer;
 import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
 import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer;
 import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.CauseCode;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,6 +39,166 @@ class DenmValidator220Test {
         assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
     }
 
+    @Test
+    void validateSituationRejectsTooManyLinkedDenms() {
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(1)
+                .eventType(new CauseCode(1, 0))
+                .linkedDenms(java.util.List.of(
+                        new ActionId(1, 1),
+                        new ActionId(1, 2),
+                        new ActionId(1, 3),
+                        new ActionId(1, 4),
+                        new ActionId(1, 5),
+                        new ActionId(1, 6),
+                        new ActionId(1, 7),
+                        new ActionId(1, 8),
+                        new ActionId(1, 9)))
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .situationContainer(situation)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateSituationRejectsEventEndOutOfRange() {
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(1)
+                .eventType(new CauseCode(1, 0))
+                .eventEnd(9000)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .situationContainer(situation)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsStationTypeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(validEventPosition())
+                .stationType(300)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsDetectionTimeOutOfRange() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(4398046511104L)
+                .referenceTime(0)
+                .eventPosition(validEventPosition())
+                .stationType(5)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateManagementRejectsEventPositionLatitudeOutOfRange() {
+        ReferencePosition invalidPosition = ReferencePosition.builder()
+                .latitude(900000002)
+                .longitude(0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(invalidPosition)
+                .stationType(5)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
+    @Test
+    void validateAlacarteRejectsPositioningSolutionOutOfRange() {
+        AlacarteContainer alacarte = AlacarteContainer.builder()
+                .positioningSolution(7)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .alacarteContainer(alacarte)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        assertThrows(DenmValidationException.class, () -> DenmValidator220.validateEnvelope(envelope));
+    }
+
     private static DenmEnvelope220 validEnvelope() {
         return DenmEnvelope220.builder()
                 .sourceUuid("com_application_42")
@@ -45,26 +208,29 @@ class DenmValidator220Test {
     }
 
     private static DenmMessage220 validMessage() {
-        ReferencePosition position = ReferencePosition.builder()
+        return DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(validManagement())
+                .build();
+    }
+
+    private static ManagementContainer validManagement() {
+        return ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(validEventPosition())
+                .stationType(5)
+                .build();
+    }
+
+    private static ReferencePosition validEventPosition() {
+        return ReferencePosition.builder()
                 .latitude(0)
                 .longitude(0)
                 .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
                 .altitude(new Altitude(0, 0))
                 .build();
-
-        ManagementContainer management = ManagementContainer.builder()
-                .actionId(new ActionId(1, 1))
-                .detectionTime(0)
-                .referenceTime(0)
-                .eventPosition(position)
-                .stationType(5)
-                .build();
-
-        return DenmMessage220.builder()
-                .protocolVersion(1)
-                .stationId(42)
-                .managementContainer(management)
-                .build();
     }
 }
-

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220Test.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.messages.denm.v220.validation;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.quadkey;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.quadkey;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/quadkey/QuadTileHelperTest.java
@@ -1,0 +1,320 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.quadkey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuadTileHelperTest {
+
+    // -------------------------------------------------------------------------
+    // tileXYToQuadKey
+    // -------------------------------------------------------------------------
+
+    @Test
+    void tileXYToQuadKeyZoom1NW() {
+        // Tile (0,0) at zoom 1 = NW quadrant
+        assertEquals("0", QuadTileHelper.tileXYToQuadKey(new TileXY(0, 0), 1));
+    }
+
+    @Test
+    void tileXYToQuadKeyZoom1NE() {
+        // Tile (1,0) at zoom 1 = NE quadrant
+        assertEquals("1", QuadTileHelper.tileXYToQuadKey(new TileXY(1, 0), 1));
+    }
+
+    @Test
+    void tileXYToQuadKeyZoom1SW() {
+        // Tile (0,1) at zoom 1 = SW quadrant
+        assertEquals("2", QuadTileHelper.tileXYToQuadKey(new TileXY(0, 1), 1));
+    }
+
+    @Test
+    void tileXYToQuadKeyZoom1SE() {
+        // Tile (1,1) at zoom 1 = SE quadrant
+        assertEquals("3", QuadTileHelper.tileXYToQuadKey(new TileXY(1, 1), 1));
+    }
+
+    @Test
+    void tileXYToQuadKeyZoom2SubtilesOf0() {
+        // The four sub-tiles of "0" are "00", "01", "02", "03"
+        assertEquals("00", QuadTileHelper.tileXYToQuadKey(new TileXY(0, 0), 2));
+        assertEquals("01", QuadTileHelper.tileXYToQuadKey(new TileXY(1, 0), 2));
+        assertEquals("02", QuadTileHelper.tileXYToQuadKey(new TileXY(0, 1), 2));
+        assertEquals("03", QuadTileHelper.tileXYToQuadKey(new TileXY(1, 1), 2));
+    }
+
+    @Test
+    void tileXYToQuadKeyLengthEqualsZoomLevel() {
+        for (int zoom = 1; zoom <= 8; zoom++) {
+            String key = QuadTileHelper.tileXYToQuadKey(new TileXY(0, 0), zoom);
+            assertEquals(zoom, key.length());
+        }
+    }
+
+    @Test
+    void tileXYToQuadKeyOnlyContainsValidDigits() {
+        String key = QuadTileHelper.tileXYToQuadKey(new TileXY(12345, 6789), 14);
+        assertTrue(key.matches("[0-3]+"), "QuadKey must only contain digits 0-3");
+    }
+
+    // -------------------------------------------------------------------------
+    // quadKeyToTileXY
+    // -------------------------------------------------------------------------
+
+    @Test
+    void quadKeyToTileXYRoundTrip() {
+        String[] keys = {"0", "1", "2", "3", "00", "13", "23", "031", "0213"};
+        for (String key : keys) {
+            TileXY tile = QuadTileHelper.quadKeyToTileXY(key);
+            assertEquals(key, QuadTileHelper.tileXYToQuadKey(tile, key.length()),
+                    "Round-trip failed for key: " + key);
+        }
+    }
+
+    @Test
+    void quadKeyToTileXYKnownValues() {
+        TileXY tile0 = QuadTileHelper.quadKeyToTileXY("0");
+        assertEquals(0, tile0.getTileX());
+        assertEquals(0, tile0.getTileY());
+
+        TileXY tile3 = QuadTileHelper.quadKeyToTileXY("3");
+        assertEquals(1, tile3.getTileX());
+        assertEquals(1, tile3.getTileY());
+
+        TileXY tile1 = QuadTileHelper.quadKeyToTileXY("1");
+        assertEquals(1, tile1.getTileX());
+        assertEquals(0, tile1.getTileY());
+
+        TileXY tile2 = QuadTileHelper.quadKeyToTileXY("2");
+        assertEquals(0, tile2.getTileX());
+        assertEquals(1, tile2.getTileY());
+    }
+
+    // -------------------------------------------------------------------------
+    // latLngToQuadKey
+    // -------------------------------------------------------------------------
+
+    @Test
+    void latLngToQuadKeyOriginIsInSEQuadrantAtZoom1() {
+        // (0, 0) falls in tile (1,1) → "3"
+        assertEquals("3", QuadTileHelper.latLngToQuadKey(0.0, 0.0, 1));
+    }
+
+    @Test
+    void latLngToQuadKeySWQuadrantAtZoom1() {
+        // (-45, -90) falls in SW tile → "2"
+        assertEquals("2", QuadTileHelper.latLngToQuadKey(-45.0, -90.0, 1));
+    }
+
+    @Test
+    void latLngToQuadKeyNWQuadrantAtZoom1() {
+        // (45, -90) falls in NW tile → "0"
+        assertEquals("0", QuadTileHelper.latLngToQuadKey(45.0, -90.0, 1));
+    }
+
+    @Test
+    void latLngToQuadKeyNEQuadrantAtZoom1() {
+        // (45, 90) falls in NE tile → "1"
+        assertEquals("1", QuadTileHelper.latLngToQuadKey(45.0, 90.0, 1));
+    }
+
+    @Test
+    void latLngToQuadKeyLengthEqualsZoomLevel() {
+        // Paris
+        String key14 = QuadTileHelper.latLngToQuadKey(48.8566, 2.3522, 14);
+        assertEquals(14, key14.length());
+        assertTrue(key14.matches("[0-3]+"));
+
+        String key8 = QuadTileHelper.latLngToQuadKey(48.8566, 2.3522, 8);
+        assertEquals(8, key8.length());
+    }
+
+    @Test
+    void latLngToQuadKeyHigherZoomIsPrefixedByLowerZoom() {
+        // The zoom-14 key for Paris must start with the zoom-8 key for Paris
+        String key8 = QuadTileHelper.latLngToQuadKey(48.8566, 2.3522, 8);
+        String key14 = QuadTileHelper.latLngToQuadKey(48.8566, 2.3522, 14);
+        assertTrue(key14.startsWith(key8),
+                "Zoom-14 key must start with zoom-8 key for the same location");
+    }
+
+    @Test
+    void latLngToQuadKeyClipsOutOfRangeCoordinates() {
+        // Should not throw, clips to valid range
+        assertDoesNotThrow(() -> QuadTileHelper.latLngToQuadKey(91.0, 181.0, 8));
+        assertDoesNotThrow(() -> QuadTileHelper.latLngToQuadKey(-91.0, -181.0, 8));
+    }
+
+    // -------------------------------------------------------------------------
+    // Pixel / LatLng round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void latLongToPixelXYToLatLongRoundTrip() {
+        double lat = 48.8566;
+        double lon = 2.3522;
+        int zoom = 14;
+
+        PixelXY pixel = QuadTileHelper.latLongToPixelXY(lat, lon, zoom);
+        LatLng recovered = QuadTileHelper.pixelXYToLatLong(pixel, zoom);
+
+        assertEquals(lat, recovered.getLatitude(), 0.01);
+        assertEquals(lon, recovered.getLongitude(), 0.01);
+    }
+
+    @Test
+    void pixelXYToTileXYAndBack() {
+        PixelXY pixel = new PixelXY(512, 768);
+        TileXY tile = QuadTileHelper.pixelXYToTileXY(pixel);
+        assertEquals(2, tile.getTileX());
+        assertEquals(3, tile.getTileY());
+    }
+
+    @Test
+    void tileXYToPixelXYCorners() {
+        TileXY tile = new TileXY(2, 3);
+
+        PixelXY upLeft = QuadTileHelper.tileXYToPixelXYUpLeft(tile);
+        assertEquals(512, upLeft.getPixelX());
+        assertEquals(768, upLeft.getPixelY());
+
+        PixelXY lowRight = QuadTileHelper.tileXYToPixelXYLowRight(tile);
+        assertEquals(768, lowRight.getPixelX());
+        assertEquals(1024, lowRight.getPixelY());
+
+        PixelXY upRight = QuadTileHelper.tileXYToPixelXYUpRight(tile);
+        assertEquals(768, upRight.getPixelX());
+        assertEquals(768, upRight.getPixelY());
+
+        PixelXY lowLeft = QuadTileHelper.tileXYToPixelXYLowLeft(tile);
+        assertEquals(512, lowLeft.getPixelX());
+        assertEquals(1024, lowLeft.getPixelY());
+    }
+
+    // -------------------------------------------------------------------------
+    // getNeighborQuadKeys
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getNeighborQuadKeysReturnsExactlyEight() {
+        ArrayList<String> neighbors = QuadTileHelper.getNeighborQuadKeys("0213");
+        assertEquals(8, neighbors.size());
+    }
+
+    @Test
+    void getNeighborQuadKeysDoesNotContainCenter() {
+        String center = "0213";
+        ArrayList<String> neighbors = QuadTileHelper.getNeighborQuadKeys(center);
+        assertFalse(neighbors.contains(center));
+    }
+
+    @Test
+    void getNeighborQuadKeysSameLengthAsInput() {
+        ArrayList<String> neighbors = QuadTileHelper.getNeighborQuadKeys("12030");
+        for (String neighbor : neighbors) {
+            assertEquals(5, neighbor.length());
+        }
+    }
+
+    @Test
+    void getNeighborQuadKeysAreSymmetric() {
+        // If B is a neighbor of A, then A must be a neighbor of B
+        String center = "0213";
+        ArrayList<String> neighbors = QuadTileHelper.getNeighborQuadKeys(center);
+        for (String neighbor : neighbors) {
+            ArrayList<String> neighborOfNeighbor = QuadTileHelper.getNeighborQuadKeys(neighbor);
+            assertTrue(neighborOfNeighbor.contains(center),
+                    center + " should be a neighbor of " + neighbor);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // substractKeys
+    // -------------------------------------------------------------------------
+
+    @Test
+    void substractKeysNoOverlapKeepsAllTargetKeys() {
+        ArrayList<String> target = new ArrayList<>(List.of("0", "1", "2", "3"));
+        ArrayList<String> extract = new ArrayList<>(); // empty
+        ArrayList<String> result = QuadTileHelper.substractKeys(target, extract);
+        assertEquals(4, result.size());
+        assertTrue(result.containsAll(target));
+    }
+
+    @Test
+    void substractKeysExactMatchRemovesKey() {
+        ArrayList<String> target = new ArrayList<>(List.of("0"));
+        ArrayList<String> extract = new ArrayList<>(List.of("0"));
+        ArrayList<String> result = QuadTileHelper.substractKeys(target, extract);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void substractKeysSubKeyTriggersSubdivision() {
+        // target = ["0"], extract = ["00"] → "0" is split; "01","02","03" survive, "00" is removed
+        ArrayList<String> target = new ArrayList<>(List.of("0"));
+        ArrayList<String> extract = new ArrayList<>(List.of("00"));
+        ArrayList<String> result = QuadTileHelper.substractKeys(target, extract);
+        assertEquals(3, result.size());
+        assertTrue(result.contains("01"));
+        assertTrue(result.contains("02"));
+        assertTrue(result.contains("03"));
+        assertFalse(result.contains("00"));
+    }
+
+    @Test
+    void substractKeysDeepSubdivision() {
+        // target = ["0"], extract = ["000"] → splits down 2 levels
+        // Level 1: "0" splits → "00","01","02","03"
+        // "00" is still a prefix of "000", splits → "000","001","002","003"
+        // "000" is removed; "001","002","003" survive
+        // Final: "001","002","003","01","02","03"
+        ArrayList<String> target = new ArrayList<>(List.of("0"));
+        ArrayList<String> extract = new ArrayList<>(List.of("000"));
+        ArrayList<String> result = QuadTileHelper.substractKeys(target, extract);
+        assertEquals(6, result.size());
+        assertTrue(result.contains("001"));
+        assertTrue(result.contains("002"));
+        assertTrue(result.contains("003"));
+        assertTrue(result.contains("01"));
+        assertTrue(result.contains("02"));
+        assertTrue(result.contains("03"));
+        assertFalse(result.contains("000"));
+        assertFalse(result.contains("0"));
+    }
+
+    @Test
+    void substractKeysNonOverlappingExtractKeepsAll() {
+        ArrayList<String> target = new ArrayList<>(List.of("0", "1"));
+        ArrayList<String> extract = new ArrayList<>(List.of("2", "3"));
+        ArrayList<String> result = QuadTileHelper.substractKeys(target, extract);
+        assertEquals(2, result.size());
+        assertTrue(result.contains("0"));
+        assertTrue(result.contains("1"));
+    }
+
+    // -------------------------------------------------------------------------
+    // quadKeyToQuadTopic
+    // -------------------------------------------------------------------------
+
+    @Test
+    void quadKeyToQuadTopicFormatsCorrectly() {
+        assertEquals("/0", QuadTileHelper.quadKeyToQuadTopic("0"));
+        assertEquals("/1/2/3", QuadTileHelper.quadKeyToQuadTopic("123"));
+        assertEquals("/0/2/1/3", QuadTileHelper.quadKeyToQuadTopic("0213"));
+    }
+
+    @Test
+    void quadKeyToQuadTopicEmptyKeyProducesEmptyTopic() {
+        assertEquals("", QuadTileHelper.quadKeyToQuadTopic(""));
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
@@ -1,0 +1,96 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.roadobjects;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HazardTypeTest {
+
+    @Test
+    void getHazardTypeReturnsCorrectTypeForKnownCauseAndSubcause() {
+        // cause=1 (TRAFFIC_CONDITION), subcause=0 → TRAFFIC_CONDITION_NO_SUBCAUSE
+        assertEquals(HazardType.TRAFFIC_CONDITION_NO_SUBCAUSE,
+                HazardType.getHazardType(1, 0));
+
+        // cause=1, subcause=5 → TRAFFIC_STATIONARY
+        assertEquals(HazardType.TRAFFIC_STATIONARY,
+                HazardType.getHazardType(1, 5));
+
+        // cause=2 (ACCIDENT), subcause=1 → MULTI_VEHICLE_ACCIDENT
+        assertEquals(HazardType.MULTI_VEHICLE_ACCIDENT,
+                HazardType.getHazardType(2, 1));
+
+        // cause=3 (ROADWORKS), subcause=0 → ROADWORKS_NO_SUBCAUSE
+        assertEquals(HazardType.ROADWORKS_NO_SUBCAUSE,
+                HazardType.getHazardType(3, 0));
+
+        // cause=6 (ADVERSE_WEATHER_CONDITION_ADHESION), subcause=5 → ICE_ON_ROAD
+        assertEquals(HazardType.ICE_ON_ROAD,
+                HazardType.getHazardType(6, 5));
+
+        // cause=91 (VEHICLE_BREAKDOWN), subcause=1 → LACK_OF_FUEL
+        assertEquals(HazardType.LACK_OF_FUEL,
+                HazardType.getHazardType(91, 1));
+    }
+
+    @Test
+    void getHazardTypeReturnsUndefinedForUnknownCombination() {
+        assertEquals(HazardType.UNDEFINED, HazardType.getHazardType(999, 999));
+        assertEquals(HazardType.UNDEFINED, HazardType.getHazardType(-1, 0));
+        assertEquals(HazardType.UNDEFINED, HazardType.getHazardType(0, 99));
+    }
+
+    @Test
+    void getCauseReturnsCorrectEtsiCauseCode() {
+        assertEquals(1, HazardType.TRAFFIC_STATIONARY.getCause());
+        assertEquals(2, HazardType.HEAVY_ACCIDENT.getCause());
+        assertEquals(91, HazardType.VEHICLE_BREAKDOWN_NO_SUBCAUSE.getCause());
+    }
+
+    @Test
+    void getSubcauseReturnsCorrectSubcauseCode() {
+        assertEquals(0, HazardType.TRAFFIC_CONDITION_NO_SUBCAUSE.getSubcause());
+        assertEquals(5, HazardType.TRAFFIC_STATIONARY.getSubcause());
+        assertEquals(1, HazardType.LACK_OF_FUEL.getSubcause());
+    }
+
+    @Test
+    void getCategoryReturnsCorrectCategory() {
+        assertEquals(HazardCategory.TRAFFIC_CONDITION,
+                HazardType.TRAFFIC_STATIONARY.getCategory());
+        assertEquals(HazardCategory.ACCIDENT,
+                HazardType.MULTI_VEHICLE_ACCIDENT.getCategory());
+        assertEquals(HazardCategory.VEHICLE_BREAKDOWN,
+                HazardType.LACK_OF_FUEL.getCategory());
+        assertEquals(HazardCategory.UNDEFINED,
+                HazardType.UNDEFINED.getCategory());
+    }
+
+    @Test
+    void getNameReturnsNonBlankString() {
+        for (HazardType type : HazardType.values()) {
+            assertFalse(type.getName().isBlank(),
+                    "HazardType " + type + " has a blank name");
+        }
+    }
+
+    @Test
+    void getHazardTypeIsConsistentWithEnumValues() {
+        // Every enum value must be findable by its own cause+subcause
+        for (HazardType type : HazardType.values()) {
+            // Skip UNDEFINED since it has cause=0/subcause=0 which may be
+            // ambiguous with other entries; just verify the lookup doesn't crash
+            HazardType found = HazardType.getHazardType(type.getCause(), type.getSubcause());
+            assertNotNull(found);
+            // The found type must have the same cause and subcause
+            assertEquals(type.getCause(), found.getCause());
+            assertEquals(type.getSubcause(), found.getSubcause());
+        }
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/HazardTypeTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadHazardTest.java
@@ -1,0 +1,258 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.roadobjects;
+
+import com.orange.iot3mobility.messages.EtsiConverter;
+import com.orange.iot3mobility.messages.denm.core.DenmCodec;
+import com.orange.iot3mobility.messages.denm.core.DenmVersion;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.EventType;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.SituationContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.CauseCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoadHazardTest {
+
+    // Paris ETSI-encoded coordinates
+    private static final int PARIS_LAT_ETSI = EtsiConverter.latitudeEtsi(48.8566);
+    private static final int PARIS_LON_ETSI = EtsiConverter.longitudeEtsi(2.3522);
+
+    // -------------------------------------------------------------------------
+    // v1.1.3 DENM frame
+    // -------------------------------------------------------------------------
+
+    private static DenmCodec.DenmFrame<?> buildFrame113(int validityDurationSec,
+                                                         int causeCause, int subcause) {
+        ReferencePosition eventPosition = new ReferencePosition(PARIS_LAT_ETSI, PARIS_LON_ETSI, 0);
+
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(eventPosition)
+                .validityDuration(validityDurationSec)
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .eventType(new EventType(causeCause, subcause))
+                .build();
+
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .build();
+
+        DenmEnvelope113 envelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(System.currentTimeMillis())
+                .message(message)
+                .build();
+
+        return new DenmCodec.DenmFrame<>(DenmVersion.V1_1_3, envelope);
+    }
+
+    @Test
+    void roadHazard113ExtractsPositionCorrectly() {
+        RoadHazard hazard = new RoadHazard("h1", buildFrame113(600, 1, 5));
+        assertNotNull(hazard.getPosition());
+        assertEquals(48.8566, hazard.getPosition().getLatitude(), 1e-4);
+        assertEquals(2.3522, hazard.getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void roadHazard113ExtractsHazardTypeCorrectly() {
+        // cause=1 (TRAFFIC_CONDITION), subcause=5 → TRAFFIC_STATIONARY
+        RoadHazard hazard = new RoadHazard("h2", buildFrame113(600, 1, 5));
+        assertEquals(HazardType.TRAFFIC_STATIONARY, hazard.getType());
+    }
+
+    @Test
+    void roadHazard113StillLivingWithPositiveLifetime() {
+        // 600 s lifetime → should be alive immediately
+        RoadHazard hazard = new RoadHazard("h3", buildFrame113(600, 1, 0));
+        assertTrue(hazard.stillLiving(),
+                "Hazard with 600s lifetime should still be living right after creation");
+    }
+
+    @Test
+    void roadHazard113GetUuidReturnsConstructedValue() {
+        RoadHazard hazard = new RoadHazard("my-uuid", buildFrame113(600, 1, 0));
+        assertEquals("my-uuid", hazard.getUuid());
+    }
+
+    @Test
+    void roadHazard113TimestampIsSet() {
+        long before = System.currentTimeMillis();
+        RoadHazard hazard = new RoadHazard("h4", buildFrame113(600, 1, 0));
+        long after = System.currentTimeMillis();
+        // timestamp comes from the envelope, which was built using System.currentTimeMillis()
+        assertTrue(hazard.getTimestamp() >= before - 10 && hazard.getTimestamp() <= after + 10,
+                "Hazard timestamp should be close to now");
+    }
+
+    // -------------------------------------------------------------------------
+    // v2.2.0 DENM frame
+    // -------------------------------------------------------------------------
+
+    private static DenmCodec.DenmFrame<?> buildFrame220(int validityDurationSec,
+                                                         int causeCode, int subcause) {
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition position =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition.builder()
+                        .latitude(PARIS_LAT_ETSI)
+                        .longitude(PARIS_LON_ETSI)
+                        .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                        .altitude(new Altitude(0, 0))
+                        .build();
+
+        com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer management =
+                com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer.builder()
+                        .actionId(new com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId(1, 1))
+                        .detectionTime(0)
+                        .referenceTime(0)
+                        .eventPosition(position)
+                        .validityDuration(validityDurationSec)
+                        .stationType(5)
+                        .build();
+
+        com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer situation =
+                com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer.builder()
+                        .informationQuality(7)
+                        .eventType(new CauseCode(causeCode, subcause))
+                        .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .build();
+
+        DenmEnvelope220 envelope = DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(System.currentTimeMillis())
+                .message(message)
+                .build();
+
+        return new DenmCodec.DenmFrame<>(DenmVersion.V2_2_0, envelope);
+    }
+
+    @Test
+    void roadHazard220ExtractsPositionCorrectly() {
+        RoadHazard hazard = new RoadHazard("h5", buildFrame220(600, 2, 1));
+        assertNotNull(hazard.getPosition());
+        assertEquals(48.8566, hazard.getPosition().getLatitude(), 1e-4);
+        assertEquals(2.3522, hazard.getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void roadHazard220ExtractsHazardTypeCorrectly() {
+        // cause=2 (ACCIDENT), subcause=1 → MULTI_VEHICLE_ACCIDENT
+        RoadHazard hazard = new RoadHazard("h6", buildFrame220(600, 2, 1));
+        assertEquals(HazardType.MULTI_VEHICLE_ACCIDENT, hazard.getType());
+    }
+
+    @Test
+    void roadHazard220StillLivingWithPositiveLifetime() {
+        RoadHazard hazard = new RoadHazard("h7", buildFrame220(600, 1, 0));
+        assertTrue(hazard.stillLiving());
+    }
+
+    // -------------------------------------------------------------------------
+    // setDenmFrame updates the hazard state
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setDenmFrameUpdatesPosition() {
+        RoadHazard hazard = new RoadHazard("h8", buildFrame113(600, 1, 0));
+
+        // Build a new frame with a different position (London)
+        int londonLatEtsi = EtsiConverter.latitudeEtsi(51.5074);
+        int londonLonEtsi = EtsiConverter.longitudeEtsi(-0.1278);
+
+        ReferencePosition newPosition = new ReferencePosition(londonLatEtsi, londonLonEtsi, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(newPosition)
+                .validityDuration(600)
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .eventType(new EventType(3, 0))
+                .build();
+
+        DenmMessage113 updatedMessage = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .build();
+
+        DenmEnvelope113 updatedEnvelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(System.currentTimeMillis())
+                .message(updatedMessage)
+                .build();
+
+        hazard.setDenmFrame(new DenmCodec.DenmFrame<>(DenmVersion.V1_1_3, updatedEnvelope));
+
+        assertEquals(51.5074, hazard.getPosition().getLatitude(), 1e-4);
+        assertEquals(-0.1278, hazard.getPosition().getLongitude(), 1e-4);
+    }
+
+    @Test
+    void setDenmFrameUpdatesHazardType() {
+        RoadHazard hazard = new RoadHazard("h9", buildFrame113(600, 1, 5));
+        assertEquals(HazardType.TRAFFIC_STATIONARY, hazard.getType());
+
+        // Update to ROADWORKS
+        ReferencePosition pos = new ReferencePosition(PARIS_LAT_ETSI, PARIS_LON_ETSI, 0);
+        ManagementContainer mgmt = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(pos)
+                .validityDuration(600)
+                .build();
+
+        SituationContainer newSituation = SituationContainer.builder()
+                .eventType(new EventType(3, 0)) // ROADWORKS_NO_SUBCAUSE
+                .build();
+
+        DenmMessage113 newMessage = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(mgmt)
+                .situationContainer(newSituation)
+                .build();
+
+        DenmEnvelope113 newEnvelope = DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(System.currentTimeMillis())
+                .message(newMessage)
+                .build();
+
+        hazard.setDenmFrame(new DenmCodec.DenmFrame<>(DenmVersion.V1_1_3, newEnvelope));
+        assertEquals(HazardType.ROADWORKS_NO_SUBCAUSE, hazard.getType());
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
@@ -1,0 +1,234 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.roadobjects;
+
+import com.orange.iot3mobility.managers.IoT3RoadSensorCallback;
+import com.orange.iot3mobility.messages.cpm.core.CpmCodec;
+import com.orange.iot3mobility.messages.cpm.core.CpmVersion;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmEnvelope121;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmMessage121;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObject;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectContainer;
+import com.orange.iot3mobility.quadkey.LatLng;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RoadSensorTest {
+
+    private IoT3RoadSensorCallback mockCallback;
+    private static final LatLng SENSOR_POSITION = new LatLng(48.8566, 2.3522);
+
+    @BeforeEach
+    void setUp() {
+        mockCallback = mock(IoT3RoadSensorCallback.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers to build CPM v1.2.1 frames
+    // -------------------------------------------------------------------------
+
+    private static CpmCodec.CpmFrame<?> buildCpm121Frame(List<PerceivedObject> objects) {
+        ReferencePosition ref = new ReferencePosition(488566000, 23522000, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(ref)
+                .confidence(confidence)
+                .build();
+
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .perceivedObjectContainer(new PerceivedObjectContainer(objects))
+                .build();
+
+        CpmEnvelope121 envelope = CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("sensor_CCU6")
+                .timestamp(System.currentTimeMillis())
+                .message(message)
+                .build();
+
+        return new CpmCodec.CpmFrame<>(CpmVersion.V1_2_1, envelope);
+    }
+
+    private static PerceivedObject makePerceivedObject(int id, int xDist, int yDist,
+                                                        int xSpeed, int ySpeed) {
+        PerceivedObjectConfidence conf = PerceivedObjectConfidence.builder()
+                .distance(1, 1)
+                .speed(0, 0)
+                .object(7)
+                .build();
+        return PerceivedObject.builder()
+                .objectId(id)
+                .timeOfMeasurement(0)
+                .distance(xDist, yDist)
+                .speed(xSpeed, ySpeed)
+                .objectAge(0)
+                .confidence(conf)
+                .build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic state tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getUuidReturnsConstructedValue() {
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of());
+        RoadSensor sensor = new RoadSensor("sensor-uuid", SENSOR_POSITION, frame, mockCallback);
+        assertEquals("sensor-uuid", sensor.getUuid());
+    }
+
+    @Test
+    void getPositionReturnsConstructedValue() {
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of());
+        RoadSensor sensor = new RoadSensor("sensor-uuid", SENSOR_POSITION, frame, mockCallback);
+        assertEquals(48.8566, sensor.getPosition().getLatitude(), 1e-9);
+        assertEquals(2.3522, sensor.getPosition().getLongitude(), 1e-9);
+    }
+
+    @Test
+    void stillLivingIsTrueImmediatelyAfterCreation() {
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of());
+        RoadSensor sensor = new RoadSensor("sensor-uuid", SENSOR_POSITION, frame, mockCallback);
+        assertTrue(sensor.stillLiving(), "A freshly created RoadSensor must be living");
+    }
+
+    @Test
+    void updateTimestampResetsLivingTimer() {
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of());
+        RoadSensor sensor = new RoadSensor("sensor-uuid", SENSOR_POSITION, frame, mockCallback);
+        sensor.updateTimestamp();
+        assertTrue(sensor.stillLiving());
+    }
+
+    // -------------------------------------------------------------------------
+    // New sensor object creation (v1.2.1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void constructorWithOnePerceivedObjectCallsNewSensorObject() {
+        PerceivedObject obj = makePerceivedObject(0, 100, 200, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj));
+
+        new RoadSensor("s1", SENSOR_POSITION, frame, mockCallback);
+
+        verify(mockCallback, times(1)).newSensorObject(any(SensorObject.class));
+        verify(mockCallback, never()).sensorObjectUpdate(any());
+    }
+
+    @Test
+    void constructorWithTwoPerceivedObjectsCallsNewSensorObjectTwice() {
+        PerceivedObject obj1 = makePerceivedObject(0, 100, 200, 0, 0);
+        PerceivedObject obj2 = makePerceivedObject(1, 300, 400, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj1, obj2));
+
+        new RoadSensor("s2", SENSOR_POSITION, frame, mockCallback);
+
+        verify(mockCallback, times(2)).newSensorObject(any(SensorObject.class));
+    }
+
+    @Test
+    void newSensorObjectHasCorrectUuidPattern() {
+        PerceivedObject obj = makePerceivedObject(7, 100, 200, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj));
+
+        new RoadSensor("s3", SENSOR_POSITION, frame, mockCallback);
+
+        ArgumentCaptor<SensorObject> captor = ArgumentCaptor.forClass(SensorObject.class);
+        verify(mockCallback).newSensorObject(captor.capture());
+        // UUID pattern: sensorUuid_objectId
+        assertEquals("s3_7", captor.getValue().getUuid());
+    }
+
+    @Test
+    void newSensorObjectIsStillLiving() {
+        PerceivedObject obj = makePerceivedObject(0, 100, 200, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj));
+
+        new RoadSensor("s4", SENSOR_POSITION, frame, mockCallback);
+
+        ArgumentCaptor<SensorObject> captor = ArgumentCaptor.forClass(SensorObject.class);
+        verify(mockCallback).newSensorObject(captor.capture());
+        assertTrue(captor.getValue().stillLiving());
+    }
+
+    // -------------------------------------------------------------------------
+    // Sensor object update on setCpmFrame (v1.2.1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setCpmFrameWithSameObjectIdCallsSensorObjectUpdate() {
+        PerceivedObject obj = makePerceivedObject(0, 100, 200, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj));
+        RoadSensor sensor = new RoadSensor("s5", SENSOR_POSITION, frame, mockCallback);
+
+        // Same object id → update
+        PerceivedObject updatedObj = makePerceivedObject(0, 150, 250, 100, 0);
+        CpmCodec.CpmFrame<?> frame2 = buildCpm121Frame(List.of(updatedObj));
+        sensor.setCpmFrame(frame2);
+
+        verify(mockCallback, times(1)).newSensorObject(any());
+        verify(mockCallback, times(1)).sensorObjectUpdate(any());
+    }
+
+    @Test
+    void setCpmFrameWithNewObjectIdCallsNewSensorObjectAgain() {
+        PerceivedObject obj = makePerceivedObject(0, 100, 200, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj));
+        RoadSensor sensor = new RoadSensor("s6", SENSOR_POSITION, frame, mockCallback);
+
+        // Different object id → new
+        PerceivedObject newObj = makePerceivedObject(99, 500, 600, 0, 0);
+        CpmCodec.CpmFrame<?> frame2 = buildCpm121Frame(List.of(newObj));
+        sensor.setCpmFrame(frame2);
+
+        // 2 newSensorObject calls (obj 0 first, then obj 99)
+        verify(mockCallback, times(2)).newSensorObject(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty perceived object list triggers no callback on first call
+    // -------------------------------------------------------------------------
+
+    @Test
+    void emptyPerceivedObjectsTriggersNoNewSensorObjectCallback() {
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of());
+        new RoadSensor("s7", SENSOR_POSITION, frame, mockCallback);
+        verify(mockCallback, never()).newSensorObject(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // getSensorObjects returns current snapshot
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getSensorObjectsContainsCreatedObjects() {
+        PerceivedObject obj1 = makePerceivedObject(0, 100, 200, 0, 0);
+        PerceivedObject obj2 = makePerceivedObject(1, 300, 400, 0, 0);
+        CpmCodec.CpmFrame<?> frame = buildCpm121Frame(List.of(obj1, obj2));
+
+        RoadSensor sensor = new RoadSensor("s8", SENSOR_POSITION, frame, mockCallback);
+
+        assertEquals(2, sensor.getSensorObjects().size());
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadSensorTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
@@ -69,7 +69,7 @@ class RoadUserTest {
     void getSpeedKmhConvertsCorrectly() {
         // 13.89 m/s * 3.6 = 50.004 km/h
         RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
-        assertEquals(13.89 * 3.6f, user.getSpeedKmh(), 0.01);
+        assertEquals(13.89 * 3.6, user.getSpeedKmh(), 0.01);
     }
 
     @Test

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
@@ -1,0 +1,158 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.roadobjects;
+
+import com.orange.iot3mobility.messages.StationType;
+import com.orange.iot3mobility.quadkey.LatLng;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoadUserTest {
+
+    private static RoadUser makeRoadUser(StationType stationType) {
+        return new RoadUser(
+                "test-uuid",
+                stationType,
+                new LatLng(48.8566, 2.3522),
+                13.89,       // ~50 km/h in m/s
+                90.0,
+                null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getUuidReturnsConstructedValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals("test-uuid", user.getUuid());
+    }
+
+    @Test
+    void getStationTypeReturnsConstructedValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals(StationType.PASSENGER_CAR, user.getStationType());
+    }
+
+    @Test
+    void getPositionReturnsConstructedValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals(48.8566, user.getPosition().getLatitude(), 1e-9);
+        assertEquals(2.3522, user.getPosition().getLongitude(), 1e-9);
+    }
+
+    @Test
+    void getSpeedReturnsConstructedValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals(13.89, user.getSpeed(), 1e-9);
+    }
+
+    @Test
+    void getHeadingReturnsConstructedValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals(90.0, user.getHeading(), 1e-9);
+    }
+
+    // -------------------------------------------------------------------------
+    // getSpeedKmh
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getSpeedKmhConvertsCorrectly() {
+        // 13.89 m/s * 3.6 = 50.004 km/h
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertEquals(13.89 * 3.6f, user.getSpeedKmh(), 0.01);
+    }
+
+    @Test
+    void getSpeedKmhIsZeroWhenSpeedIsZero() {
+        RoadUser user = new RoadUser("u", StationType.UNKNOWN, new LatLng(0, 0), 0.0, 0.0, null);
+        assertEquals(0.0, user.getSpeedKmh(), 1e-9);
+    }
+
+    // -------------------------------------------------------------------------
+    // Setters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setStationTypeUpdatesValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        user.setStationType(StationType.BUS);
+        assertEquals(StationType.BUS, user.getStationType());
+    }
+
+    @Test
+    void setPositionUpdatesValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        LatLng newPos = new LatLng(51.5074, -0.1278);
+        user.setPosition(newPos);
+        assertEquals(51.5074, user.getPosition().getLatitude(), 1e-9);
+        assertEquals(-0.1278, user.getPosition().getLongitude(), 1e-9);
+    }
+
+    @Test
+    void setSpeedUpdatesValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        user.setSpeed(27.78);
+        assertEquals(27.78, user.getSpeed(), 1e-9);
+    }
+
+    @Test
+    void setHeadingUpdatesValue() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        user.setHeading(180.0);
+        assertEquals(180.0, user.getHeading(), 1e-9);
+    }
+
+    // -------------------------------------------------------------------------
+    // stillLiving
+    // -------------------------------------------------------------------------
+
+    @Test
+    void stillLivingIsTrueImmediatelyAfterCreation() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        assertTrue(user.stillLiving(), "A freshly created RoadUser must still be living");
+    }
+
+    @Test
+    void updateTimestampResetsLivingTimer() {
+        RoadUser user = makeRoadUser(StationType.PASSENGER_CAR);
+        user.updateTimestamp();
+        assertTrue(user.stillLiving());
+    }
+
+    // -------------------------------------------------------------------------
+    // isVulnerable
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isVulnerableReturnsTrueForCyclist() {
+        assertTrue(makeRoadUser(StationType.CYCLIST).isVulnerable());
+    }
+
+    @Test
+    void isVulnerableReturnsTrueForPedestrian() {
+        assertTrue(makeRoadUser(StationType.PEDESTRIAN).isVulnerable());
+    }
+
+    @Test
+    void isVulnerableReturnsFalseForPassengerCar() {
+        assertFalse(makeRoadUser(StationType.PASSENGER_CAR).isVulnerable());
+    }
+
+    @Test
+    void isVulnerableReturnsFalseForBus() {
+        assertFalse(makeRoadUser(StationType.BUS).isVulnerable());
+    }
+
+    @Test
+    void isVulnerableReturnsFalseForUnknown() {
+        assertFalse(makeRoadUser(StationType.UNKNOWN).isVulnerable());
+    }
+}
+

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/RoadUserTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
@@ -2,6 +2,8 @@
  Copyright 2016-2026 Orange
 
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
@@ -67,8 +67,8 @@ class SensorObjectTest {
 
     @Test
     void getSpeedKmhConvertsCorrectly() {
-        // 13.89 m/s * 3.6f ≈ 50.0 km/h
-        assertEquals(13.89 * 3.6f, makeSensorObject().getSpeedKmh(), 0.01);
+        // 13.89 m/s * 3.6 ≈ 50.0 km/h
+        assertEquals(13.89 * 3.6, makeSensorObject().getSpeedKmh(), 0.01);
     }
 
     // -------------------------------------------------------------------------

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/roadobjects/SensorObjectTest.java
@@ -1,0 +1,128 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+ */
+package com.orange.iot3mobility.roadobjects;
+
+import com.orange.iot3mobility.quadkey.LatLng;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SensorObjectTest {
+
+    private static SensorObject makeSensorObject() {
+        return new SensorObject(
+                "sensor_42_obj1",
+                SensorObjectType.PASSENGER_CAR,
+                new LatLng(48.8566, 2.3522),
+                13.89,
+                90.0,
+                5);
+    }
+
+    // -------------------------------------------------------------------------
+    // Getters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getUuidReturnsConstructedValue() {
+        assertEquals("sensor_42_obj1", makeSensorObject().getUuid());
+    }
+
+    @Test
+    void getTypeReturnsConstructedValue() {
+        assertEquals(SensorObjectType.PASSENGER_CAR, makeSensorObject().getType());
+    }
+
+    @Test
+    void getPositionReturnsConstructedValue() {
+        SensorObject obj = makeSensorObject();
+        assertEquals(48.8566, obj.getPosition().getLatitude(), 1e-9);
+        assertEquals(2.3522, obj.getPosition().getLongitude(), 1e-9);
+    }
+
+    @Test
+    void getSpeedReturnsConstructedValue() {
+        assertEquals(13.89, makeSensorObject().getSpeed(), 1e-9);
+    }
+
+    @Test
+    void getHeadingReturnsConstructedValue() {
+        assertEquals(90.0, makeSensorObject().getHeading(), 1e-9);
+    }
+
+    @Test
+    void getInfoQualityReturnsConstructedValue() {
+        assertEquals(5, makeSensorObject().getInfoQuality());
+    }
+
+    // -------------------------------------------------------------------------
+    // getSpeedKmh
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getSpeedKmhConvertsCorrectly() {
+        // 13.89 m/s * 3.6f ≈ 50.0 km/h
+        assertEquals(13.89 * 3.6f, makeSensorObject().getSpeedKmh(), 0.01);
+    }
+
+    // -------------------------------------------------------------------------
+    // Setters
+    // -------------------------------------------------------------------------
+
+    @Test
+    void setTypeUpdatesValue() {
+        SensorObject obj = makeSensorObject();
+        obj.setType(SensorObjectType.PEDESTRIAN);
+        assertEquals(SensorObjectType.PEDESTRIAN, obj.getType());
+    }
+
+    @Test
+    void setPositionUpdatesValue() {
+        SensorObject obj = makeSensorObject();
+        LatLng newPos = new LatLng(51.5074, -0.1278);
+        obj.setPosition(newPos);
+        assertEquals(51.5074, obj.getPosition().getLatitude(), 1e-9);
+    }
+
+    @Test
+    void setSpeedUpdatesValue() {
+        SensorObject obj = makeSensorObject();
+        obj.setSpeed(27.78);
+        assertEquals(27.78, obj.getSpeed(), 1e-9);
+    }
+
+    @Test
+    void setHeadingUpdatesValue() {
+        SensorObject obj = makeSensorObject();
+        obj.setHeading(270.0);
+        assertEquals(270.0, obj.getHeading(), 1e-9);
+    }
+
+    @Test
+    void setInfoQualityUpdatesValue() {
+        SensorObject obj = makeSensorObject();
+        obj.setInfoQuality(7);
+        assertEquals(7, obj.getInfoQuality());
+    }
+
+    // -------------------------------------------------------------------------
+    // stillLiving
+    // -------------------------------------------------------------------------
+
+    @Test
+    void stillLivingIsTrueImmediatelyAfterCreation() {
+        assertTrue(makeSensorObject().stillLiving(),
+                "A freshly created SensorObject must still be living");
+    }
+
+    @Test
+    void updateTimestampResetsLivingTimer() {
+        SensorObject obj = makeSensorObject();
+        obj.updateTimestamp();
+        assertTrue(obj.stillLiving());
+    }
+}
+


### PR DESCRIPTION
What's new
------------
Unit tests have been added to the Java IoT3 SDK Core and Mobility packages.

Close #505 

What to do
------------
After reviewing code changes:

1. Clone this branch of the its-client project.
2. Ensure that you have Gradle to be able to build the java/iot3 core and mobility modules.
3. Run the core module tests (with your IDE or run `./gradlew :core:test`).
4. Run the mobility mode tests (with your IDE or run `./gradlew :mobility:test`).

Expected results
------------
- Core module tests: 91/91 tests passed.
- Mobility module tests: 292/292 tests passed.