### PR TITLE
java/iot3mobility: fix DENM v2+ management container field name

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/codec/DenmReader220.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/codec/DenmReader220.java
@@ -151,7 +151,7 @@ public final class DenmReader220 {
             switch (field) {
                 case "protocol_version" -> protocolVersion = parser.getIntValue();
                 case "station_id" -> stationId = parser.getLongValue();
-                case "management_container" -> management = readManagement(parser);
+                case "management" -> management = readManagement(parser);
                 case "situation_container" -> situation = readSituation(parser);
                 case "location_container" -> location = readLocation(parser);
                 case "alacarte_container" -> alacarte = readAlacarte(parser);
@@ -162,7 +162,7 @@ public final class DenmReader220 {
         return new DenmMessage220(
                 requireField(protocolVersion, "protocol_version"),
                 requireField(stationId, "station_id"),
-                requireField(management, "management_container"),
+                requireField(management, "management"),
                 situation,
                 location,
                 alacarte);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/codec/DenmWriter220.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/codec/DenmWriter220.java
@@ -64,7 +64,7 @@ public final class DenmWriter220 {
         gen.writeStartObject();
         gen.writeNumberField("protocol_version", message.protocolVersion());
         gen.writeNumberField("station_id", message.stationId());
-        gen.writeFieldName("management_container");
+        gen.writeFieldName("management");
         writeManagement(gen, message.managementContainer());
         if (message.situationContainer() != null) {
             gen.writeFieldName("situation_container");

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/model/DenmMessage220.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/model/DenmMessage220.java
@@ -76,7 +76,7 @@ public record DenmMessage220(
             return new DenmMessage220(
                     requireNonNull(protocolVersion, "protocol_version"),
                     requireNonNull(stationId, "station_id"),
-                    requireNonNull(managementContainer, "management_container"),
+                    requireNonNull(managementContainer, "management"),
                     situationContainer,
                     locationContainer,
                     alacarteContainer);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v220/validation/DenmValidator220.java
@@ -63,7 +63,7 @@ public final class DenmValidator220 {
     }
 
     private static void validateManagement(ManagementContainer container) {
-        requireNonNull("management_container", container);
+        requireNonNull("management", container);
         validateActionId(container.actionId());
         checkRange("detection_time", container.detectionTime(), 0L, 4398046511103L);
         checkRange("reference_time", container.referenceTime(), 0L, 4398046511103L);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/codec/DenmReader230.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/codec/DenmReader230.java
@@ -156,7 +156,7 @@ public final class DenmReader230 {
             switch (field) {
                 case "protocol_version" -> protocolVersion = parser.getIntValue();
                 case "station_id" -> stationId = parser.getLongValue();
-                case "management_container" -> management = readManagement(parser);
+                case "management" -> management = readManagement(parser);
                 case "situation_container" -> situation = readSituation(parser);
                 case "location_container" -> location = readLocation(parser);
                 case "alacarte_container" -> alacarte = readAlacarte(parser);
@@ -167,7 +167,7 @@ public final class DenmReader230 {
         return new DenmMessage230(
                 requireField(protocolVersion, "protocol_version"),
                 requireField(stationId, "station_id"),
-                requireField(management, "management_container"),
+                requireField(management, "management"),
                 situation,
                 location,
                 alacarte);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/codec/DenmWriter230.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/codec/DenmWriter230.java
@@ -69,7 +69,7 @@ public final class DenmWriter230 {
         gen.writeStartObject();
         gen.writeNumberField("protocol_version", message.protocolVersion());
         gen.writeNumberField("station_id", message.stationId());
-        gen.writeFieldName("management_container");
+        gen.writeFieldName("management");
         writeManagement(gen, message.managementContainer());
         if (message.situationContainer() != null) {
             gen.writeFieldName("situation_container");

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/model/DenmMessage230.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/model/DenmMessage230.java
@@ -76,7 +76,7 @@ public record DenmMessage230(
             return new DenmMessage230(
                     requireNonNull(protocolVersion, "protocol_version"),
                     requireNonNull(stationId, "station_id"),
-                    requireNonNull(managementContainer, "management_container"),
+                    requireNonNull(managementContainer, "management"),
                     situationContainer,
                     locationContainer,
                     alacarteContainer);

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/validation/DenmValidator230.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/denm/v230/validation/DenmValidator230.java
@@ -68,7 +68,7 @@ public final class DenmValidator230 {
     }
 
     private static void validateManagement(ManagementContainer container) {
-        requireNonNull("management_container", container);
+        requireNonNull("management", container);
         validateActionId(container.actionId());
         checkRange("detection_time", container.detectionTime(), 0L, 4398046511103L);
         checkRange("reference_time", container.referenceTime(), 0L, 4398046511103L);


### PR DESCRIPTION
**What's been fixed**

DENM v2.2.0 and v2.3.0 **management container** JSON field has been renamed from `management_container` into `management`, in accordance with the corresponding JSON schemas.

Close #552 

**What to do**

Review the code changes.