### PR TITLE
rust: avoid to double encode mqtt messages

### DIFF
--- a/rust/examples/collector/main.rs
+++ b/rust/examples/collector/main.rs
@@ -22,7 +22,6 @@ use libits::client::logger::create_stdout_logger;
 use libits::transport::mqtt::mqtt_client::MqttClient;
 use libits::transport::mqtt::mqtt_router::MqttRouter;
 use libits::transport::mqtt::routed_str_topic::RoutedStrTopic;
-use libits::transport::packet::Packet;
 #[cfg(feature = "telemetry")]
 use libits::transport::telemetry::init_tracer;
 use log::{debug, error, info, trace};
@@ -234,16 +233,17 @@ async fn main() {
                                     };
                                 }
 
-                                // Create a Packet from the payload string
-                                let packet = Packet::<CollectorStrTopic, String> {
-                                    topic,
-                                    payload: payload.to_string(),
-                                    properties: PublishProperties::default(),
-                                };
-
-                                trace!("Start packet publishing...");
-                                current_publish_client.publish(packet).await;
-                                trace!("Packet published");
+                                // Publish this already-serialized payload as-is to avoid double
+                                // JSON-encoding the message that came from the external broker.
+                                trace!("Start payload forwarding...");
+                                current_publish_client
+                                    .publish_forward(
+                                        topic,
+                                        payload.to_string(),
+                                        PublishProperties::default(),
+                                    )
+                                    .await;
+                                trace!("Payload forwarded");
                             }
                         }
                         None => error!("Failed to downcast payload to String"),
@@ -905,5 +905,68 @@ mod tests {
                 .topic_level_update_list
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn str_route_with_valid_json_payload() {
+        // Test that a JSON payload is correctly parsed and returned as a String
+        let json_payload = br#"{"message_type":"cam","data":"test"}"#.to_vec();
+        let publish = Publish {
+            payload: json_payload.into(),
+            properties: Some(PublishProperties::default()),
+            ..Default::default()
+        };
+        let result = str_route(publish);
+        assert!(result.is_some());
+        let (boxed_payload, _) = result.unwrap();
+        let payload_str = boxed_payload.downcast_ref::<String>().unwrap();
+        assert_eq!(payload_str, r#"{"message_type":"cam","data":"test"}"#);
+    }
+
+    #[test]
+    fn str_route_with_double_encoded_json_invalid() {
+        // Test that a double-encoded JSON (bug case) is still returned as-is
+        // This would be the faulty payload from the old collector MQTT export.
+        // When using publish_forward, this should NOT happen.
+        let double_encoded = br#""{\"message_type\":\"cam\"}""#.to_vec();
+        let publish = Publish {
+            payload: double_encoded.into(),
+            properties: Some(PublishProperties::default()),
+            ..Default::default()
+        };
+        let result = str_route(publish);
+        assert!(result.is_some());
+        let (boxed_payload, _) = result.unwrap();
+        let payload_str = boxed_payload.downcast_ref::<String>().unwrap();
+        // The faulty payload would be this string (which is NOT valid JSON for the message structure)
+        assert!(payload_str.contains("message_type"));
+    }
+
+    #[test]
+    fn mqtt_export_forwarded_payload_not_double_encoded() {
+        // This test documents the expected behavior: when exporting to MQTT,
+        // the collector should use publish_forward (not publish) to avoid double-encoding.
+        //
+        // Scenario:
+        // 1. Collector receives JSON string from str_route: {"msg":"hello"}
+        // 2. Export to MQTT must call: publish_forward(topic, payload_string, properties)
+        //    NOT: Packet<_, String> + publish() which would call serde_json::to_string
+        //
+        // If using publish():
+        //   serde_json::to_string(&payload_string) -> ""{\"msg\":\"hello\"}"" (WRONG - double encoded)
+        // If using publish_forward(payload_string):
+        //   Direct send: {"msg":"hello"} (CORRECT)
+        let json_payload = r#"{"msg":"hello"}"#.to_string();
+
+        // Demonstrate the bug: serializing a String twice
+        let wrong_double_encoded = serde_json::to_string(&json_payload).expect("Should serialize");
+
+        // Verify the WRONG path (what old code did):
+        assert!(wrong_double_encoded.contains("\\"));
+        assert!(wrong_double_encoded.starts_with("\""));
+
+        // The RIGHT path (what publish_forward does - no re-serialization):
+        assert_eq!(json_payload, r#"{"msg":"hello"}"#);
+        assert!(!json_payload.starts_with("\""));
     }
 }

--- a/rust/src/transport/mqtt/mqtt_client.rs
+++ b/rust/src/transport/mqtt/mqtt_client.rs
@@ -16,7 +16,7 @@ use crate::transport::payload::Payload;
 use crossbeam_channel::Sender;
 use log::{debug, error, info, trace, warn};
 use rumqttc::v5::mqttbytes::QoS;
-use rumqttc::v5::mqttbytes::v5::Filter;
+use rumqttc::v5::mqttbytes::v5::{Filter, PublishProperties};
 use rumqttc::v5::{AsyncClient, Event, EventLoop, MqttOptions};
 
 #[cfg(feature = "telemetry")]
@@ -102,6 +102,36 @@ impl MqttClient {
             Err(e) => error!("Failed to send publish, is the connection close? \nError: {e:?}"),
         }
     }
+
+    /// Forwards an already-serialized payload as-is, without re-serializing it.
+    ///
+    /// This is required when forwarding payloads received from another source
+    /// (e.g. a JSON string from another broker): using [`MqttClient::publish`] would call
+    /// `serde_json::to_string` on the `String`, escaping it and producing a
+    /// double-encoded message.
+    pub async fn publish_forward<T: Topic>(
+        &self,
+        topic: T,
+        payload: String,
+        properties: PublishProperties,
+    ) {
+        match self
+            .client
+            .publish_with_properties(
+                topic.to_string(),
+                QoS::ExactlyOnce,
+                false,
+                payload,
+                properties,
+            )
+            .await
+        {
+            Ok(()) => trace!("Sent forwarded publish"),
+            Err(e) => {
+                error!("Failed to send forwarded publish, is the connection close? \nError: {e:?}")
+            }
+        }
+    }
 }
 
 pub async fn listen(mut event_loop: EventLoop, sender: Sender<Event>) {
@@ -123,4 +153,79 @@ pub async fn listen(mut event_loop: EventLoop, sender: Sender<Event>) {
         }
     }
     warn!("Listening done");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mqtt_client_creation() {
+        let mut options = MqttOptions::new("test_client", "localhost", 1883);
+        options.set_keep_alive(core::time::Duration::from_secs(60));
+        let (_client, _event_loop) = MqttClient::new(&options);
+        // Verify client is created without panicking
+        assert!(true);
+    }
+
+    #[test]
+    fn test_publish_forward_payload_not_double_encoded() {
+        // This test verifies that a forwarded JSON string payload is NOT
+        // further JSON-encoded when using publish_forward.
+        // The payload should be transmitted as-is without escaping.
+        let json_payload = r#"{"message_type":"cam","data":"test"}"#;
+
+        // When this payload would be passed to publish (typed),
+        // serde_json::to_string would escape it to:
+        // "{\"message_type\":\"cam\",\"data\":\"test\"}"
+        // which is double-encoded and invalid.
+
+        // publish_forward should send json_payload directly without re-encoding.
+        // We can't easily test the actual MQTT output without mocking,
+        // but we document the expected behavior here.
+        assert_eq!(
+            json_payload, r#"{"message_type":"cam","data":"test"}"#,
+            "Forwarded JSON payload must not be modified"
+        );
+    }
+
+    #[test]
+    fn test_publish_serialized_typed_payload() {
+        // Test that a typed payload (like Exchange) is correctly serialized
+        // once when using the regular publish method.
+        // This prevents regression: publish should still work for typed payloads.
+
+        #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+        struct TestPayload {
+            msg_type: String,
+            value: i32,
+        }
+
+        let payload = TestPayload {
+            msg_type: "test".to_string(),
+            value: 42,
+        };
+
+        let serialized = serde_json::to_string(&payload).expect("Should serialize");
+        // Verify single encoding: no escaping of quotes
+        assert!(serialized.contains("\"msg_type\""));
+        assert!(!serialized.contains("\\\"msg_type\\\""));
+    }
+
+    #[test]
+    fn test_string_double_encoding_with_publish_scenario() {
+        // Demonstrate the bug: a String (forwarded JSON) serialized twice
+        let json_payload_string = r#"{"message":"hello"}"#.to_string();
+
+        // First serialization (correct for typed Payload, wrong for String):
+        let once_encoded = serde_json::to_string(&json_payload_string).expect("Should serialize");
+
+        // Verify it's double-encoded (contains escaped quotes):
+        assert!(once_encoded.contains("\\\""));
+        assert!(once_encoded.starts_with("\""));
+        assert!(once_encoded.ends_with("\""));
+
+        // publish_forward should bypass this by passing json_payload_string directly
+        // to mqtt client without serde_json::to_string
+    }
 }


### PR DESCRIPTION
Add unit tests to valid.

Go to the `Preview`, right above,
and select the appropriate template in the list:

* [Python](?expand=1&template=python.md)
* [Rust](?expand=1&template=rust.md)
* [Swift](?expand=1&template=swift.md)

If no template matches your changes, remove this whole text,
and enter your own description with the following information:

* In the title text:
    * the main impacted component
    * a short summary of the changes
* In the description:
    * a human-readable summary of the changes, with a focus on semantics
      rather than technical details (unless that's really important)
    * a list of issues this PR closes
    * the sequence of steps to test the changes
    * the expected result for each steps in 3, above
