### PR TITLE
Java/IoT3Mobility: Test JSON ETSI ITS messages against their JSON schema

### DIFF
--- a/java/iot3/.github/skills/java-coding-conventions.md
+++ b/java/iot3/.github/skills/java-coding-conventions.md
@@ -10,6 +10,7 @@ This is the umbrella skill for all Java IoT3 coding conventions. When working on
 | [`java-jackson-streaming`](java-jackson-streaming.md) | Codecs, readers, writers |
 | [`java-naming-conventions`](java-naming-conventions.md) | All Java code |
 | [`java-testing`](java-testing.md) | Test files |
+| [`java-schema-validation-testing`](java-schema-validation-testing.md) | JSON Schema conformance tests |
 
 ## Quick Checklist
 
@@ -21,4 +22,5 @@ This is the umbrella skill for all Java IoT3 coding conventions. When working on
 - [ ] Jackson streaming only — no `ObjectMapper`, `@JsonProperty`, `JsonNode`
 - [ ] Full descriptive variable names — no single-letter abbreviations
 - [ ] Tests use JUnit 5 + Mockito only
+- [ ] Schema conformance tests follow the `java-schema-validation-testing` skill (codec → bytes → `SchemaTestUtils.assertConformsToSchema`)
 

--- a/java/iot3/.github/skills/java-schema-validation-testing.md
+++ b/java/iot3/.github/skills/java-schema-validation-testing.md
@@ -1,0 +1,103 @@
+# Skill: JSON Schema Validation Testing
+
+## Purpose
+
+Use this skill when writing tests that verify a serialized JSON message conforms to its ETSI JSON Schema file.
+
+## Location Convention
+
+Schema validation test classes live in a `schema` sub-package under the version package:
+
+```
+messages/{type}/v{version}/schema/{Type}Schema{Version}Test.java
+```
+
+Examples:
+- `messages/cam/v240/schema/CamSchema240Test.java`
+- `messages/denm/v230/schema/DenmSchema230Test.java`
+- `messages/cpm/v211/schema/CpmSchema211Test.java`
+
+## Schema Loading
+
+Load the schema **once** in a `static {}` block using `SchemaTestUtils.loadSchema()`.
+Pass a path relative to the repository `schema/` directory:
+
+```java
+private static final JsonSchema SCHEMA;
+
+static {
+    try {
+        SCHEMA = SchemaTestUtils.loadSchema("cam/cam_schema_2-4-0.json");
+    } catch (Exception e) {
+        throw new RuntimeException(e);
+    }
+}
+```
+
+## Encoding and Asserting
+
+Encode the message with the type-specific codec (not `ObjectMapper`) and validate the raw bytes:
+
+```java
+@Test
+void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+    CamEnvelope240 envelope = minimalEnvelope();
+    CamCodec codec = new CamCodec(new JsonFactory());
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    codec.write(CamVersion.V2_4_0, envelope, out);
+
+    SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+}
+```
+
+## Test Method Naming
+
+Follow the pattern `write_{scenario}_conformsToSchema`:
+
+| Scenario | Method name |
+|---|---|
+| Only mandatory fields | `write_minimalValidEnvelope_conformsToSchema` |
+| All optional fields populated | `write_fullyPopulatedEnvelope_conformsToSchema` |
+| Specific optional container added | `write_envelopeWith{Container}_conformsToSchema` |
+
+## Test Helper Methods
+
+Extract fixture construction into private static helpers to keep tests readable:
+
+```java
+private static CamEnvelope240 minimalEnvelope() { ... }
+private static CamEnvelope240 fullyPopulatedEnvelope() { ... }
+private static BasicContainer validBasicContainer() { ... }
+private static BasicVehicleContainerHighFrequency validHighFrequencyContainer() { ... }
+```
+
+- `minimalEnvelope()` — only mandatory fields; always write this test first.
+- `fullyPopulatedEnvelope()` — every optional field set to a valid value.
+- `valid{Container}()` — shared sub-structures reused across multiple tests.
+
+## SchemaTestUtils
+
+`SchemaTestUtils` is the single shared utility class for all schema validation tests:
+
+```java
+// Load a schema from the repository schema/ directory
+JsonSchema schema = SchemaTestUtils.loadSchema("cam/cam_schema_2-4-0.json");
+
+// Assert a byte array conforms to the schema (throws AssertionError with violation details on failure)
+SchemaTestUtils.assertConformsToSchema(schema, out.toByteArray());
+```
+
+- The factory uses **JSON Schema 2020-12** (`SpecVersion.VersionFlag.V202012`).
+- A schema mapper automatically redirects any remote `$ref` ending in `dsrc_schema_2-0-0.json` to the local copy under `schema/dsrc/`, so no network access is required.
+- Do **not** create a second `JsonSchemaFactory` in individual tests — always go through `SchemaTestUtils`.
+
+## Checklist
+
+- [ ] Class in the `schema` sub-package of the version package
+- [ ] Schema loaded once in `static {}` via `SchemaTestUtils.loadSchema()`
+- [ ] Encoding done with the type's codec + `JsonFactory` (not `ObjectMapper`)
+- [ ] At least a `write_minimalValidEnvelope_conformsToSchema` test
+- [ ] A `write_fullyPopulatedEnvelope_conformsToSchema` test when optional containers exist
+- [ ] Fixture helpers are `private static` methods, not inline in `@Test` methods
+- [ ] Validation via `SchemaTestUtils.assertConformsToSchema(SCHEMA, bytes)`

--- a/java/iot3/AGENTS.md
+++ b/java/iot3/AGENTS.md
@@ -267,4 +267,5 @@ Coding conventions are maintained as individual skills in [`.github/skills/`](.g
 | [`java-jackson-streaming`](.github/skills/java-jackson-streaming.md)   | Codecs, readers, writers                                 |
 | [`java-naming-conventions`](.github/skills/java-naming-conventions.md) | All Java code                                            |
 | [`java-testing`](.github/skills/java-testing.md)                       | Test files                                               |
+| [`java-schema-validation-testing`](.github/skills/java-schema-validation-testing.md) | JSON Schema conformance tests              |
 | [`java-coding-conventions`](.github/skills/java-coding-conventions.md) | Summary checklist of all conventions                     |

--- a/java/iot3/mobility/build.gradle
+++ b/java/iot3/mobility/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
     // Mockito for mock-based unit tests.
     testImplementation 'org.mockito:mockito-core:5.11.0'
+    // JSON Schema validation for schema conformance tests.
+    testImplementation 'com.networknt:json-schema-validator:1.5.6'
 }
 
 tasks.named('test') {

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/SchemaTestUtils.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/SchemaTestUtils.java
@@ -1,0 +1,81 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.AbsoluteIri;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Utility methods for validating serialized JSON against ETSI schema files.
+ * <p>
+ * Schema files are resolved relative to {@code ../../../schema/} from the
+ * Gradle test working directory ({@code java/iot3/mobility/}).
+ * <p>
+ * Some schemas (MAPEM, SPATEM) use {@code $ref} values that are resolved against
+ * the schema's {@code $id} URL (an {@code https://} address) rather than the local
+ * file path. The factory is configured with a schema mapper that redirects any
+ * remote DSRC schema URI to the local copy on disk.
+ */
+public final class SchemaTestUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Path SCHEMA_ROOT = Path.of("../../../schema");
+
+    private static final JsonSchemaFactory FACTORY = buildFactory();
+
+    private SchemaTestUtils() {
+    }
+
+    private static JsonSchemaFactory buildFactory() {
+        String dsrcUri = SCHEMA_ROOT.resolve("dsrc/dsrc_schema_2-0-0.json").toAbsolutePath().toUri().toString();
+        return JsonSchemaFactory.builder(
+                        JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012))
+                .schemaMappers(mappers -> mappers.add(iri -> {
+                    if (iri.toString().endsWith("dsrc_schema_2-0-0.json")) {
+                        return AbsoluteIri.of(dsrcUri);
+                    }
+                    return null;
+                }))
+                .build();
+    }
+
+    /**
+     * Loads a JSON Schema from a path relative to the repository {@code schema/} directory.
+     *
+     * @param relativePath e.g. {@code "cam/cam_schema_2-4-0.json"}
+     */
+    public static JsonSchema loadSchema(String relativePath) throws IOException {
+        Path schemaPath = SCHEMA_ROOT.resolve(relativePath);
+        return FACTORY.getSchema(schemaPath.toUri());
+    }
+
+    /**
+     * Asserts that the given JSON bytes conform to the provided schema.
+     *
+     * @param schema the JSON Schema to validate against
+     * @param json   the serialized JSON bytes
+     */
+    public static void assertConformsToSchema(JsonSchema schema, byte[] json) throws IOException {
+        JsonNode node = OBJECT_MAPPER.readTree(json);
+        Set<ValidationMessage> violations = schema.validate(node);
+        assertTrue(violations.isEmpty(),
+                "Schema violations: " + violations);
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/schema/CamSchema113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v113/schema/CamSchema113Test.java
@@ -1,0 +1,136 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.cam.v113.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.cam.core.CamCodec;
+import com.orange.iot3mobility.messages.cam.core.CamVersion;
+import com.orange.iot3mobility.messages.cam.v113.model.BasicContainer;
+import com.orange.iot3mobility.messages.cam.v113.model.CamEnvelope113;
+import com.orange.iot3mobility.messages.cam.v113.model.CamMessage113;
+import com.orange.iot3mobility.messages.cam.v113.model.HighFrequencyContainer;
+import com.orange.iot3mobility.messages.cam.v113.model.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.cam.v113.model.HighFrequencyConfidence;
+import com.orange.iot3mobility.messages.cam.v113.model.LowFrequencyContainer;
+import com.orange.iot3mobility.messages.cam.v113.model.PathPoint;
+import com.orange.iot3mobility.messages.cam.v113.model.PositionConfidence;
+import com.orange.iot3mobility.messages.cam.v113.model.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cam.v113.model.ReferencePosition;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class CamSchema113Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("cam/cam_schema_1-1-3.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        CamEnvelope113 envelope = minimalEnvelope();
+        CamCodec codec = new CamCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V1_1_3, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        CamEnvelope113 envelope = fullyPopulatedEnvelope();
+
+        CamCodec codec = new CamCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V1_1_3, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static CamEnvelope113 minimalEnvelope() {
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 0, 0))
+                .build();
+        HighFrequencyContainer high = HighFrequencyContainer.builder().build();
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .build();
+        return CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CamEnvelope113 fullyPopulatedEnvelope() {
+        BasicContainer basic = BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(new ReferencePosition(0, 0, 0))
+                .positionConfidence(new PositionConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+
+        HighFrequencyContainer high = HighFrequencyContainer.builder()
+                .heading(0)
+                .speed(0)
+                .driveDirection(0)
+                .vehicleSize(10, 10)
+                .curvature(0)
+                .curvatureCalculationMode(0)
+                .longitudinalAcceleration(0)
+                .yawRate(0)
+                .accelerationControl("0000000")
+                .lanePosition(0)
+                .lateralAcceleration(0)
+                .verticalAcceleration(0)
+                .highFrequencyConfidence(HighFrequencyConfidence.builder()
+                        .heading(1).speed(1).vehicleLength(0).yawRate(0)
+                        .longitudinalAcceleration(0).curvature(0)
+                        .lateralAcceleration(0).verticalAcceleration(0)
+                        .build())
+                .build();
+
+        LowFrequencyContainer low = LowFrequencyContainer.builder()
+                .vehicleRole(0)
+                .exteriorLights("00000000")
+                .pathHistory(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1)))
+                .build();
+
+        CamMessage113 message = CamMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(basic)
+                .highFrequencyContainer(high)
+                .lowFrequencyContainer(low)
+                .build();
+
+        return CamEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v240/schema/CamSchema240Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cam/v240/schema/CamSchema240Test.java
@@ -1,0 +1,202 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.cam.v240.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.cam.core.CamCodec;
+import com.orange.iot3mobility.messages.cam.core.CamVersion;
+import com.orange.iot3mobility.messages.cam.v240.model.CamEnvelope240;
+import com.orange.iot3mobility.messages.cam.v240.model.CamStructuredData;
+import com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.Altitude;
+import com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.BasicContainer;
+import com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cam.v240.model.basiccontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.AccelerationComponent;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.AccelerationControl;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.BasicVehicleContainerHighFrequency;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.CenDsrcTollingZone;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Curvature;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Heading;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.Speed;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.SteeringWheelAngle;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.VehicleLength;
+import com.orange.iot3mobility.messages.cam.v240.model.highfrequencycontainer.YawRate;
+import com.orange.iot3mobility.messages.cam.v240.model.lowfrequencycontainer.BasicVehicleContainerLowFrequency;
+import com.orange.iot3mobility.messages.cam.v240.model.lowfrequencycontainer.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.cam.v240.model.lowfrequencycontainer.ExteriorLights;
+import com.orange.iot3mobility.messages.cam.v240.model.lowfrequencycontainer.LowFrequencyContainer;
+import com.orange.iot3mobility.messages.cam.v240.model.lowfrequencycontainer.PathPoint;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.CauseCode;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.EmergencyContainer;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.EmergencyPriority;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.IncidentIndication;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.LightBarSiren;
+import com.orange.iot3mobility.messages.cam.v240.model.specialvehiclecontainer.SpecialVehicleContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class CamSchema240Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("cam/cam_schema_2-4-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        CamEnvelope240 envelope = minimalEnvelope();
+        CamCodec codec = new CamCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V2_4_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_envelopeWithLowFrequencyContainer_conformsToSchema() throws Exception {
+        LowFrequencyContainer low = new LowFrequencyContainer(
+                new BasicVehicleContainerLowFrequency(
+                        0,
+                        new ExteriorLights(true, false, false, false, false, false, false, false),
+                        List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 1))));
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .lowFrequencyContainer(low)
+                .build();
+
+        CamEnvelope240 envelope = CamEnvelope240.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CamCodec codec = new CamCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V2_4_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        BasicVehicleContainerHighFrequency hf = BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(900, 1))
+                .speed(new Speed(1400, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(45, 0))
+                .vehicleWidth(18)
+                .longitudinalAcceleration(new AccelerationComponent(20, 1))
+                .curvature(new Curvature(100, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(500, 1))
+                .accelerationControl(new AccelerationControl(true, false, false, false, false, true, false))
+                .lanePosition(1)
+                .steeringWheelAngle(new SteeringWheelAngle(10, 1))
+                .lateralAcceleration(new AccelerationComponent(5, 1))
+                .verticalAcceleration(new AccelerationComponent(3, 1))
+                .performanceClass(1)
+                .cenDsrcTollingZone(new CenDsrcTollingZone(480000000, 160000000, 42))
+                .build();
+
+        LowFrequencyContainer low = new LowFrequencyContainer(
+                new BasicVehicleContainerLowFrequency(
+                        6,
+                        new ExteriorLights(true, false, false, true, false, false, false, true),
+                        List.of(
+                                new PathPoint(new DeltaReferencePosition(10, 20, 0), 100),
+                                new PathPoint(new DeltaReferencePosition(20, 40, 0), 200))));
+
+        EmergencyContainer emergency = EmergencyContainer.builder()
+                .lightBarSirenInUse(new LightBarSiren(true, true))
+                .incidentIndication(new IncidentIndication(new CauseCode(95, 1)))
+                .emergencyPriority(new EmergencyPriority(true, false))
+                .build();
+
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(65000)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(hf)
+                .lowFrequencyContainer(low)
+                .specialVehicleContainer(new SpecialVehicleContainer(emergency))
+                .build();
+
+        CamEnvelope240 envelope = CamEnvelope240.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+
+        CamCodec codec = new CamCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CamVersion.V2_4_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static CamEnvelope240 minimalEnvelope() {
+        CamStructuredData message = CamStructuredData.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .basicContainer(validBasicContainer())
+                .highFrequencyContainer(validHighFrequencyContainer())
+                .build();
+        return CamEnvelope240.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static BasicContainer validBasicContainer() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        return BasicContainer.builder()
+                .stationType(5)
+                .referencePosition(reference)
+                .build();
+    }
+
+    private static BasicVehicleContainerHighFrequency validHighFrequencyContainer() {
+        return BasicVehicleContainerHighFrequency.builder()
+                .heading(new Heading(0, 1))
+                .speed(new Speed(0, 1))
+                .driveDirection(0)
+                .vehicleLength(new VehicleLength(1, 0))
+                .vehicleWidth(1)
+                .longitudinalAcceleration(new AccelerationComponent(0, 1))
+                .curvature(new Curvature(0, 0))
+                .curvatureCalculationMode(0)
+                .yawRate(new YawRate(0, 0))
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/schema/CpmSchema121Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v121/schema/CpmSchema121Test.java
@@ -1,0 +1,149 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.cpm.v121.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.cpm.core.CpmCodec;
+import com.orange.iot3mobility.messages.cpm.core.CpmVersion;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmEnvelope121;
+import com.orange.iot3mobility.messages.cpm.v121.model.CpmMessage121;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v121.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObject;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectConfidence;
+import com.orange.iot3mobility.messages.cpm.v121.model.perceivedobjectcontainer.PerceivedObjectContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.OriginatingVehicleContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.StationDataContainer;
+import com.orange.iot3mobility.messages.cpm.v121.model.stationdatacontainer.VehicleConfidence;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class CpmSchema121Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("cpm/cpm_schema_1-2-1.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        CpmEnvelope121 envelope = minimalEnvelope();
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V1_2_1, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        CpmEnvelope121 envelope = fullyPopulatedEnvelope();
+
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V1_2_1, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static ManagementContainer validManagement() {
+        ReferencePosition referencePosition = new ReferencePosition(0, 0, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        return ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(referencePosition)
+                .confidence(confidence)
+                .build();
+    }
+
+    private static CpmEnvelope121 minimalEnvelope() {
+        ReferencePosition referencePosition = new ReferencePosition(0, 0, 0);
+        PositionConfidenceEllipse ellipse = new PositionConfidenceEllipse(0, 0, 0);
+        ManagementConfidence confidence = new ManagementConfidence(ellipse, 0);
+        ManagementContainer management = ManagementContainer.builder()
+                .stationType(5)
+                .referencePosition(referencePosition)
+                .confidence(confidence)
+                .build();
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(management)
+                .build();
+        return CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CpmEnvelope121 fullyPopulatedEnvelope() {
+        VehicleConfidence vehicleConf = VehicleConfidence.builder()
+                .heading(1).speed(1).build();
+        OriginatingVehicleContainer vehicle = OriginatingVehicleContainer.builder()
+                .heading(0)
+                .speed(0)
+                .confidence(vehicleConf)
+                .driveDirection(0)
+                .vehicleLength(10)
+                .vehicleWidth(10)
+                .longitudinalAcceleration(0)
+                .yawRate(0)
+                .build();
+        StationDataContainer stationData = StationDataContainer.builder()
+                .originatingVehicleContainer(vehicle)
+                .build();
+
+        PerceivedObjectConfidence objConf = PerceivedObjectConfidence.builder()
+                .distance(1, 1)
+                .speed(0, 0)
+                .object(0)
+                .build();
+        PerceivedObject obj = PerceivedObject.builder()
+                .objectId(0)
+                .timeOfMeasurement(0)
+                .distance(0, 0)
+                .speed(0, 0)
+                .objectAge(0)
+                .confidence(objConf)
+                .build();
+        PerceivedObjectContainer perceivedObjects = new PerceivedObjectContainer(List.of(obj));
+
+        CpmMessage121 message = CpmMessage121.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .generationDeltaTime(1)
+                .managementContainer(validManagement())
+                .stationDataContainer(stationData)
+                .perceivedObjectContainer(perceivedObjects)
+                .build();
+
+        return CpmEnvelope121.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/schema/CpmSchema211Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/cpm/v211/schema/CpmSchema211Test.java
@@ -1,0 +1,140 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.cpm.v211.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.cpm.core.CpmCodec;
+import com.orange.iot3mobility.messages.cpm.core.CpmVersion;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmEnvelope211;
+import com.orange.iot3mobility.messages.cpm.v211.model.CpmMessage211;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Altitude;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.ReferencePosition;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.Angle;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianCoordinateWithConfidence;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.CartesianPosition3dWithConfidence;
+import com.orange.iot3mobility.messages.cpm.v211.model.defs.MessageRateHz;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.MessageRateRange;
+import com.orange.iot3mobility.messages.cpm.v211.model.managementcontainer.SegmentationInfo;
+import com.orange.iot3mobility.messages.cpm.v211.model.originatingvehiclecontainer.OriginatingVehicleContainer;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObject;
+import com.orange.iot3mobility.messages.cpm.v211.model.perceivedobjectcontainer.PerceivedObjectContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class CpmSchema211Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("cpm/cpm_schema_2-1-1.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        CpmEnvelope211 envelope = minimalEnvelope();
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V2_1_1, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        CpmEnvelope211 envelope = fullyPopulatedEnvelope();
+
+        CpmCodec codec = new CpmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(CpmVersion.V2_1_1, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static ReferencePosition validReferencePosition() {
+        return ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+    }
+
+    private static CpmEnvelope211 minimalEnvelope() {
+        ReferencePosition reference = ReferencePosition.builder()
+                .latitudeLongitude(0, 0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(reference)
+                .build();
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        return CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static CpmEnvelope211 fullyPopulatedEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .referenceTime(0)
+                .referencePosition(validReferencePosition())
+                .segmentationInfo(new SegmentationInfo(1, 1))
+                .messageRateRange(new MessageRateRange(new MessageRateHz(1, 0), new MessageRateHz(10, 0)))
+                .build();
+
+        OriginatingVehicleContainer ovc = OriginatingVehicleContainer.builder()
+                .orientationAngle(new Angle(0, 1))
+                .build();
+
+        CartesianPosition3dWithConfidence position = new CartesianPosition3dWithConfidence(
+                new CartesianCoordinateWithConfidence(0, 1),
+                new CartesianCoordinateWithConfidence(0, 1),
+                null);
+        PerceivedObject obj = PerceivedObject.builder()
+                .measurementDeltaTime(0)
+                .position(position)
+                .objectId(1)
+                .build();
+        PerceivedObjectContainer perceivedObjects = PerceivedObjectContainer.builder()
+                .perceivedObjects(List.of(obj))
+                .build();
+
+        CpmMessage211 message = CpmMessage211.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .originatingVehicleContainer(ovc)
+                .perceivedObjectContainer(perceivedObjects)
+                .build();
+
+        return CpmEnvelope211.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .objectIdRotationCount(10)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/schema/DenmSchema113Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v113/schema/DenmSchema113Test.java
@@ -1,0 +1,140 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.denm.v113.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.denm.core.DenmCodec;
+import com.orange.iot3mobility.messages.denm.core.DenmVersion;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmEnvelope113;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.DenmMessage113;
+import com.orange.iot3mobility.messages.denm.v113.model.alacartecontainer.AlacarteContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.LocationConfidence;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.LocationContainer;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.PathHistory;
+import com.orange.iot3mobility.messages.denm.v113.model.locationcontainer.PathPoint;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.PositionConfidence;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v113.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.EventType;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.LinkedCause;
+import com.orange.iot3mobility.messages.denm.v113.model.situationcontainer.SituationContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class DenmSchema113Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("denm/denm_schema_1-1-3.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope113 envelope = minimalEnvelope();
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V1_1_3, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope113 envelope = fullyPopulatedEnvelope();
+
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V1_1_3, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static DenmEnvelope113 minimalEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(new ReferencePosition(0, 0, 0))
+                .build();
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        return DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static DenmEnvelope113 fullyPopulatedEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(1000L)
+                .referenceTime(1000L)
+                .termination(0)
+                .eventPosition(new ReferencePosition(0, 0, 0))
+                .relevanceDistance(0)
+                .relevanceTrafficDirection(0)
+                .validityDuration(60)
+                .transmissionInterval(1000)
+                .stationType(5)
+                .confidence(new PositionConfidence(new PositionConfidenceEllipse(0, 0, 0), 0))
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(3)
+                .eventType(new EventType(97, 0))
+                .linkedCause(new LinkedCause(1, 0))
+                .build();
+
+        LocationContainer location = LocationContainer.builder()
+                .eventSpeed(500)
+                .eventPositionHeading(900)
+                .traces(List.of(new PathHistory(
+                        List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 10)))))
+                .roadType(0)
+                .confidence(new LocationConfidence(1, 1))
+                .build();
+
+        AlacarteContainer alacarte = new AlacarteContainer(0, 1);
+
+        DenmMessage113 message = DenmMessage113.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .locationContainer(location)
+                .alacarteContainer(alacarte)
+                .build();
+
+        return DenmEnvelope113.builder()
+                .origin("self")
+                .sourceUuid("CCU6")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/schema/DenmSchema220Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v220/schema/DenmSchema220Test.java
@@ -1,0 +1,163 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.denm.v220.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.denm.core.DenmCodec;
+import com.orange.iot3mobility.messages.denm.core.DenmVersion;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmEnvelope220;
+import com.orange.iot3mobility.messages.denm.v220.model.DenmMessage220;
+import com.orange.iot3mobility.messages.denm.v220.model.alacartecontainer.AlacarteContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.denm.v220.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.DetectionZone;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.EventPositionHeading;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.EventSpeed;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.LocationContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.locationcontainer.PathPoint;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v220.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.CauseCode;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.EventZone;
+import com.orange.iot3mobility.messages.denm.v220.model.situationcontainer.SituationContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class DenmSchema220Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("denm/denm_schema_2-2-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope220 envelope = minimalEnvelope();
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V2_2_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope220 envelope = fullyPopulatedEnvelope();
+
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V2_2_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static ReferencePosition validEventPosition() {
+        return ReferencePosition.builder()
+                .latitude(0)
+                .longitude(0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+    }
+
+    private static DenmEnvelope220 minimalEnvelope() {
+        ReferencePosition position = ReferencePosition.builder()
+                .latitude(0)
+                .longitude(0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(position)
+                .stationType(5)
+                .build();
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        return DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static DenmEnvelope220 fullyPopulatedEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(1000L)
+                .referenceTime(1000L)
+                .termination(0)
+                .eventPosition(validEventPosition())
+                .awarenessDistance(0)
+                .trafficDirection(0)
+                .validityDuration(60)
+                .transmissionInterval(1000)
+                .stationType(5)
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(3)
+                .eventType(new CauseCode(97, 0))
+                .linkedCause(new CauseCode(1, 0))
+                .eventZone(List.of(EventZone.builder()
+                        .eventPosition(new DeltaReferencePosition(0, 0, 0))
+                        .eventDeltaTime(100)
+                        .informationQuality(1)
+                        .build()))
+                .linkedDenms(List.of(new ActionId(2, 1)))
+                .eventEnd(100)
+                .build();
+
+        LocationContainer location = LocationContainer.builder()
+                .eventSpeed(new EventSpeed(500, 1))
+                .eventPositionHeading(new EventPositionHeading(900, 1))
+                .detectionZonesToEventPosition(List.of(DetectionZone.builder()
+                        .path(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 10)))
+                        .build()))
+                .roadType(0)
+                .build();
+
+        AlacarteContainer alacarte = AlacarteContainer.builder()
+                .lanePosition(0)
+                .positioningSolution(1)
+                .build();
+
+        DenmMessage220 message = DenmMessage220.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .locationContainer(location)
+                .alacarteContainer(alacarte)
+                .build();
+
+        return DenmEnvelope220.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v230/schema/DenmSchema230Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/denm/v230/schema/DenmSchema230Test.java
@@ -1,0 +1,194 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.denm.v230.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.denm.core.DenmCodec;
+import com.orange.iot3mobility.messages.denm.core.DenmVersion;
+import com.orange.iot3mobility.messages.denm.v230.model.DenmEnvelope230;
+import com.orange.iot3mobility.messages.denm.v230.model.DenmMessage230;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.AlacarteContainer;
+import com.orange.iot3mobility.messages.denm.v230.model.defs.Altitude;
+import com.orange.iot3mobility.messages.denm.v230.model.defs.PositionConfidenceEllipse;
+import com.orange.iot3mobility.messages.denm.v230.model.locationcontainer.EventPositionHeading;
+import com.orange.iot3mobility.messages.denm.v230.model.locationcontainer.EventSpeed;
+import com.orange.iot3mobility.messages.denm.v230.model.locationcontainer.LocationContainer;
+import com.orange.iot3mobility.messages.denm.v230.model.managementcontainer.ActionId;
+import com.orange.iot3mobility.messages.denm.v230.model.managementcontainer.ManagementContainer;
+import com.orange.iot3mobility.messages.denm.v230.model.managementcontainer.ReferencePosition;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.CarryingDangerousGoods;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.ClosedLanes;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.RoadWorks;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.StationaryVehicle;
+import com.orange.iot3mobility.messages.denm.v230.model.alacartecontainer.VehicleIdentification;
+import com.orange.iot3mobility.messages.denm.v230.model.defs.DeltaReferencePosition;
+import com.orange.iot3mobility.messages.denm.v230.model.locationcontainer.DetectionZone;
+import com.orange.iot3mobility.messages.denm.v230.model.locationcontainer.PathPoint;
+import com.orange.iot3mobility.messages.denm.v230.model.situationcontainer.CauseCode;
+import com.orange.iot3mobility.messages.denm.v230.model.situationcontainer.EventZone;
+import com.orange.iot3mobility.messages.denm.v230.model.situationcontainer.SituationContainer;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class DenmSchema230Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("denm/denm_schema_2-3-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope230 envelope = minimalEnvelope();
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V2_3_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        DenmEnvelope230 envelope = fullyPopulatedEnvelope();
+
+        DenmCodec codec = new DenmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(DenmVersion.V2_3_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static DenmEnvelope230 minimalEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(0)
+                .referenceTime(0)
+                .eventPosition(validEventPosition())
+                .stationType(5)
+                .build();
+        DenmMessage230 message = DenmMessage230.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .build();
+        return DenmEnvelope230.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static DenmEnvelope230 fullyPopulatedEnvelope() {
+        ManagementContainer management = ManagementContainer.builder()
+                .actionId(new ActionId(1, 1))
+                .detectionTime(1000L)
+                .referenceTime(1000L)
+                .termination(0)
+                .eventPosition(validEventPosition())
+                .awarenessDistance(0)
+                .trafficDirection(0)
+                .validityDuration(60)
+                .transmissionInterval(1000)
+                .stationType(5)
+                .build();
+
+        SituationContainer situation = SituationContainer.builder()
+                .informationQuality(3)
+                .eventType(new CauseCode(97, 0))
+                .linkedCause(new CauseCode(1, 0))
+                .eventZone(List.of(EventZone.builder()
+                        .eventPosition(new DeltaReferencePosition(0, 0, 0))
+                        .eventDeltaTime(100)
+                        .informationQuality(1)
+                        .build()))
+                .linkedDenms(List.of(new ActionId(2, 1)))
+                .eventEnd(100)
+                .build();
+
+        LocationContainer location = LocationContainer.builder()
+                .eventSpeed(new EventSpeed(500, 1))
+                .eventPositionHeading(new EventPositionHeading(900, 1))
+                .detectionZonesToEventPosition(List.of(DetectionZone.builder()
+                        .path(List.of(new PathPoint(new DeltaReferencePosition(0, 0, 0), 10)))
+                        .build()))
+                .roadType(0)
+                .build();
+
+        RoadWorks roadWorks = RoadWorks.builder()
+                .lightBarSirenInUse(0)
+                .closedLanes(new ClosedLanes(1, 3))
+                .restriction(List.of(5, 8))
+                .speedLimit(50)
+                .incidentIndication(new CauseCode(3, 1))
+                .recommendedPath(List.of(new DeltaReferencePosition(100, 200, 0)))
+                .startingPointSpeedLimit(new DeltaReferencePosition(50, 50, 0))
+                .trafficFlowRule(2)
+                .referenceDenms(List.of(new ActionId(10, 1)))
+                .build();
+
+        StationaryVehicle stationaryVehicle = StationaryVehicle.builder()
+                .stationarySince(1)
+                .stationaryCause(new CauseCode(94, 2))
+                .carryingDangerousGoods(CarryingDangerousGoods.builder()
+                        .dangerousGoodsType(9)
+                        .unNumber(1234)
+                        .elevatedTemperature(true)
+                        .tunnelsRestricted(false)
+                        .limitedQuantity(false)
+                        .emergencyActionCode("3YE")
+                        .phoneNumber("+33600000000")
+                        .companyName("Orange")
+                        .build())
+                .numberOfOccupants(1)
+                .vehicleIdentification(new VehicleIdentification("WBA", "123456"))
+                .energyStorageType(4)
+                .build();
+
+        AlacarteContainer alacarte = AlacarteContainer.builder()
+                .lanePosition(0)
+                .roadWorks(roadWorks)
+                .positioningSolution(1)
+                .stationaryVehicle(stationaryVehicle)
+                .build();
+
+        DenmMessage230 message = DenmMessage230.builder()
+                .protocolVersion(1)
+                .stationId(42)
+                .managementContainer(management)
+                .situationContainer(situation)
+                .locationContainer(location)
+                .alacarteContainer(alacarte)
+                .build();
+
+        return DenmEnvelope230.builder()
+                .sourceUuid("com_application_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static ReferencePosition validEventPosition() {
+        return ReferencePosition.builder()
+                .latitude(0)
+                .longitude(0)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(0, 0, 0))
+                .altitude(new Altitude(0, 0))
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/mapem/v200/schema/MapemSchema200Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/mapem/v200/schema/MapemSchema200Test.java
@@ -1,0 +1,148 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.mapem.v200.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.mapem.core.MapemCodec;
+import com.orange.iot3mobility.messages.mapem.core.MapemVersion;
+import com.orange.iot3mobility.messages.mapem.v200.model.MapemEnvelope200;
+import com.orange.iot3mobility.messages.mapem.v200.model.MapemMessage200;
+import com.orange.iot3mobility.messages.mapem.v200.model.intersection.IntersectionGeometry;
+import com.orange.iot3mobility.messages.mapem.v200.model.intersection.IntersectionReferenceId;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.GenericLane;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.LaneAttributes;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.LaneType;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.NodeDelta;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.NodeList;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.NodeXY;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.NodeXYOffset;
+import com.orange.iot3mobility.messages.mapem.v200.model.lane.enums.LaneDirection;
+import com.orange.iot3mobility.messages.mapem.v200.model.roadsegment.RoadSegmentData;
+import com.orange.iot3mobility.messages.mapem.v200.model.roadsegment.RoadSegmentReferenceId;
+import com.orange.iot3mobility.messages.mapem.v200.model.shared.Position3D;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class MapemSchema200Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("mapem/mapem_schema_2-0-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        MapemEnvelope200 envelope = minimalEnvelope();
+        MapemCodec codec = new MapemCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(MapemVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        MapemEnvelope200 envelope = fullyPopulatedEnvelope();
+
+        MapemCodec codec = new MapemCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(MapemVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static GenericLane validGenericLane() {
+        NodeXYOffset nodeXYOffset = new NodeXYOffset(0, 0);
+        NodeDelta nodeDelta = new NodeDelta(nodeXYOffset, null);
+        NodeXY nodeXY = NodeXY.builder().delta(nodeDelta).build();
+        NodeList nodeList = new NodeList(List.of(nodeXY, nodeXY), null);
+        LaneType laneType = new LaneType(List.of(), null, null, null, null, null, null, null);
+        LaneAttributes laneAttributes = LaneAttributes.builder()
+                .directionalUse(LaneDirection.INGRESS_PATH)
+                .sharedWith()
+                .laneType(laneType)
+                .build();
+        return GenericLane.builder()
+                .laneId(1)
+                .laneAttributes(laneAttributes)
+                .nodeList(nodeList)
+                .build();
+    }
+
+    private static MapemEnvelope200 minimalEnvelope() {
+        GenericLane lane = validGenericLane();
+
+        IntersectionReferenceId intersectionReferenceId = new IntersectionReferenceId(null, 1001);
+        IntersectionGeometry geometry = IntersectionGeometry.builder()
+                .id(intersectionReferenceId)
+                .revision(0)
+                .refPoint(Position3D.builder().latitude(485000000).longitude(22000000).build())
+                .laneSet(List.of(lane))
+                .build();
+
+        MapemMessage200 message = MapemMessage200.builder()
+                .protocolVersion(1)
+                .stationId(42L)
+                .msgIssueRevision(0)
+                .intersections(List.of(geometry))
+                .build();
+
+        return MapemEnvelope200.builder()
+                .origin("self")
+                .sourceUuid("rsu_intersection_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static MapemEnvelope200 fullyPopulatedEnvelope() {
+        GenericLane lane = validGenericLane();
+
+        IntersectionReferenceId intersectionReferenceId = new IntersectionReferenceId(null, 1001);
+        IntersectionGeometry geometry = IntersectionGeometry.builder()
+                .id(intersectionReferenceId)
+                .revision(0)
+                .refPoint(Position3D.builder().latitude(485000000).longitude(22000000).build())
+                .laneSet(List.of(lane))
+                .build();
+
+        RoadSegmentReferenceId roadSegmentReferenceId = new RoadSegmentReferenceId(null, 2001);
+        RoadSegmentData roadSegment = RoadSegmentData.builder()
+                .id(roadSegmentReferenceId)
+                .revision(0)
+                .refPoint(Position3D.builder().latitude(485100000).longitude(22100000).build())
+                .roadLaneSet(List.of(lane))
+                .build();
+
+        MapemMessage200 message = MapemMessage200.builder()
+                .protocolVersion(1)
+                .stationId(42L)
+                .msgIssueRevision(0)
+                .intersections(List.of(geometry))
+                .roadSegments(List.of(roadSegment))
+                .build();
+
+        return MapemEnvelope200.builder()
+                .origin("self")
+                .sourceUuid("rsu_intersection_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/mcm/v200/schema/McmSchema200Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/mcm/v200/schema/McmSchema200Test.java
@@ -1,0 +1,203 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.mcm.v200.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.mcm.core.McmCodec;
+import com.orange.iot3mobility.messages.mcm.core.McmVersion;
+import com.orange.iot3mobility.messages.mcm.v200.model.McmData;
+import com.orange.iot3mobility.messages.mcm.v200.model.McmEnvelope200;
+import com.orange.iot3mobility.messages.mcm.v200.model.McmMessage200;
+import com.orange.iot3mobility.messages.mcm.v200.model.defs.*;
+import com.orange.iot3mobility.messages.mcm.v200.model.defs.enums.ManoeuvreStrategy;
+import com.orange.iot3mobility.messages.mcm.v200.model.manoeuvreadvice.AdvisedSubmanoeuvre;
+import com.orange.iot3mobility.messages.mcm.v200.model.manoeuvreadvice.ManoeuvreAdvice;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.McmGenericCurrentStateContainer;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.Submanoeuvre;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.VehicleCurrentStateContainer;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.VehicleLength;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.VehicleManoeuvreContainer;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.VehicleSize;
+import com.orange.iot3mobility.messages.mcm.v200.model.defs.WayPoint;
+import com.orange.iot3mobility.messages.mcm.v200.model.vehiclemanoeuvrecontainer.Rational;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class McmSchema200Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("mcm/mcm_schema_2-0-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_vehicleManoeuvreEnvelope_conformsToSchema() throws Exception {
+        McmEnvelope200 envelope = vehicleEnvelope();
+        McmCodec codec = new McmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(McmVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_advisedManoeuvreEnvelope_conformsToSchema() throws Exception {
+        McmEnvelope200 envelope = advisedEnvelope();
+        McmCodec codec = new McmCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(McmVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedVehicleEnvelope_conformsToSchema() throws Exception {
+        McmGenericCurrentStateContainer genericState = McmGenericCurrentStateContainer.builder()
+                .mcmType(1)
+                .manoeuvreId(42)
+                .concept(0)
+                .rational(Rational.ofGoal(2))
+                .executionStatus(1)
+                .build();
+
+        VehicleCurrentStateContainer vehicleState = VehicleCurrentStateContainer.builder()
+                .manoeuvreOverallStrategy(ManoeuvreStrategy.OVERTAKE)
+                .vehicleSpeed(new Speed(800, 10))
+                .vehicleHeading(new Wgs84Angle(1800, 5))
+                .vehicleSize(VehicleSize.builder()
+                        .vehicleType(6)
+                        .vehicleLength(VehicleLength.builder()
+                                .vehicleLengthValue(100)
+                                .vehicleLengthConfidenceIndication(1)
+                                .build())
+                        .vehicleWidth(20)
+                        .vehicleHeight(30)
+                        .build())
+                .build();
+
+        WayPoint wayPoint = WayPoint.builder()
+                .wayPointType(0)
+                .latitude(487_417_800)
+                .longitude(22_415_320)
+                .altitude(-100000)
+                .heading(new Wgs84Angle(900, 10))
+                .speed(30)
+                .build();
+
+        Submanoeuvre submanoeuvre = Submanoeuvre.builder()
+                .submanoeuvreId(0)
+                .submanoeuvreStrategy(ManoeuvreStrategy.GO_TO_LEFT_LANE)
+                .referenceTrajectory(List.of(wayPoint))
+                .temporalCharacteristics(new TemporalCharacteristics(0, 3000))
+                .kinematicsCharacteristics(KinematicsCharacteristics.INSTANCE)
+                .build();
+
+        ManoeuvreAdvice advice = ManoeuvreAdvice.builder()
+                .executantId(4294967295L)
+                .currentStateAdvisedChange("stay_in_lane")
+                .submaneuvres(List.of(AdvisedSubmanoeuvre.builder().submanoeuvreId(0).build()))
+                .build();
+
+        VehicleManoeuvreContainer vmc = VehicleManoeuvreContainer.builder()
+                .mcmGenericCurrentStateContainer(genericState)
+                .vehicleCurrentStateContainer(vehicleState)
+                .submaneuvres(List.of(submanoeuvre))
+                .manoeuvreAdvice(List.of(advice))
+                .build();
+
+        McmEnvelope200 envelope = new McmEnvelope200(
+                "mcm", "json/raw", "com_car_42", 1_600_000_000_000L, "2.0.0",
+                new McmMessage200(2, 4294967295L, 65535, 1, 1,
+                        new ReferencePosition(487_417_800, 22_415_320,
+                                new PositionConfidenceEllipse(10, 10, 900), null),
+                        McmData.ofVehicle(vmc)));
+
+        McmCodec codec = new McmCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(McmVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static McmEnvelope200 vehicleEnvelope() {
+        return McmEnvelope200.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1_600_000_000_000L)
+                .message(McmMessage200.builder()
+                        .protocolVersion(1)
+                        .stationId(1L)
+                        .generationDeltaTime(0)
+                        .stationType(1)
+                        .itssRole(0)
+                        .position(validReferencePosition())
+                        .mcmData(McmData.ofVehicle(VehicleManoeuvreContainer.builder()
+                                .mcmGenericCurrentStateContainer(McmGenericCurrentStateContainer.builder()
+                                        .mcmType(1)
+                                        .manoeuvreId(42)
+                                        .concept(0)
+                                        .build())
+                                .vehicleCurrentStateContainer(VehicleCurrentStateContainer.builder()
+                                        .manoeuvreOverallStrategy(ManoeuvreStrategy.DRIVE_STRAIGHT)
+                                        .vehicleSpeed(new Speed(0, 1))
+                                        .vehicleHeading(new Wgs84Angle(0, 1))
+                                        .vehicleSize(new VehicleSize(1, null, new VehicleLength(10, 0), 10, 10))
+                                        .build())
+                                .submaneuvres(List.of(new Submanoeuvre(0, null, null, null,
+                                        new TemporalCharacteristics(0, 1000),
+                                        KinematicsCharacteristics.INSTANCE)))
+                                .build()))
+                        .build())
+                .build();
+    }
+
+    private static McmEnvelope200 advisedEnvelope() {
+        return McmEnvelope200.builder()
+                .messageFormat("json/raw")
+                .sourceUuid("com_car_42")
+                .timestamp(1_600_000_000_000L)
+                .message(McmMessage200.builder()
+                        .protocolVersion(1)
+                        .stationId(99L)
+                        .generationDeltaTime(0)
+                        .stationType(2)
+                        .itssRole(0)
+                        .position(validReferencePosition())
+                        .mcmData(McmData.ofAdvised(List.of(
+                                ManoeuvreAdvice.builder()
+                                        .executantId(99L)
+                                        .currentStateAdvisedChange("stay_in_lane")
+                                        .submaneuvres(List.of(
+                                                AdvisedSubmanoeuvre.builder()
+                                                        .submanoeuvreId(0)
+                                                        .build()))
+                                        .build())))
+                        .build())
+                .build();
+    }
+
+    private static ReferencePosition validReferencePosition() {
+        return ReferencePosition.builder()
+                .latitude(487_417_800)
+                .longitude(22_415_320)
+                .positionConfidenceEllipse(new PositionConfidenceEllipse(10, 10, 900))
+                .build();
+    }
+}

--- a/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/spatem/v200/schema/SpatemSchema200Test.java
+++ b/java/iot3/mobility/src/test/java/com/orange/iot3mobility/messages/spatem/v200/schema/SpatemSchema200Test.java
@@ -1,0 +1,130 @@
+/*
+ Copyright 2016-2026 Orange
+
+ This software is distributed under the MIT license, see LICENSE.txt file for more details.
+
+ @author Mathieu LEFEBVRE <mathieu1.lefebvre@orange.com>
+ @generated GitHub Copilot (Claude Sonnet 4.6)
+ */
+package com.orange.iot3mobility.messages.spatem.v200.schema;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.networknt.schema.JsonSchema;
+import com.orange.iot3mobility.messages.SchemaTestUtils;
+import com.orange.iot3mobility.messages.spatem.core.SpatemCodec;
+import com.orange.iot3mobility.messages.spatem.core.SpatemVersion;
+import com.orange.iot3mobility.messages.spatem.v200.model.SpatemEnvelope200;
+import com.orange.iot3mobility.messages.spatem.v200.model.SpatemMessage200;
+import com.orange.iot3mobility.messages.spatem.v200.model.intersection.IntersectionReferenceId;
+import com.orange.iot3mobility.messages.spatem.v200.model.intersection.IntersectionState;
+import com.orange.iot3mobility.messages.spatem.v200.model.intersection.MovementEvent;
+import com.orange.iot3mobility.messages.spatem.v200.model.intersection.MovementState;
+import com.orange.iot3mobility.messages.spatem.v200.model.intersection.TimeChangeDetail;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+class SpatemSchema200Test {
+
+    private static final JsonSchema SCHEMA;
+
+    static {
+        try {
+            SCHEMA = SchemaTestUtils.loadSchema("spatem/spatem_schema_2-0-0.json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_minimalValidEnvelope_conformsToSchema() throws Exception {
+        SpatemEnvelope200 envelope = minimalEnvelope();
+        SpatemCodec codec = new SpatemCodec(new JsonFactory());
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(SpatemVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    @Test
+    void write_fullyPopulatedEnvelope_conformsToSchema() throws Exception {
+        SpatemEnvelope200 envelope = fullyPopulatedEnvelope();
+
+        SpatemCodec codec = new SpatemCodec(new JsonFactory());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        codec.write(SpatemVersion.V2_0_0, envelope, out);
+
+        SchemaTestUtils.assertConformsToSchema(SCHEMA, out.toByteArray());
+    }
+
+    private static SpatemEnvelope200 minimalEnvelope() {
+        MovementEvent movementEvent = MovementEvent.builder()
+                .eventState(6)
+                .build();
+        MovementState movementState = MovementState.builder()
+                .signalGroup(1)
+                .stateTimeSpeed(List.of(movementEvent))
+                .build();
+        IntersectionReferenceId intersectionReferenceId = new IntersectionReferenceId(null, 1001);
+        IntersectionState intersectionState = IntersectionState.builder()
+                .id(intersectionReferenceId)
+                .revision(0)
+                .status(List.of())
+                .states(List.of(movementState))
+                .build();
+        SpatemMessage200 message = SpatemMessage200.builder()
+                .protocolVersion(1)
+                .stationId(42L)
+                .intersections(List.of(intersectionState))
+                .build();
+        return SpatemEnvelope200.builder()
+                .origin("self")
+                .sourceUuid("rsu_intersection_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+
+    private static SpatemEnvelope200 fullyPopulatedEnvelope() {
+        MovementEvent movementEvent = MovementEvent.builder()
+                .eventState(6)
+                .timing(TimeChangeDetail.builder()
+                        .minEndTime(100)
+                        .maxEndTime(200)
+                        .likelyTime(150)
+                        .build())
+                .build();
+
+        MovementState movementState1 = MovementState.builder()
+                .signalGroup(1)
+                .stateTimeSpeed(List.of(movementEvent))
+                .build();
+        MovementState movementState2 = MovementState.builder()
+                .signalGroup(2)
+                .stateTimeSpeed(List.of(MovementEvent.builder().eventState(3).build()))
+                .build();
+
+        IntersectionReferenceId id = new IntersectionReferenceId(42, 1001);
+        IntersectionState intersectionState = IntersectionState.builder()
+                .id(id)
+                .revision(1)
+                .status(List.of())
+                .states(List.of(movementState1, movementState2))
+                .build();
+
+        SpatemMessage200 message = SpatemMessage200.builder()
+                .protocolVersion(1)
+                .stationId(42L)
+                .intersections(List.of(intersectionState))
+                .build();
+
+        return SpatemEnvelope200.builder()
+                .origin("self")
+                .sourceUuid("rsu_intersection_42")
+                .timestamp(1514764800000L)
+                .message(message)
+                .build();
+    }
+}


### PR DESCRIPTION
**What's new**

The conformity of JSON format ETSI ITS messages generated by the Java IoT3 Mobility SDK is now tested against their respective JSON schema.

Close #560 

Note: the validation classes remain (e.g. `CamValidator240`) as they are useful at runtime to trigger errors when users try to generate incomplete messages, or receive incomplete or badly formatted ones. However, they did not guarantee the absence of implementation error in the SDK itself... 

---
**What to do**

Read new test classes. The GitHub CI pipeline should already have validated the tests, but you can also run them on your machine.