### PR TITLE
java/iot3mobility: fix CAM v2.4.0 protectedCommunicationZonesRsu

### DIFF
--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/codec/CamReader240.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/codec/CamReader240.java
@@ -356,8 +356,7 @@ public final class CamReader240 {
                 parser.skipChildren();
             }
         }
-        return new RsuContainerHighFrequency(
-                requireField(zones, "rsu_container_high_frequency.protected_communication_zones_rsu"));
+        return new RsuContainerHighFrequency(zones);
     }
 
     private List<ProtectedCommunicationZone> readProtectedZones(JsonParser parser) throws IOException {

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/codec/CamWriter240.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/codec/CamWriter240.java
@@ -189,24 +189,26 @@ public final class CamWriter240 {
 
     private void writeRsuHF(JsonGenerator gen, RsuContainerHighFrequency container) throws IOException {
         gen.writeStartObject();
-        gen.writeArrayFieldStart("protected_communication_zones_rsu");
-        for (ProtectedCommunicationZone zone : container.protectedCommunicationZonesRsu()) {
-            gen.writeStartObject();
-            gen.writeNumberField("protected_zone_type", zone.protectedZoneType());
-            if (zone.expiryTime() != null) {
-                gen.writeNumberField("expiry_time", zone.expiryTime());
+        if (container.protectedCommunicationZonesRsu() != null) {
+            gen.writeArrayFieldStart("protected_communication_zones_rsu");
+            for (ProtectedCommunicationZone zone : container.protectedCommunicationZonesRsu()) {
+                gen.writeStartObject();
+                gen.writeNumberField("protected_zone_type", zone.protectedZoneType());
+                if (zone.expiryTime() != null) {
+                    gen.writeNumberField("expiry_time", zone.expiryTime());
+                }
+                gen.writeNumberField("protected_zone_latitude", zone.protectedZoneLatitude());
+                gen.writeNumberField("protected_zone_longitude", zone.protectedZoneLongitude());
+                if (zone.protectedZoneRadius() != null) {
+                    gen.writeNumberField("protected_zone_radius", zone.protectedZoneRadius());
+                }
+                if (zone.protectedZoneId() != null) {
+                    gen.writeNumberField("protected_zone_id", zone.protectedZoneId());
+                }
+                gen.writeEndObject();
             }
-            gen.writeNumberField("protected_zone_latitude", zone.protectedZoneLatitude());
-            gen.writeNumberField("protected_zone_longitude", zone.protectedZoneLongitude());
-            if (zone.protectedZoneRadius() != null) {
-                gen.writeNumberField("protected_zone_radius", zone.protectedZoneRadius());
-            }
-            if (zone.protectedZoneId() != null) {
-                gen.writeNumberField("protected_zone_id", zone.protectedZoneId());
-            }
-            gen.writeEndObject();
+            gen.writeEndArray();
         }
-        gen.writeEndArray();
         gen.writeEndObject();
     }
 

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/model/highfrequencycontainer/RsuContainerHighFrequency.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/model/highfrequencycontainer/RsuContainerHighFrequency.java
@@ -8,16 +8,19 @@
 package com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * RsuContainerHighFrequency v2.4.0
  *
- * @param protectedCommunicationZonesRsu List of RSU {@link ProtectedCommunicationZone}
+ * @param protectedCommunicationZonesRsu Optional list of RSU {@link ProtectedCommunicationZone}.
+ *                                       May be {@code null} — the field is optional per the schema.
+ *                                       When present, must contain between 1 and 16 entries.
  */
 public record RsuContainerHighFrequency(
         List<ProtectedCommunicationZone> protectedCommunicationZonesRsu) implements HighFrequencyContainer {
     public RsuContainerHighFrequency {
-        protectedCommunicationZonesRsu = List.copyOf(Objects.requireNonNull(protectedCommunicationZonesRsu));
+        protectedCommunicationZonesRsu = protectedCommunicationZonesRsu != null
+                ? List.copyOf(protectedCommunicationZonesRsu)
+                : null;
     }
 }

--- a/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/validation/CamValidator240.java
+++ b/java/iot3/mobility/src/main/java/com/orange/iot3mobility/messages/cam/v240/validation/CamValidator240.java
@@ -151,9 +151,10 @@ public final class CamValidator240 {
     }
 
     private static void validateRsuHF(RsuContainerHighFrequency container) {
-        List<ProtectedCommunicationZone> zones =
-                requireNonNull("rsu_container_high_frequency.protected_communication_zones_rsu",
-                        container.protectedCommunicationZonesRsu());
+        List<ProtectedCommunicationZone> zones = container.protectedCommunicationZonesRsu();
+        if (zones == null) {
+            return;
+        }
         int size = zones.size();
         if (size < 1 || size > 16) {
             throw new CamValidationException("protected_communication_zones_rsu size out of range [1,16]: " + size);

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/CamCodecTest.java
@@ -25,6 +25,7 @@ import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Ac
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.BasicVehicleContainerHighFrequency;
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Curvature;
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Heading;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.RsuContainerHighFrequency;
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Speed;
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.VehicleLength;
 import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.YawRate;
@@ -81,6 +82,24 @@ class CamCodecTest {
         assertEquals(CamVersion.V2_4_0, frame.version());
         CamEnvelope240 parsed = (CamEnvelope240) frame.envelope();
         assertEquals(4294967295L, parsed.linkedStationId());
+    }
+
+    @Test
+    void writeRead240RsuWithoutZonesRoundTrip() throws Exception {
+        CamEnvelope240 envelope = validEnvelope240Rsu();
+        CamCodec codec = new CamCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V2_4_0, envelope, out);
+
+        CamCodec.CamFrame<?> frame = codec.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(CamVersion.V2_4_0, frame.version());
+        assertTrue(frame.envelope() instanceof CamEnvelope240);
+        CamEnvelope240 parsed = (CamEnvelope240) frame.envelope();
+        assertEquals(envelope.sourceUuid(), parsed.sourceUuid());
+        CamStructuredData parsedMsg = (CamStructuredData) parsed.message();
+        assertTrue(parsedMsg.highFrequencyContainer() instanceof RsuContainerHighFrequency);
+        assertNull(((RsuContainerHighFrequency) parsedMsg.highFrequencyContainer()).protectedCommunicationZonesRsu());
     }
 
     @Test
@@ -149,6 +168,37 @@ class CamCodecTest {
         return CamEnvelope240.builder()
                 .messageFormat("json/raw")
                 .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CamEnvelope240 validEnvelope240Rsu() {
+        com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.ReferencePosition reference =
+                com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.ReferencePosition.builder()
+                          .latitudeLongitude(0, 0)
+                          .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                          .altitude(new Altitude(0, 0))
+                          .build();
+
+        BasicContainer basic = BasicContainer.builder()
+                         .stationType(15)
+                         .referencePosition(reference)
+                         .build();
+
+        RsuContainerHighFrequency rsu = new RsuContainerHighFrequency(null);
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(99)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(rsu)
+                .build();
+
+        return CamEnvelope240.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_rsu_99")
                 .timestamp(1514764800000L)
                 .message(message)
                 .build();

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v240/validation/CamValidator240Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v240/validation/CamValidator240Test.java
@@ -84,6 +84,28 @@ class CamValidator240Test {
     }
 
     @Test
+    void validateEnvelopeAcceptsRsuWithoutProtectedZones() {
+        RsuContainerHighFrequency rsu = new RsuContainerHighFrequency(null);
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(rsu)
+                .build();
+
+        CamEnvelope240 envelope = CamEnvelope240.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_rsu_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CamValidator240.validateEnvelope(envelope);
+    }
+
+    @Test
     void validateEnvelopeRejectsEmptyRsuZones() {
         ReferencePosition reference = ReferencePosition.builder()
                 .latitudeLongitude(0, 0)


### PR DESCRIPTION
**What's been fixed**

CAM v2.4.0 **RSU High Frequency Container** `protected_communication_zones_rsu` field has been made optional in accordance with the corresponding JSON schema.

Close #553 

**What to do**

Review the code changes.
