### PR TITLE
Java/iot3core: add retain span attribute

### DIFF
--- a/java/iot3/core/build.gradle
+++ b/java/iot3/core/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group 'com.orange.iot3core'
-version '0.2.0'
+version '0.2.1-dev'
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
+++ b/java/iot3/core/src/main/java/com/orange/iot3core/clients/MqttClient.java
@@ -303,6 +303,8 @@ public class MqttClient {
                 span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.topic"), topic);
                 span.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
                         String.valueOf(message.length()));
+                if(retained)
+                    span.setAttribute(AttributeKey.booleanKey("iot3.core.mqtt.retain"), true);
                 span.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
 
                 // Inject the trace context into a map
@@ -385,6 +387,8 @@ public class MqttClient {
                     publish.getTopic().toString());
             receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.mqtt.payload_size"),
                     String.valueOf(message.length()));
+            if(publish.isRetain())
+                receivedSpan.setAttribute(AttributeKey.booleanKey("iot3.core.mqtt.retain"), true);
             receivedSpan.setAttribute(AttributeKey.stringKey("iot3.core.sdk_language"), "java");
             receivedSpan.end();
         }


### PR DESCRIPTION
**What's new**

A new `iot3.core.mqtt.retain` span attribute has been added to the Java IoT3 Core SDK consumer spans.

Close #545 

**What to do**

Review code change.