### PR TITLE
python/iot3/mobility: fix retrieving message timestamp

### DIFF
--- a/python/iot3/src/iot3/mobility/etsi.py
+++ b/python/iot3/src/iot3/mobility/etsi.py
@@ -277,7 +277,7 @@ class Message(abc.ABC):
     def timestamp(self):
         return ETSI.etsi2si(
             self._message["timestamp"],
-            etsi.ETSI.MILLI_SECOND,
+            ETSI.MILLI_SECOND,
         )
 
     def __getitem__(self, key):


### PR DESCRIPTION
Closes: #528

Changes
=======

* IoT3 SDK:
    * mobility: fixed something that was broken

Close #538

Test
====

How to test
-----------

_**Note:** in the following, lines starting with `$` are to be executed on your
machine, as a non-root user;
lines starting with `(docker)$` are to be executed in the Docker container;
lines starting with `(docker)🐍 $` are to be executed in the Docker container,
in the python venv._

1. Prepare a test environment:
    1. start a container with Python 3.11 and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.14-slim-trixie \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential curl socat
        $ docker container exec -u 0:0 iot3 install -d -m 0755 /run/zoneinfo
        $ docker container exec -u 0:0 iot3 curl -o /run/zoneinfo/leap-seconds.list 'https://data.iana.org/time-zones/data/leap-seconds.list' 

        $ docker container attach iot3
        ```
    2. prepare a Python 3.11 environment:
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        ```
2. Build the Python IoT3 package:
    ```sh
    (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir \
                     wheel -w /tmp/wheels python/iot3
    ```
3. Install the Python packages:
    ```sh
    (docker)🐍 $ pip --disable-pip-version-check --no-cache-dir \
                        install --no-deps /tmp/wheels/*.whl
    ```
4. Test issue #528 was fixed:
    ```sh
    (docker)🐍 python
    >>> from iot3.mobility.gnss import GNSSReport
    >>> from iot3.mobility.cpm import CPM
    >>> cpm = CPM(uuid="foo", gnss_report=GNSSReport())
    >>> cpm.timestamp
    ```

Expected results
-------

1. The test environment is ready
2. The IoT3 package was built successfully
3. The IoT3 package was installed successfully
4. Issue #528 was fixed: a timestamp matching the cpm creation time is reported, e.g.:
    ```
    1779441244.862
    ```
