### PR TITLE
python/iot3/mobility/cpm: fix z_angle scale unit

### DIFF
--- a/python/iot3/src/iot3/mobility/cpm.py
+++ b/python/iot3/src/iot3/mobility/cpm.py
@@ -358,7 +358,7 @@ class CollectivePerceptionMessage(etsi.Message):
                         "z_angle": {
                             "value": etsi.ETSI.si2etsi(
                                 value=perceived_object.bounding_box.heading,
-                                scale=etsi.ETSI.DECI_METER,
+                                scale=etsi.ETSI.DECI_DEGREE,
                                 undef=3601,
                             ),
                             "confidence": 127,
@@ -547,7 +547,7 @@ class CollectivePerceptionMessage(etsi.Message):
             )
             heading = etsi.ETSI.etsi2si(
                 value=po.get("angles", {}).get("z_angle", {}).get("value"),
-                scale=etsi.ETSI.DECI_METER,
+                scale=etsi.ETSI.DECI_DEGREE,
                 undef=3601,
             )
 


### PR DESCRIPTION
Changes
=======

* IoT3 SDK:
    * mobility: fix CPM z_angle scale unit (#566)

Close #566

Test
====

How to test
-----------

1. Review the change: the `z_angle` scale unit is now deci-degrees instead of deci-meters