### PR TITLE
Java: IoT3 SDK v0.2.0

### DIFF
--- a/java/iot3/core/build.gradle
+++ b/java/iot3/core/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.orange.iot3core'
-version '0.1.2'
+version '0.2.0'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/java/iot3/examples/build.gradle
+++ b/java/iot3/examples/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.orange'
-version = '0.0.1-SNAPSHOT'
+version = '0.2.0'
 
 repositories {
     mavenCentral()

--- a/java/iot3/mobility/build.gradle
+++ b/java/iot3/mobility/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.orange.iot3mobility'
-version '0.1.2'
+version '0.2.0'
 
 repositories {
     // Use Maven Central for resolving dependencies.


### PR DESCRIPTION
**What's new**

IoT3 Core and Mobility modules `build.gradle` files have both been bumped to v0.2.0.

IoT3 Mobility:
- new multi-version message handling capability
- new messages implemented (MAPEM / SPATEM / MCM)
- unit tests

IoT3 Core:
- unit tests

Close #543 

**What to do**

Not much: the only change of this PR is the `build.gradle` files version bump, all the important updates came in the previous PRs.