### PR TITLE
python/iot3: add service_id to OTLP spans

### DIFF
--- a/python/iot3/src/iot3/core/otel.py
+++ b/python/iot3/src/iot3/core/otel.py
@@ -68,6 +68,7 @@ class Otel(threading.Thread):
         *,
         service_name: str,
         endpoint: str,
+        service_id: Optional[str] = None,
         auth: Optional[Auth] = Auth.NONE,
         username: Optional[str] = None,
         password: Optional[str] = None,
@@ -94,6 +95,7 @@ class Otel(threading.Thread):
         pending spans not yet exported.
 
         :param service_name: The name of the service.
+        :param service_id: The ID of this instance.
         :param endpoint: The URL to the OTLP collector (without the trailing
                          /v1/traces).
         :param auth: Type of HTTP authentication to employ.
@@ -110,6 +112,7 @@ class Otel(threading.Thread):
 
         self.service_name = service_name
         self.endpoint = endpoint
+        self.service_id = service_id
         if self.endpoint.endswith("/"):
             self.endpoint = self.endpoint[:-1]
 
@@ -186,6 +189,11 @@ class Otel(threading.Thread):
                 kwargs["parent_span"] = current_span
 
         s = Span(*args, **kwargs)
+        if self.service_id:
+            s.set_attribute(
+                key="iot3.core.service_id",
+                value=self.service_id,
+            )
         try:
             self.tls.spans.append(s)
             yield s

--- a/python/iot3/src/iot3/core/otel.py
+++ b/python/iot3/src/iot3/core/otel.py
@@ -68,12 +68,12 @@ class Otel(threading.Thread):
         *,
         service_name: str,
         endpoint: str,
-        auth: Auth = Auth.NONE,
+        auth: Optional[Auth] = Auth.NONE,
         username: Optional[str] = None,
         password: Optional[str] = None,
         batch_period: Optional[float] = None,
-        max_backlog: int = 1023,
-        compression: Compression = Compression.NONE,
+        max_backlog: Optional[int] = 1023,
+        compression: Optional[Compression] = Compression.NONE,
     ):
         """
         Simple span exporter

--- a/python/iot3/tests/test-iot3-core-otel
+++ b/python/iot3/tests/test-iot3-core-otel
@@ -6,6 +6,7 @@ import time
 
 o = iot3.core.otel.Otel(
     service_name="test-service",
+    service_id="test_42",
     endpoint="http://localhost:4318",
     batch_period=15,
     max_backlog=15,
@@ -32,5 +33,16 @@ with o.span(name="Root span") as s0:
 
 with o.span(name="Root span with link", span_links=[s0]) as s10:
     time.sleep(0.1)
+
+attrs = [
+    attr["value"]["stringValue"]
+    for attr in s0.to_dict()["attributes"]
+    if (
+        attr["key"] == "iot3.core.service_id"
+        and "stringValue" in attr["value"]
+    )
+]
+assert len(attrs) == 1
+assert attrs[0] == "test_42"
 
 o.stop()

--- a/python/its-interqueuemanager/src/its_iqm/iqm.py
+++ b/python/its-interqueuemanager/src/its_iqm/iqm.py
@@ -62,6 +62,7 @@ class IQM:
             self.otel = iot3.core.otel.Otel(
                 service_name="its-interqueuemanager",
                 endpoint=cfg["telemetry"]["endpoint"],
+                service_id=self.instance_id,
                 auth=iot3.core.otel.Auth(cfg["telemetry"]["authentication"]),
                 username=cfg["telemetry"]["username"],
                 password=cfg["telemetry"]["password"],

--- a/python/its-vehicle/src/its_vehicle/main.py
+++ b/python/its-vehicle/src/its_vehicle/main.py
@@ -114,6 +114,7 @@ def main():
         otel = iot3.core.otel.Otel(
             service_name="its-vehicle",
             endpoint=cfg["telemetry"]["endpoint"],
+            service_id=cfg["general"]["instance-id"],
             auth=iot3.core.otel.Auth(cfg["telemetry"]["authentication"]),
             username=cfg["telemetry"]["username"],
             password=cfg["telemetry"]["password"],


### PR DESCRIPTION
Changes
=======

* IoT3 SDK:
    * core: add _service-id_ tag to OTLP trace spans
* applications:
    * interqueuemanager: set the _service-id_ tag
    * vehicle: set the _service-id_ tag

Close #491

Test
====

How to test
-----------

_**Note:** in the following, lines starting with `$` are to be executed on your
machine, as a non-root user;
lines starting with `(docker)$` are to be executed in the Docker container;
lines starting with `(docker)🐍 $` are to be executed in the Docker container,
in the python venv._

1. Prepare a test environment:
    1. in a terminal, prepare a collector implementing the OpenTelemetry API, on localhost. If you don't have one, you may use an existing one, like:
        ```
        $ docker container run \
            --rm \
            -p 16686:16686 \
            -p 4318:4318 \
            jaegertracing/all-in-one:1.58
        ```
       then open a browser on the Jaegger UI (or that of your own collector if you have one):
        ```
        http://localhost:16686/
        ```
    2. in another terminal, start a container with Python 3.11
       and the necessary packages:
        ```sh
        $ docker container run \
            --detach \
            --name iot3 \
            --rm \
            -ti \
            --network host \
            -e http_proxy \
            -e https_proxy \
            -e no_proxy \
            --user $(id -u):$(id -u) \
            --mount type=bind,source=$(pwd),destination=$(pwd) \
            --workdir $(pwd) \
            python:3.11.14-slim-trixie \
            /bin/bash -il

        $ docker container exec -u 0:0 iot3 apt update
        $ docker container exec -u 0:0 iot3 apt install -y git build-essential

        $ docker container attach iot3
        ```
    3. prepare a Python 3.11 environment
        ```sh
        (docker)$ python3.11 -m venv /tmp/venv
        (docker)$ . /tmp/venv/bin/activate
        ```
2. Build the Python IoT3 package:
    ```sh
    (docker)🐍 $ pip \
                    --disable-pip-version-check \
                    --no-cache-dir \
                    wheel \
                    -w /tmp/wheels \
                    python/iot3
    ```
3. Install the Python IoT3 package:
    ```sh
    (docker)🐍 $ pip \
                    --disable-pip-version-check \
                    --no-cache-dir \
                    install \
                    --no-deps \
                    /tmp/wheels/*.whl
    ```
4. Run the IoT3 Core SDK tests:
    ```sh
    (docker)🐍 ./python/iot3/tests/test-iot3-core-otel
    ```
5. In the Jaeger UI, search traces for the _test-service_. Open a span, and look for its attributes.

Expected results
-------

1. The test environment is ready
2. The package was built successfully
3. The package was installed successfully
4. The test succeds
5. The traces are available; spans have an attribute named _iot3.core.service_id_ with value _test_42_.
