### PR TITLE
rust: fix MQTT forwarding string escaping

### DIFF
--- a/rust/examples/collector/main.rs
+++ b/rust/examples/collector/main.rs
@@ -27,6 +27,7 @@ use libits::transport::packet::Packet;
 use libits::transport::telemetry::init_tracer;
 use log::{debug, error, info, trace};
 use rumqttc::v5::mqttbytes::v5::{Publish, PublishProperties};
+use serde_json::Value;
 use std::any::Any;
 use std::fs::{File, OpenOptions, create_dir_all};
 use std::io::Write;
@@ -235,9 +236,10 @@ async fn main() {
                                 }
 
                                 // Create a Packet from the payload string
-                                let packet = Packet::<CollectorStrTopic, String> {
+                                let packet = Packet::<CollectorStrTopic, Value> {
                                     topic,
-                                    payload: payload.to_string(),
+                                    payload: serde_json::from_str(payload.as_str())
+                                        .unwrap_or(Value::Null),
                                     properties: PublishProperties::default(),
                                 };
 

--- a/rust/src/transport/payload.rs
+++ b/rust/src/transport/payload.rs
@@ -9,8 +9,9 @@
  * Authors: see CONTRIBUTORS.md
  */
 use serde::Serialize;
+use serde_json::Value;
 use std::fmt::Debug;
 
 pub trait Payload: Clone + Debug + PartialEq + Serialize {}
 
-impl Payload for String {}
+impl Payload for Value {}


### PR DESCRIPTION
What's new
---------------

- rust: in collector example, encapsulate the str payload as a `serde_json::Value` before publishing to avoid quotes escaping when `to_string` is called

How to test
---------------

1. Enable MQTT forwarding in collector example
2. Run the example
3. Check that forwarded messages contains plain JSON without `\"` escaping
