### PR TITLE
python/iot3: CPM improvements

### DIFF
--- a/python/iot3/src/iot3/mobility/cpm.py
+++ b/python/iot3/src/iot3/mobility/cpm.py
@@ -83,6 +83,11 @@ class CollectivePerceptionMessage(etsi.Message):
             multiple_objects = {"other": 2}
             bulk_material = {"other": 3}
 
+        BoundingBox = collections.namedtuple(
+            "BoundingBox",
+            ["width", "length", "height", "heading"],
+        )
+
         object_id: int
         measurement_delta_time: float
         x_distance: float
@@ -93,6 +98,7 @@ class CollectivePerceptionMessage(etsi.Message):
         quality: Optional[int] = 0
         object_class: Optional[Vehicle | Vru | Other] = None
         object_class_confidence: int = 0
+        bounding_box: Optional[BoundingBox] = None
 
     SegmentationInfo = collections.namedtuple(
         "SegmentationInfo",
@@ -315,6 +321,52 @@ class CollectivePerceptionMessage(etsi.Message):
             )
             po["classification"] = list([c])
 
+        if perceived_object.bounding_box is not None:
+            po.update(
+                {
+                    "object_dimension_x": {
+                        "value": etsi.ETSI.si2etsi(
+                            value=perceived_object.bounding_box.length,
+                            scale=etsi.ETSI.DECI_METER,
+                            undef=256,
+                            validity_range={"min": 1, "max": 254},
+                            out_of_range=255,
+                        ),
+                        "confidence": 32,
+                    },
+                    "object_dimension_y": {
+                        "value": etsi.ETSI.si2etsi(
+                            value=perceived_object.bounding_box.width,
+                            scale=etsi.ETSI.DECI_METER,
+                            undef=256,
+                            validity_range={"min": 1, "max": 254},
+                            out_of_range=255,
+                        ),
+                        "confidence": 32,
+                    },
+                    "object_dimension_z": {
+                        "value": etsi.ETSI.si2etsi(
+                            value=perceived_object.bounding_box.height,
+                            scale=etsi.ETSI.DECI_METER,
+                            undef=256,
+                            validity_range={"min": 1, "max": 254},
+                            out_of_range=255,
+                        ),
+                        "confidence": 32,
+                    },
+                    "angles": {
+                        "z_angle": {
+                            "value": etsi.ETSI.si2etsi(
+                                value=perceived_object.bounding_box.heading,
+                                scale=etsi.ETSI.DECI_METER,
+                                undef=3601,
+                            ),
+                            "confidence": 127,
+                        }
+                    },
+                }
+            )
+
         self._message["message"]["perceived_object_container"].append(po)
 
     @property
@@ -473,6 +525,42 @@ class CollectivePerceptionMessage(etsi.Message):
                         "object_class": best["object_class"],
                         "object_class_confidence": best["confidence"],
                     },
+                )
+
+            length = etsi.ETSI.etsi2si(
+                value=po.get("object_dimension_x", {}).get("value"),
+                scale=etsi.ETSI.DECI_METER,
+                undef=256,
+                out_of_range=255,
+            )
+            width = etsi.ETSI.etsi2si(
+                value=po.get("object_dimension_y", {}).get("value"),
+                scale=etsi.ETSI.DECI_METER,
+                undef=256,
+                out_of_range=255,
+            )
+            height = etsi.ETSI.etsi2si(
+                value=po.get("object_dimension_z", {}).get("value"),
+                scale=etsi.ETSI.DECI_METER,
+                undef=256,
+                out_of_range=255,
+            )
+            heading = etsi.ETSI.etsi2si(
+                value=po.get("angles", {}).get("z_angle", {}).get("value"),
+                scale=etsi.ETSI.DECI_METER,
+                undef=3601,
+            )
+
+            # It is acceptable to create a bounding box with an unknown height.
+            # Having jut the footprint of the shape is enough for a lot of
+            # cases, like collision prediction and so on... But any other
+            # value missing would make for a useless bounding box...
+            if all([width is not None, length is not None, heading is not None]):
+                kwargs["bounding_box"] = self.PerceivedObject.BoundingBox(
+                    width=width,
+                    length=length,
+                    height=height,
+                    heading=heading,
                 )
 
             yield self.PerceivedObject(**kwargs)

--- a/python/iot3/src/iot3/mobility/cpm.py
+++ b/python/iot3/src/iot3/mobility/cpm.py
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: MIT
 # Author: Yann E. MORIN <yann.morin@orange.com>
 
+import collections
 import dataclasses
 import time
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Tuple
 
 from . import etsi
 from .gnss import GNSSReport
@@ -93,6 +94,18 @@ class CollectivePerceptionMessage(etsi.Message):
         object_class: Optional[Vehicle | Vru | Other] = None
         object_class_confidence: int = 0
 
+    SegmentationInfo = collections.namedtuple(
+        "SegmentationInfo",
+        [
+            "total_msg_no",
+            "this_msg_no",
+        ],
+        # Allow initialising with total_msg_no only, setting this_msg_no to 0:
+        defaults=[
+            0,
+        ],
+    )
+
     def __init__(
         self,
         *,
@@ -101,6 +114,7 @@ class CollectivePerceptionMessage(etsi.Message):
             etsi.Message.StationType
         ] = etsi.Message.StationType.unknown,
         gnss_report: GNSSReport,
+        segmentation_info: Optional[SegmentationInfo] = None,
         perceived_objects: Optional[Iterable[PerceivedObject]] = [],
     ):
         """Create a basic Cooperative Awareness Message
@@ -108,6 +122,10 @@ class CollectivePerceptionMessage(etsi.Message):
         :param uuid: the UUID of this station
         :param station_type: The type of this station
         :param gnss_report: a GNSS report, coming from a GNSS device
+        :param segmentation_info: The segementation information about the
+                                  sequence of CPM this one belongs to,
+                                  when the scene needs more than one CPM
+                                  to be described
         :param perceived_objects: A list of perceived objects
         """
         self._gnss_report = gnss_report
@@ -207,6 +225,20 @@ class CollectivePerceptionMessage(etsi.Message):
                     "confidence": 127,
                 },
             }
+
+        if segmentation_info:
+            if segmentation_info.this_msg_no >= segmentation_info.total_msg_no:
+                raise ValueError(
+                    f"More CPMs ({segmentation_info.this_msg_no}) in segmentation than expected ({segmentation_info.total_msg_no})"
+                )
+            self._message["message"]["management_container"]["segmentation_info"] = (
+                dict(
+                    [
+                        ("total_msg_no", segmentation_info.total_msg_no),
+                        ("this_msg_no", segmentation_info.this_msg_no),
+                    ]
+                )
+            )
 
         for po in perceived_objects:
             self.add_perceived_object(perceived_object=po)
@@ -344,6 +376,46 @@ class CollectivePerceptionMessage(etsi.Message):
             etsi.ETSI.CENTI_METER,
             800001,
         )
+
+    # Explicitly no setter for this property: we do not wot want to
+    # change the segmentation of an existing CPM, unless with switching
+    # to the "next-segment message" (see below).
+    @property
+    def segmentation(self) -> Optional[SegmentationInfo]:
+        try:
+            seg = self._message["message"]["management_container"]["segmentation_info"]
+        except KeyError:
+            return None
+
+        return self.SegmentationInfo(
+            total_msg_no=seg["total_msg_no"],
+            this_msg_no=seg["this_msg_no"],
+        )
+
+    def segmentation_next(self):
+        """Update the already segmnented CPM to be the next message
+
+        This is equivalent to separately removing all perceived objects, then
+        increasing message.management_container.segmentation_info.this_msg_no by 1.
+        """
+        if "segmentation_info" not in self._message["message"]["management_container"]:
+            raise RuntimeError(
+                "CPM is not segmented: can't start next CPM in segmentation"
+            )
+        seg_info = self._message["message"]["management_container"]["segmentation_info"]
+        total_msg_no = seg_info["total_msg_no"]
+        next_this_msg_no = seg_info["this_msg_no"] + 1
+        if next_this_msg_no == total_msg_no:
+            raise ValueError(
+                f"More CPMs in segmentation than expected ({total_msg_no})",
+            )
+        self.reset_perceived_objects()
+        self._message["message"]["management_container"]["segmentation_info"][
+            "this_msg_no"
+        ] = next_this_msg_no
+
+    def reset_perceived_objects(self):
+        self._message["message"]["perceived_object_container"] = list()
 
     @property
     def perceived_objects(self):

--- a/python/iot3/src/iot3/mobility/cpm.py
+++ b/python/iot3/src/iot3/mobility/cpm.py
@@ -97,7 +97,7 @@ class CollectivePerceptionMessage(etsi.Message):
         y_speed: Optional[float] = None
         quality: Optional[int] = 0
         object_class: Optional[Vehicle | Vru | Other] = None
-        object_class_confidence: int = 0
+        object_class_confidence: int = 101  # 101 is "unavailable", range is 1-100.
         bounding_box: Optional[BoundingBox] = None
 
     SegmentationInfo = collections.namedtuple(

--- a/python/iot3/src/iot3/mobility/etsi.py
+++ b/python/iot3/src/iot3/mobility/etsi.py
@@ -273,6 +273,13 @@ class Message(abc.ABC):
             16,
         )
 
+    @property
+    def timestamp(self):
+        return ETSI.etsi2si(
+            self._message["timestamp"],
+            etsi.ETSI.MILLI_SECOND,
+        )
+
     def __getitem__(self, key):
         return self._message[key]
 

--- a/python/iot3/src/iot3/mobility/leapseconds.py
+++ b/python/iot3/src/iot3/mobility/leapseconds.py
@@ -35,6 +35,7 @@ Python 2.6+, Python 3, Jython, Pypy support.
 """
 from __future__ import with_statement
 
+import hashlib
 import time
 from collections import namedtuple
 from datetime import datetime, timedelta
@@ -206,27 +207,68 @@ def leapseconds(
 
 
 def leapseconds_from_listfile(file, now=None):
-    """Extract leap seconds from *file*
+    r"""Extract leap seconds from *file*
 
     See /usr/share/zoneinfo/leap-seconds.list
+
+    >>> import io
+    >>> fd = open("/usr/share/zoneinfo/leap-seconds.list", "rb")
+    >>> ls_io = io.BytesIO(fd.read())
+    >>> fd.close()
+    >>> leapseconds_from_listfile(ls_io)[0]
+    LeapSecond(utc=datetime.datetime(1972, 1, 1, 0, 0), dTAI_UTC=datetime.timedelta(seconds=10))
+    >>> ls_io.seek(0)
+    0
+    >>> ls_io2 = io.BytesIO(b''.join(ls_io.readlines()[:-1]))
+    >>> leapseconds_from_listfile(ls_io2)[0]
+    Traceback (most recent call last):
+    ...
+    ValueError: leap-seconds.list has no hash
+    >>> ls_io2.seek(0, 2) and 0
+    0
+    >>> ls_io2.write(b"#h\tda39a3ee 5e6b4b0d 3255bfef 95601890 afd80709\n")  # NUL-hash
+    48
+    >>> ls_io2.seek(0)
+    0
+    >>> leapseconds_from_listfile(ls_io2)[0]    # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError: leap-seconds.list has wrong hash: computed: ..., expected: ...
     """
     if now is None:
         now = time.time()
     result = []
+    data_sha1 = hashlib.new("sha1")
     for line in file:
         if not line.startswith(b"#"):  # skip comments
+            data = line.partition(b"#")[0]
+            data_sha1.update(data.replace(b" ", b""))
             # ntp time, dtai, # day month year
-            ntp_time, dtai = line.partition(comment)[0].split()
+            ntp_time, dtai = data.split()
             utc = NTP_EPOCH + timedelta(seconds=int(ntp_time))
             result.append(LeapSecond(utc, timedelta(seconds=int(dtai))))
-        elif line.startswith(b"#@"):
+        elif line[:2] in [b"#$", b"#@"]:
             ntp_time = line[2:].strip()
+            data_sha1.update(ntp_time)
             utc = NTP_EPOCH + timedelta(seconds=int(ntp_time))
-            if utc.timestamp() < now:
+            if line[:2] == b"#$" and utc.timestamp() > now:
+                raise ValueError(
+                    f"leap-seconds.list is in the futrue, starts on {utc.isoformat()}"
+                )
+            if line[:2] == b"#@" and utc.timestamp() < now:
                 raise ValueError(
                     f"leap-seconds.list is out of date, expired on {utc.isoformat()}"
                 )
-    return result
+        elif line[:2] == b"#h":
+            h_file = line[2:].strip().replace(b" ", b"").decode()
+            h_data = data_sha1.hexdigest()
+            if h_file == h_data:
+                return result
+            raise ValueError(
+                f"leap-seconds.list has wrong hash: computed: {h_data}, expected: {h_file}"
+            )
+
+    raise ValueError("leap-seconds.list has no hash")
 
 
 def _fallback():

--- a/python/iot3/src/iot3/mobility/leapseconds.py
+++ b/python/iot3/src/iot3/mobility/leapseconds.py
@@ -205,7 +205,7 @@ def leapseconds(
         return LeapSeconds
 
 
-def leapseconds_from_listfile(file, now=None, comment="#".encode()):
+def leapseconds_from_listfile(file, now=None):
     """Extract leap seconds from *file*
 
     See /usr/share/zoneinfo/leap-seconds.list
@@ -214,12 +214,12 @@ def leapseconds_from_listfile(file, now=None, comment="#".encode()):
         now = time.time()
     result = []
     for line in file:
-        if not line.startswith(comment):  # skip comments
+        if not line.startswith(b"#"):  # skip comments
             # ntp time, dtai, # day month year
             ntp_time, dtai = line.partition(comment)[0].split()
             utc = NTP_EPOCH + timedelta(seconds=int(ntp_time))
             result.append(LeapSecond(utc, timedelta(seconds=int(dtai))))
-        elif line.startswith("#@".encode()):
+        elif line.startswith(b"#@"):
             ntp_time = line[2:].strip()
             utc = NTP_EPOCH + timedelta(seconds=int(ntp_time))
             if utc.timestamp() < now:

--- a/python/iot3/tests/test-iot3-mobility-message
+++ b/python/iot3/tests/test-iot3-mobility-message
@@ -171,7 +171,7 @@ except ValueError:
 else:
     raise RuntimeError("Invalid subcause should not be allowed")
 
-print("New DENM sith invalid subcause...")
+print("DENM with invalid subcause...")
 try:
     DENM(
         uuid="test_1234",

--- a/python/iot3/tests/test-iot3-mobility-message
+++ b/python/iot3/tests/test-iot3-mobility-message
@@ -118,6 +118,7 @@ msg = iot3.mobility.message_from_json(msg_json=json_msg)
 assert msg.msg_type == "cpm"
 assert msg["message"]["management_container"]["station_type"] == Message.StationType.passengerCar
 assert len(msg["message"]["perceived_object_container"]) == 3
+po = list(msg.perceived_objects)[-1]
 assert po.object_class["vehicle"] == Message.StationType.motorcycle
 
 #-----------------------------------------------------------------------------------------

--- a/python/iot3/tests/test-iot3-mobility-message
+++ b/python/iot3/tests/test-iot3-mobility-message
@@ -121,6 +121,79 @@ assert len(msg["message"]["perceived_object_container"]) == 3
 po = list(msg.perceived_objects)[-1]
 assert po.object_class["vehicle"] == Message.StationType.motorcycle
 
+print("CPM with segmentation...")
+msg = CPM(
+    uuid="test_1234",
+    station_type=Message.StationType.passengerCar,
+    gnss_report=GNSSReport(
+        latitude=43.635212,
+        longitude=1.374562,
+    ),
+    segmentation_info=CPM.SegmentationInfo(
+        total_msg_no=3,
+        this_msg_no=1,
+    ),
+    perceived_objects=[
+        CPM.PerceivedObject(
+            object_id= 27,
+            measurement_delta_time=0.128,
+            x_distance= 12,
+            y_distance= -16,
+            object_age= 127,
+        ),
+        CPM.PerceivedObject(
+            object_id= 42,
+            measurement_delta_time=-1.640,
+            x_distance= 63,
+            y_distance= -32,
+            object_age= 255,
+            quality=7,
+        ),
+    ],
+)
+assert msg.segmentation.total_msg_no == 3
+assert msg.segmentation.this_msg_no == 1
+assert len(msg["message"]["perceived_object_container"]) == 2
+
+print("CPM next in segmentation...")
+msg.segmentation_next()
+assert msg.segmentation.total_msg_no == 3
+assert msg.segmentation.this_msg_no == 2
+assert len(msg["message"]["perceived_object_container"]) == 0
+
+print("CPM segment with some P.O...")
+for po in [
+    CPM.PerceivedObject(
+        object_id= 12,
+        measurement_delta_time=1.280,
+        x_distance= 1,
+        y_distance= -2,
+        object_age= 3,
+        quality=15,
+        object_class=CPM.PerceivedObject.Vehicle.motorcycle,
+        object_class_confidence=50,
+    ),
+    CPM.PerceivedObject(
+        object_id= 27,
+        measurement_delta_time=0.128,
+        x_distance= 12,
+        y_distance= -16,
+        object_age= 127,
+    ),
+    CPM.PerceivedObject(
+        object_id= 42,
+        measurement_delta_time=-1.640,
+        x_distance= 63,
+        y_distance= -32,
+        object_age= 255,
+        quality=7,
+    ),
+]:
+    msg.add_perceived_object(perceived_object=po)
+assert len(msg["message"]["perceived_object_container"]) == 3
+po = list(msg.perceived_objects)[0]
+assert po.object_class["vehicle"] == Message.StationType.motorcycle
+
 #-----------------------------------------------------------------------------------------
 print("DENM with nothing set...")
 msg = DENM(

--- a/python/iot3/tests/test-iot3-mobility-message
+++ b/python/iot3/tests/test-iot3-mobility-message
@@ -96,6 +96,12 @@ msg.add_perceived_object(
         quality=15,
         object_class=CPM.PerceivedObject.Vehicle.motorcycle,
         object_class_confidence=50,
+        bounding_box=CPM.PerceivedObject.BoundingBox(
+            length=12.0,
+            width=2.48,
+            height=4.53,
+            heading=57.12,
+        )
     ),
 )
 assert len(msg["message"]["perceived_object_container"]) == 3
@@ -109,6 +115,9 @@ assert count == 3
 assert po.quality == 15
 assert po.object_class["vehicle"] == Message.StationType.motorcycle
 assert po.object_class_confidence == 50
+# CPM perceived objects dimensions only have decimeter-level precision
+assert po.bounding_box.width == 2.5
+assert po.bounding_box.heading == 57.1
 
 print("CPM serialisation...")
 json_msg = msg.to_json()
@@ -120,6 +129,8 @@ assert msg["message"]["management_container"]["station_type"] == Message.Station
 assert len(msg["message"]["perceived_object_container"]) == 3
 po = list(msg.perceived_objects)[-1]
 assert po.object_class["vehicle"] == Message.StationType.motorcycle
+assert po.bounding_box.width == 2.5
+assert po.bounding_box.heading == 57.1
 
 print("CPM with segmentation...")
 msg = CPM(


### PR DESCRIPTION
Changes
=======

* IoT3 SDK:
    * mobility:
        * extend CPM with bounding boxes for P.O. #513
        * add segmentation info to CPM #514
        * add checksum verification for leap-second file #517
        * fix default for P.O object-class confidence #521 

Close #513 
Close #514 
Close #517 
Close #521 

Test
====

How to test
-----------

_**Note:** in the following, lines starting with `$` are to be executed on your machine, as a non-root user;
lines starting with `(docker)$` are to be executed in the Docker container;
lines starting with `(docker)🐍 $` are to be executed in the Docker container, in the python venv._

1. Prepare a test environment:
    1. start a container with Python 3.11
       and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.15-slim-trixie \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential curl
        $ docker container exec -u 0:0 iot3 install -d -m 0755 /run/zoneinfo
        $ docker container exec -u 0:0 iot3 curl -o /run/zoneinfo/leap-seconds.list 'https://data.iana.org/time-zones/data/leap-seconds.list'

        $ docker container attach iot3
        ```
    6. prepare a Python 3.11 environment, with tests dependencies and packages' dependencies:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir install \
                        -r python/requirements-tests.txt \
                        $(sed -r -e '/.*"(.+(==|>=|<=).+)".*/!d; s//\1/; s/ //g;' \
                          python/*/pyproject.toml
                         )
        ```
       _**Note:**_ we install the packages dependencies manually, and do not rely on _pip_ to do so, because our Python packages depend one on the others by git hash, as they are not published on PyPi yet, so installing one of our packages may overwrite another.
2. Build the Python packages:
    ```sh
    (docker)🐍 $ for pkg in python/*/; do
                    python -m build -w "${pkg}" || break
                 done
    ```
3. Install the Python packages:
    ```sh
    (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir \
                        install --no-deps python/*/dist/*.whl
    ```
4. Run the IoT3 Core SDK tests for mobility messages:
    ```sh
    (docker)🐍 ./python/iot3/tests/test-iot3-mobility-message
    ```
5. Run the leap-second test suite:
    ```sh
    (docker)🐍 ./python/iot3/src/iot3/mobility/leapseconds.py --test; echo $?
    ```

Expected results
-------

1. The test environment is ready
2. The packages were all built successfully
3. The packages were all installed successfully
4. The tests all succeed:
    ```
    CAM with nothing available...
    CAM with latitude and longitude...
    CAM serialisation...
    CAM de-serialisation...
    CPM with no P.O...
    CPM of a car with some P.O...
    CPM with a new P.O...
    CPM iteration of P.O...
    CPM serialisation...
    CPM deserialisation...
    CPM with segmentation...
    CPM next in segmentation...
    CPM segment with some P.O...
    DENM with nothing set...
    DENM with latitude, longitude, and cause...
    DENM continuation (update)...
    DENM update with invalid subcause...
    DENM with invalid subcause...
    DENM continuation (update without subcause)...
    DENM continuation (termination)...
    DENM serialisation...
    DENM de-serialisation...
    Invalid generic message...
    De-serialisation of unrecognised message...
    De-serialisation of broken message...
    ```
5. The test-suite passes: there is no output, the exit code is 0 (zero)
