### PR TITLE
swift: Xcode 26.2 build

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Set up Xcode 26
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Build
         run: |
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set up Xcode 26
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Build
         run: |


### PR DESCRIPTION
# Changes

- Chore: Use Xcode 26.2 to have a simulator to launch the tests

Close #534