### PR TITLE
java/iot3mobility: add missing @generated tag with agent details

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/MapemHelper.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/MapemHelper.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/MapemLaneConverter.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/MapemLaneConverter.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemCodec.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemCodec.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemException.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemException.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemVersion.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/core/MapemVersion.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/codec/MapemReader200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/codec/MapemReader200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.codec;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/codec/MapemWriter200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/codec/MapemWriter200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.codec;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/MapemEnvelope200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/MapemEnvelope200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/MapemMessage200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/MapemMessage200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/intersection/IntersectionGeometry.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/intersection/IntersectionGeometry.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/intersection/IntersectionReferenceId.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/intersection/IntersectionReferenceId.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ComputedLane.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ComputedLane.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ConnectingLane.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ConnectingLane.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ConnectsTo.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/ConnectsTo.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/GenericLane.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/GenericLane.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/LaneAttributes.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/LaneAttributes.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/LaneType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/LaneType.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeAttributeData.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeAttributeData.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeAttributes.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeAttributes.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeDelta.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeDelta.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeLatLon.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeLatLon.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeList.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeList.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeXY.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeXY.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeXYOffset.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/NodeXYOffset.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/AllowedManeuver.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/AllowedManeuver.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/BikeLaneAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/BikeLaneAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/CrosswalkAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/CrosswalkAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneDirection.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneDirection.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneSharing.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneSharing.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneTypeFlag.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/LaneTypeFlag.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/MedianAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/MedianAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/NodeAttributeXY.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/NodeAttributeXY.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/ParkingAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/ParkingAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/SegmentAttributeXY.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/SegmentAttributeXY.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/SidewalkAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/SidewalkAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/StripingAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/StripingAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/TrackedVehicleAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/TrackedVehicleAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/VehicleLaneAttribute.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/lane/enums/VehicleLaneAttribute.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.lane.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/roadsegment/RoadSegmentData.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/roadsegment/RoadSegmentData.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.roadsegment;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/roadsegment/RoadSegmentReferenceId.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/roadsegment/RoadSegmentReferenceId.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.roadsegment;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/DataParameters.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/DataParameters.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/Position3D.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/Position3D.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/RestrictionClassAssignment.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/RestrictionClassAssignment.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/SpeedLimit.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/SpeedLimit.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/enums/RestrictionUserType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/enums/RestrictionUserType.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/enums/SpeedLimitType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/model/shared/enums/SpeedLimitType.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.model.shared.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/validation/MapemValidationException.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/validation/MapemValidationException.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.validation;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/validation/MapemValidator200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/mapem/v200/validation/MapemValidator200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.mapem.v200.validation;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/SpatemHelper.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/SpatemHelper.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemCodec.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemCodec.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemException.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemException.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemVersion.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/core/SpatemVersion.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.core;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/codec/SpatemReader200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/codec/SpatemReader200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.codec;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/codec/SpatemWriter200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/codec/SpatemWriter200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.codec;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/SpatemEnvelope200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/SpatemEnvelope200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/SpatemMessage200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/SpatemMessage200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/AdvisorySpeed.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/AdvisorySpeed.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/IntersectionReferenceId.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/IntersectionReferenceId.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/IntersectionState.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/IntersectionState.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/ManeuverAssist.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/ManeuverAssist.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/MovementEvent.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/MovementEvent.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/MovementState.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/MovementState.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/TimeChangeDetail.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/TimeChangeDetail.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/enums/IntersectionStatusFlag.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/model/intersection/enums/IntersectionStatusFlag.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.model.intersection.enums;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/validation/SpatemValidationException.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/validation/SpatemValidationException.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.validation;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/validation/SpatemValidator200.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/spatem/v200/validation/SpatemValidator200.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.messages.spatem.v200.validation;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadGeometry.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadGeometry.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadIntersection.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadIntersection.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadSegment.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/RoadSegment.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalColor.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalColor.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalController.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalController.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalGroup.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalGroup.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalGroupUpdateType.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalGroupUpdateType.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalPhase.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/roadobjects/SignalPhase.java
@@ -4,6 +4,7 @@
  This software is distributed under the MIT license, see LICENSE.txt file for more details.
 
  @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
  */
 package com.orange.iot3mobility.roadobjects;
 


### PR DESCRIPTION
**What's new**

Missing @generated tag has been added to all MAPEM and SPATEM related files to indicate which tool and model were used to generate the code.
