### PR TITLE
Identity feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,10 @@ jobs:
         run: |
           cd rust
           cargo build --features geo_routing --verbose
+      - name: Build identity feature
+        run: |
+          cd rust
+          cargo build --features identity --verbose
       - name: Build all features
         run: |
           cd rust
@@ -107,6 +111,10 @@ jobs:
         run: |
           cd rust
           cargo test --features geo_routing --verbose
+      - name: Test identity feature
+        run: |
+          cd rust
+          cargo test --features identity --verbose
       - name: Test all features
         run: |
           cd rust

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,7 @@ crate-type = ["lib"]
 mobility = ["geo"]
 geo_routing = ["mobility"]
 telemetry = ["base64", "opentelemetry", "opentelemetry-http", "opentelemetry-otlp", "opentelemetry_sdk"]
+identity = []
 
 [[example]]
 name = "json_counter"

--- a/rust/examples/config.ini
+++ b/rust/examples/config.ini
@@ -7,6 +7,11 @@
 #username = username
 #password = password
 
+# Reads service credentials from file
+# It will override the username and password fields provided in the other section if they are present
+[identity]
+file=/etc/identity.json
+
 # mqtt settings
 [mqtt]
 # broker host to connect to

--- a/rust/src/client/configuration.rs
+++ b/rust/src/client/configuration.rs
@@ -31,12 +31,18 @@ use crate::client::configuration::mobility_configuration::{
 
 #[cfg(feature = "geo_routing")]
 use crate::client::configuration::geo_configuration::{GEO_SECTION, GeoConfiguration};
+
+#[cfg(feature = "identity")]
+use crate::client::configuration::identity::override_with_identity;
+
 use crate::client::configuration::mqtt_configuration::MqttConfiguration;
 
 pub(crate) mod bootstrap_configuration;
 pub mod configuration_error;
 #[cfg(feature = "geo_routing")]
 pub(crate) mod geo_configuration;
+#[cfg(feature = "identity")]
+mod identity;
 #[cfg(feature = "mobility")]
 pub(crate) mod mobility_configuration;
 pub mod mqtt_configuration;
@@ -218,7 +224,8 @@ impl TryFrom<Ini> for Configuration {
     fn try_from(ini_config: Ini) -> Result<Self, Self::Error> {
         let mut ini_config = ini_config;
 
-        Ok(Configuration {
+        #[allow(unused_mut)]
+        let mut configuration = Configuration {
             mqtt: MqttConfiguration::try_from(&pick_mandatory_section(
                 MQTT_SECTION,
                 &mut ini_config,
@@ -238,8 +245,15 @@ impl TryFrom<Ini> for Configuration {
                 MOBILITY_SECTION,
                 &mut ini_config,
             )?)?,
-            custom_settings: Some(ini_config),
-        })
+            custom_settings: None,
+        };
+
+        #[cfg(feature = "identity")]
+        override_with_identity(&mut ini_config, &mut configuration)?;
+
+        configuration.custom_settings = Some(ini_config);
+
+        Ok(configuration)
     }
 }
 

--- a/rust/src/client/configuration/configuration_error.rs
+++ b/rust/src/client/configuration/configuration_error.rs
@@ -17,6 +17,8 @@ pub enum ConfigurationError {
     BootstrapFailure(String),
     #[error("Could not found field '{0}'")]
     FieldNotFound(&'static str),
+    #[error("Could not find file '{0}'")]
+    FileNotFound(String),
     #[error("Cannot parse '{0}' due to invalid file type")]
     InvalidFileType(String),
     #[error("Configuration missing mandatory field {0}")]

--- a/rust/src/client/configuration/identity.rs
+++ b/rust/src/client/configuration/identity.rs
@@ -1,0 +1,116 @@
+/*
+ * Software Name : libits-client
+ * SPDX-FileCopyrightText: Copyright (c) Orange SA
+ * SPDX-License-Identifier: MIT
+ *
+ * This software is distributed under the MIT license,
+ * see the "LICENSE.txt" file for more details or https://opensource.org/license/MIT/
+ *
+ * Authors: see CONTRIBUTORS.md
+ */
+use crate::client::configuration::configuration_error::ConfigurationError;
+use crate::client::configuration::configuration_error::ConfigurationError::{
+    FileNotFound, InvalidFileType,
+};
+use crate::client::configuration::{
+    Configuration, get_mandatory_from_properties, pick_mandatory_section,
+};
+use ini::Ini;
+use log::{info, warn};
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Deserialize)]
+struct Identity {
+    #[serde(alias = "psk-identity")]
+    username: String,
+    #[serde(alias = "psk-secret-key")]
+    password: String,
+    #[serde(alias = "iot3-id")]
+    id: String,
+}
+
+/// Overrides the [Configuration] parts related to service access
+///
+/// This function will:
+/// - override the credentials attributes
+/// - suffix the id attributes (MQTT client_id for example)
+/// in all relevant configuration structures.
+///
+/// The username, password and id suffix will be read from the file provided through the
+/// `identity.file` field in the INI configuration file (see [example/config.ini]).
+///
+/// The file must content a single JSON object with these three fields.
+/// Example:
+///  ```json
+///   {
+///     "id": "192837465",
+///     "username": "zqsdfguiqjoizhfze57451zg5f4",
+///     "password": "86e16f35a59311780627630d9357fbabe11dbd71f7c9ce662402cb846c5c24f0"
+///   }
+///   ```
+pub(crate) fn override_with_identity(
+    ini_configuration: &mut Ini,
+    configuration: &mut Configuration,
+) -> Result<(), ConfigurationError> {
+    match pick_mandatory_section("identity", ini_configuration) {
+        Ok(identity) => {
+            let file_name = get_mandatory_from_properties::<String>("file", &identity)?;
+
+            match fs::read_to_string(&file_name) {
+                Ok(json_str) => match serde_json::from_str::<Identity>(&json_str) {
+                    Ok(identity) => {
+                        configuration.mqtt.suffix_client_id(&identity.id);
+                        configuration
+                            .mqtt
+                            .mqtt_options
+                            .set_credentials(&identity.username, &identity.password);
+
+                        #[cfg(feature = "telemetry")]
+                        {
+                            configuration.telemetry.username = Some(identity.username);
+                            configuration.telemetry.password = Some(identity.password);
+                        }
+
+                        Ok(())
+                    }
+                    Err(e) => {
+                        warn!("{}", e);
+                        Err(InvalidFileType(file_name))
+                    }
+                },
+                Err(err) => {
+                    warn!("{}", err);
+                    Err(FileNotFound(file_name))
+                }
+            }
+        }
+        Err(error) => {
+            info!(
+                "No identity section found, using credentials from dedicated sections: {}",
+                error
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ini::Ini;
+
+    #[test]
+    fn missing_section_returns_ok() {
+        let ini_str = r#"
+        [not_identity]
+        file=/dev/null        
+        "#;
+        let mut ini_cfg = Ini::load_from_str(ini_str).unwrap();
+        let mut configuration = Configuration::default();
+
+        let result = override_with_identity(&mut ini_cfg, &mut configuration);
+
+        assert!(result.is_ok());
+    }
+}

--- a/rust/src/client/configuration/mqtt_configuration.rs
+++ b/rust/src/client/configuration/mqtt_configuration.rs
@@ -105,6 +105,54 @@ impl Deref for MqttConfiguration {
     }
 }
 
+impl MqttConfiguration {
+    #[cfg(feature = "identity")]
+    pub(crate) fn suffix_client_id(&mut self, suffix: &str) {
+        let old_mqtt_options = &self.mqtt_options.clone();
+        let suffixed_id = format!("{}-{}", old_mqtt_options.client_id(), suffix);
+        let mut mqtt_options = MqttOptions::new(
+            suffixed_id,
+            old_mqtt_options.broker_address().0,
+            old_mqtt_options.broker_address().1,
+        );
+
+        match old_mqtt_options.credentials() {
+            Some(credentials) => {
+                mqtt_options.set_credentials(credentials.0, credentials.1);
+            }
+            None => {}
+        }
+        mqtt_options.set_connection_timeout(old_mqtt_options.connection_timeout());
+        mqtt_options.set_keep_alive(old_mqtt_options.keep_alive());
+        mqtt_options.set_clean_start(old_mqtt_options.clean_start());
+        mqtt_options.set_transport(old_mqtt_options.transport());
+        mqtt_options.set_request_channel_capacity(old_mqtt_options.request_channel_capacity());
+        mqtt_options.set_pending_throttle(old_mqtt_options.pending_throttle());
+        mqtt_options.set_manual_acks(old_mqtt_options.manual_acks());
+        mqtt_options.set_network_options(old_mqtt_options.network_options());
+        mqtt_options.set_receive_maximum(old_mqtt_options.receive_maximum());
+        mqtt_options.set_max_packet_size(old_mqtt_options.max_packet_size());
+        mqtt_options.set_topic_alias_max(old_mqtt_options.topic_alias_max());
+        mqtt_options.set_request_response_info(old_mqtt_options.request_response_info());
+        mqtt_options.set_request_problem_info(old_mqtt_options.request_problem_info());
+        mqtt_options.set_user_properties(old_mqtt_options.user_properties());
+        mqtt_options.set_authentication_method(old_mqtt_options.authentication_method());
+        mqtt_options.set_authentication_data(old_mqtt_options.authentication_data());
+        if let Some(connect_properties) = old_mqtt_options.connect_properties() {
+            mqtt_options.set_connect_properties(connect_properties);
+        }
+        if let Some(upper_limit) = old_mqtt_options.get_outgoing_inflight_upper_limit() {
+            mqtt_options.set_outgoing_inflight_upper_limit(upper_limit);
+        }
+
+        if let Some(last_will) = old_mqtt_options.last_will() {
+            mqtt_options.set_last_will(last_will);
+        }
+
+        self.mqtt_options = mqtt_options;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,5 +262,88 @@ mod tests {
             config.mqtt_options.transport(),
             rumqttc::Transport::Tcp
         ));
+    }
+
+    #[cfg(feature = "identity")]
+    #[test]
+    fn suffix_client_id_changes_only_client_id() {
+        let mut properties = create_properties();
+        properties.insert("username", "user".to_string());
+        properties.insert("password", "pass".to_string());
+        let mut config = MqttConfiguration::try_from(&properties).unwrap();
+        config
+            .mqtt_options
+            .set_keep_alive(std::time::Duration::from_secs(60));
+        config.mqtt_options.set_clean_start(false);
+        config.mqtt_options.set_connection_timeout(17);
+        config.mqtt_options.set_request_channel_capacity(11);
+        config
+            .mqtt_options
+            .set_pending_throttle(std::time::Duration::from_millis(123));
+        config.mqtt_options.set_manual_acks(true);
+        config.mqtt_options.set_receive_maximum(Some(7));
+        config.mqtt_options.set_max_packet_size(Some(4096));
+        config.mqtt_options.set_topic_alias_max(Some(9));
+        config.mqtt_options.set_request_response_info(Some(128));
+        config.mqtt_options.set_request_problem_info(None);
+        let initial_client_id = config.mqtt_options.client_id();
+        let initial_broker_address = config.mqtt_options.broker_address();
+        let initial_credentials = config.mqtt_options.credentials();
+        let initial_keep_alive = config.mqtt_options.keep_alive();
+        let initial_clean_start = config.mqtt_options.clean_start();
+        let initial_connection_timeout = config.mqtt_options.connection_timeout();
+        let initial_request_channel_capacity = config.mqtt_options.request_channel_capacity();
+        let initial_pending_throttle = config.mqtt_options.pending_throttle();
+        let initial_manual_acks = config.mqtt_options.manual_acks();
+        let initial_receive_maximum = config.mqtt_options.receive_maximum();
+        let initial_max_packet_size = config.mqtt_options.max_packet_size();
+        let initial_topic_alias_max = config.mqtt_options.topic_alias_max();
+        let initial_request_response_info = config.mqtt_options.request_response_info();
+        let initial_request_problem_info = config.mqtt_options.request_problem_info();
+
+        config.suffix_client_id("suffix");
+
+        assert_ne!(config.mqtt_options.client_id(), initial_client_id);
+        assert_eq!(
+            config.mqtt_options.client_id(),
+            format!("{}-{}", initial_client_id, "suffix")
+        );
+        assert_eq!(config.mqtt_options.broker_address(), initial_broker_address);
+        assert_eq!(config.mqtt_options.credentials(), initial_credentials);
+        assert_eq!(config.mqtt_options.keep_alive(), initial_keep_alive);
+        assert_eq!(config.mqtt_options.clean_start(), initial_clean_start);
+        assert_eq!(
+            config.mqtt_options.connection_timeout(),
+            initial_connection_timeout
+        );
+        assert_eq!(
+            config.mqtt_options.request_channel_capacity(),
+            initial_request_channel_capacity
+        );
+        assert_eq!(
+            config.mqtt_options.pending_throttle(),
+            initial_pending_throttle
+        );
+        assert_eq!(config.mqtt_options.manual_acks(), initial_manual_acks);
+        assert_eq!(
+            config.mqtt_options.receive_maximum(),
+            initial_receive_maximum
+        );
+        assert_eq!(
+            config.mqtt_options.max_packet_size(),
+            initial_max_packet_size
+        );
+        assert_eq!(
+            config.mqtt_options.topic_alias_max(),
+            initial_topic_alias_max
+        );
+        assert_eq!(
+            config.mqtt_options.request_response_info(),
+            initial_request_response_info
+        );
+        assert_eq!(
+            config.mqtt_options.request_problem_info(),
+            initial_request_problem_info
+        );
     }
 }

--- a/rust/src/client/configuration/telemetry_configuration.rs
+++ b/rust/src/client/configuration/telemetry_configuration.rs
@@ -41,8 +41,8 @@ pub struct TelemetryConfiguration {
     pub use_tls: bool,
     pub path: String,
     pub batch_size: usize,
-    username: Option<String>,
-    password: Option<String>,
+    pub(crate) username: Option<String>,
+    pub(crate) password: Option<String>,
 }
 
 impl TelemetryConfiguration {


### PR DESCRIPTION
What's new
---------------

**Rust**

1. Add a new feature that provides a way to configure the credentials to access services using a JSON file

Closes #483 

How to test
---------------

1. Apply the [configuration patch][1]
   ```
   git apply config.patch
   ```
2. Run the `json_counter` example
   ```
   cargo run --example json_counter
   ```
   **It must fail as the broker requires credentials**
   > ...
   > ERROR [json_counter] Connection error received: ConnectionRefused(NotAuthorized)
   > INFO [json_counter] Exiting...
3. Fill the identity file
   ```bash
   cat << EOF > /tmp/identity.json
   {
     "id": "suffix",
     "username": "rw",
     "password": "readwrite"
   }
   EOF
   ```
4. Apply the [identity patch][2]
   ```
   git apply identity.patch
   ```
5. Run the `json_counter` with the telemetry feature
   ```
   cargo run --example json_counter --features identity
   ```
   **=> You must be connected successfully and receive messages**
   > Received 1000 messages including 997 as JSON
   > Received 2000 messages including 1997 as JSON
   > Received 3000 messages including 2997 as JSON
   > Received 4000 messages including 3997 as JSON
   > Received 5000 messages including 4997 as JSON
   > Received 6000 messages including 5997 as JSON


[1]: https://github.com/user-attachments/files/30778392/config.patch
[2]: https://github.com/user-attachments/files/30778381/identity.patch

